### PR TITLE
parity now between osx and linux tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ Vagrantfile
 #conda version
 __conda_version__.txt
 mbuild/version.py
+
+#virtual env
+.env/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     - { os: linux, env: PYTHON_VERSION=2.7 }
     - { os: linux, env: PYTHON_VERSION=3.4 }
     - { os: linux, env: PYTHON_VERSION=3.5 }
+    - { os: osx, env: PYTHON_VERSION=2.7 }
+    - { os: osx, env: PYTHON_VERSION=3.4 }
     - { os: osx, env: PYTHON_VERSION=3.5 }
 
 env:


### PR DESCRIPTION
Now both osx and linux tests will test the same versions of python which is important for the conda builds.

I've also added .env/ to the .gitignore file to support virtualenv  