### PR TITLE
Check if file exists in compound.save

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -547,6 +547,10 @@ class Compound(object):
         except KeyError:  # TODO: better reporting
             saver = None
 
+        if not hasattr(fname, 'write'):
+            if os.path.exists(filename) and not overwrite:
+                raise IOError('{0} exists; not overwriting' % fname)
+
         structure = self.to_parmed(**kwargs)
         if saver:  # mBuild/InterMol supported saver.
             saver(filename, structure, forcefield_name,

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -511,7 +511,7 @@ class Compound(object):
         load(filename, compound=self, coords_only=True)
 
     def save(self, filename, show_ports=False, forcefield_name=None,
-             forcefield_files=None, box=None, **kwargs):
+             forcefield_files=None, box=None, overwrite=False, **kwargs):
         """Save the Compound to a file.
 
         Parameters
@@ -558,7 +558,7 @@ class Compound(object):
             traj = self.to_trajectory(show_ports=show_ports)
             traj.save(filename)
         else:  # ParmEd supported saver.
-            return structure.save(filename, **kwargs)
+            return structure.save(filename, overwrite=overwrite, **kwargs)
 
     def _apply_forcefield(self, structure, forcefield_files, forcefield_name):
         from foyer import Forcefield

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -547,9 +547,8 @@ class Compound(object):
         except KeyError:  # TODO: better reporting
             saver = None
 
-        if not hasattr(fname, 'write'):
-            if os.path.exists(filename) and not overwrite:
-                raise IOError('{0} exists; not overwriting' % fname)
+        if os.path.exists(filename) and not overwrite:
+            raise IOError('{0} exists; not overwriting' % filename)
 
         structure = self.to_parmed(**kwargs)
         if saver:  # mBuild/InterMol supported saver.

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -28,7 +28,7 @@ class TestCompound(BaseTest):
     def test_save_overwrite(self):
         methyl = mb.load(get_fn('methyl.pdb'))
         extensions = ['.gsd', 'hoomdxml', 'lammps' 'lmp']
-        for ext in extension:
+        for ext in extensions:
             outfile = 'lyhtem' + ext
             methyl.save(filename=outfile)
             methyl.save(filename=outfile, overwrite=True)

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -25,6 +25,16 @@ class TestCompound(BaseTest):
             methyl.save(filename=outfile)
             assert os.path.exists(outfile)
 
+    def test_save_overwrite(self):
+        methyl = mb.load(get_fn('methyl.pdb'))
+        extensions = ['.gsd', 'hoomdxml', 'lammps' 'lmp']
+        for ext in extension:
+            outfile = 'lyhtem' + ext
+            methyl.save(filename=outfile)
+            methyl.save(filename=outfile, overwrite=True)
+            with pytest.raises(IOError):
+                methyl.save(filename=outfile, overwrite=False)
+
     def test_batch_add(self, ethane, h2o):
         compound = mb.Compound()
         compound.add([ethane, h2o])


### PR DESCRIPTION
Raise an error if the file exists and overwrite == False.
This is checked before figuring out which writer needs to be used, so
that the internal writers won't ever see the overwrite kwarg.

Resolves #252 