### PR TITLE
Cord trans

### DIFF
--- a/mbuild/coordinate_transform.py
+++ b/mbuild/coordinate_transform.py
@@ -50,8 +50,7 @@ def force_overlap(move_this, from_positions, to_positions, add_bond=True):
     if add_bond:
         if isinstance(from_positions, Port) and isinstance(to_positions, Port):
             if not from_positions.anchor or not to_positions.anchor:
-                # TODO: I think warnings is undefined here
-                warnings.warn("Attempting to form bond from port that has no anchor")
+                warn("Attempting to form bond from port that has no anchor")
             else:
                 from_positions.anchor.parent.add_bond((from_positions.anchor, to_positions.anchor))
                 to_positions.anchor.parent.add_bond((from_positions.anchor, to_positions.anchor))
@@ -349,7 +348,7 @@ def equivalence_transform(compound, from_positions, to_positions, add_bond=True)
         if isinstance(from_positions, Port) and isinstance(to_positions, Port):
             if not from_positions.anchor or not to_positions.anchor:
                 # TODO: I think warnings is undefined here
-                warnings.warn("Attempting to form bond from port that has no anchor")
+                warn("Attempting to form bond from port that has no anchor")
             else:
                 from_positions.anchor.parent.add_bond((from_positions.anchor, to_positions.anchor))
                 to_positions.anchor.parent.add_bond((from_positions.anchor, to_positions.anchor))


### PR DESCRIPTION
This file had windows line endings so it shows that everything has been changed. Other than some simple pep8 fixes I did two things of significance:

1. I got rid of `from numpy import *` since that can cause issues with name space
2. We had 'from warnings import warn' but then things like 'warnings.warn("foo")' which need to be `warn.("foo")` 