### PR TITLE
Cleanup forcefield application during saving

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -528,7 +528,7 @@ class Compound(object):
         ----------
         filename : str
             Filesystem path in which to save the trajectory. The extension or
-            prefix will be parsed and will control the format. Supported
+            prefix will be parsed and control the format. Supported
             extensions are: 'hoomdxml', 'gsd', 'gro', 'top', 'lammps', 'lmp'
         show_ports : bool, default=False
             Save ports contained within the compound.
@@ -538,10 +538,8 @@ class Compound(object):
         forcefield_name : str, default=None
             Apply a forcefield to the output file using the `foyer` package and
             a specific forcefield.xml file.
-
-        Other Parameters
-        ----------------
-        force_overwrite : bool
+        overwrite : bool
+            Overwrite the file if it already exists.
 
         """
         extension = os.path.splitext(filename)[-1]

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -20,10 +20,12 @@ from six import integer_types, string_types
 from mbuild.bond_graph import BondGraph
 from mbuild.box import Box
 from mbuild.exceptions import MBuildError
-from mbuild.periodic_kdtree import PeriodicCKDTree
-from mbuild.utils.io import run_from_ipython, import_
 from mbuild.formats.hoomdxml import write_hoomdxml
 from mbuild.formats.lammpsdata import write_lammpsdata
+from mbuild.formats.gsdwriter import write_gsd
+from mbuild.periodic_kdtree import PeriodicCKDTree
+from mbuild.utils.io import run_from_ipython, import_
+
 
 
 def load(filename, relative_to_module=None, compound=None, coords_only=False,
@@ -333,7 +335,6 @@ class Compound(object):
         for child in self.children:
             child.remove(yet_to_remove)
 
-
     def _remove_references(self, removed_part):
         """Remove labels pointing to this part and vice versa. """
         removed_part.parent = None
@@ -527,7 +528,8 @@ class Compound(object):
         ----------
         filename : str
             Filesystem path in which to save the trajectory. The extension or
-            prefix will be parsed and will control the format.
+            prefix will be parsed and will control the format. Supported
+            extensions are: 'hoomdxml', 'gsd', 'gro', 'top', 'lammps', 'lmp'
         show_ports : bool, default=False
             Save ports contained within the compound.
         forcefield_name : str, default=None
@@ -543,108 +545,54 @@ class Compound(object):
 
         """
         extension = os.path.splitext(filename)[-1]
+        if extension == '.xyz':
+            traj = self.to_trajectory(show_ports=show_ports)
+            traj.save(filename)
+            return
 
-        savers = {'.hoomdxml': self.save_hoomdxml,
-                  '.gsd': self.save_gsd,
-                  '.gro': self.save_gromacs,
-                  '.top': self.save_gromacs,
-                  '.lammps': self.save_lammpsdata,
-                  '.lmp': self.save_lammpsdata}
+        # Savers supported by mbuild.formats
+        savers = {'.hoomdxml': write_hoomdxml,
+                  '.gsd': write_gsd,
+                  '.lammps': write_lammpsdata,
+                  '.lmp': write_lammpsdata}
 
         try:
             saver = savers[extension]
-        except KeyError:  # TODO: better reporting
+        except KeyError:
             saver = None
 
         if os.path.exists(filename) and not overwrite:
             raise IOError('{0} exists; not overwriting'.format(filename))
 
         structure = self.to_parmed(**kwargs)
-        if saver:  # mBuild/InterMol supported saver.
-            saver(filename, structure, forcefield_name,
-                  forcefield_files, box, **kwargs)
-        elif extension == '.xyz':
-            traj = self.to_trajectory(show_ports=show_ports)
-            traj.save(filename)
+
+        # Apply a force field with foyer if specified
+        if forcefield_name or forcefield_files:
+            kwargs['forcefield'] = True
+            from foyer import Forcefield
+            ff = Forcefield(forcefield_files=forcefield_files,
+                            name=forcefield_name)
+            structure = ff.apply(structure)
+        else:
+            kwargs['forcefield'] = False
+
+        if box is None:
+            box = self.boundingbox
+            for dim, val in enumerate(self.periodicity):
+                if val:
+                    box.lengths[dim] = val
+                    box.maxs[dim] = val
+                    box.mins[dim] = 0.0
+                if not val:
+                    box.maxs[dim] += 0.25
+                    box.mins[dim] -= 0.25
+                    box.lengths[dim] += 0.5
+
+        if saver:  # mBuild supported saver.
+            saver(filename=filename, structure=structure, box=box, **kwargs)
         else:  # ParmEd supported saver.
-            return structure.save(filename, overwrite=overwrite, **kwargs)
-
-    def _apply_forcefield(self, structure, forcefield_files, forcefield_name):
-        from foyer import Forcefield
-        ff = Forcefield(forcefield_files=forcefield_files, name=forcefield_name)
-        structure = ff.apply(structure)
-        return structure
-
-    def _gen_box(self):
-        box = self.boundingbox
-        for dim, val in enumerate(self.periodicity):
-            if val:
-                box.lengths[dim] = val
-                box.maxs[dim] = val
-                box.mins[dim] = 0.0
-            if not val:
-                box.maxs[dim] += 0.25
-                box.mins[dim] -= 0.25
-                box.lengths[dim] += 0.5
-        return box
-
-    def save_hoomdxml(self, filename, structure, forcefield_name,
-                      forcefield_files, box, **kwargs):
-        """ """
-        forcefield = False
-        if forcefield_name or forcefield_files:
-            forcefield = True
-            structure = self._apply_forcefield(structure, forcefield_files,
-                                               forcefield_name)
-
-        if box is None:
-            box = self._gen_box()
-        write_hoomdxml(structure, filename, forcefield, box, **kwargs)
-
-    def save_gsd(self, filename, structure, forcefield_name,
-                 forcefield_files, box=None, **kwargs):
-        """ """
-        from mbuild.formats.gsdwriter import write_gsd
-        forcefield = False
-        if forcefield_name or forcefield_files:
-            forcefield = True
-            structure = self._apply_forcefield(structure, forcefield_files,
-                                               forcefield_name)
-
-        if box is None:
-            box = self._gen_box()
-        write_gsd(structure, filename, forcefield, box, **kwargs)
-
-    def save_gromacs(self, filename, structure, forcefield_name,
-                     forcefield_files, box, **kwargs):
-        """ """
-        # Create separate file paths for .gro and .top
-        filepath, filename = os.path.split(filename)
-        basename = os.path.splitext(filename)[0]
-        top_filename = os.path.join(filepath, basename + '.top')
-        gro_filename = os.path.join(filepath, basename + '.gro')
-        #  TODO: I think  the forcefield varable can be deleted here
-
-        if forcefield_name or forcefield_files:
-            structure = self._apply_forcefield(structure, forcefield_files,
-                                               forcefield_name)
-        if box is None:
-            box = self._gen_box()
-        structure.save(top_filename, 'gromacs', **kwargs)
-        structure.save(gro_filename, 'gro', **kwargs)
-
-    def save_lammpsdata(self, filename, structure, forcefield_name,
-                        forcefield_files, box, **kwargs):
-        """ """
-        forcefield = False
-        if forcefield_name or forcefield_files:
-            forcefield = True
-            structure = self._apply_forcefield(structure, forcefield_files,
-                                               forcefield_name)
-
-        if box is None:
-            box = self._gen_box()
-        write_lammpsdata(structure, filename, forcefield, box, **kwargs)
+            kwargs.pop('forcefield')
+            structure.save(filename, overwrite=overwrite, **kwargs)
 
     # Interface to Trajectory for reading/writing .pdb and .mol2 files.
     # -----------------------------------------------------------------

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -5,7 +5,7 @@ import pytest
 
 import mbuild as mb
 from mbuild.exceptions import MBuildError
-from mbuild.utils.io import get_fn, has_intermol
+from mbuild.utils.io import get_fn, has_intermol, has_foyer
 from mbuild.tests.base_test import BaseTest
 
 
@@ -17,23 +17,30 @@ class TestCompound(BaseTest):
     def test_update_from_file(self, ch3):
         ch3.update_coordinates(get_fn("methyl.pdb"))
 
-    def test_save(self):
-        methyl = mb.load(get_fn('methyl.pdb'))
+    def test_save_simple(self, ch3):
         extensions = ['.xyz', '.pdb', '.mol2']
         for ext in extensions:
             outfile = 'methyl_out' + ext
-            methyl.save(filename=outfile)
+            ch3.save(filename=outfile)
             assert os.path.exists(outfile)
 
-    def test_save_overwrite(self):
-        methyl = mb.load(get_fn('methyl.pdb'))
+    def test_save_overwrite(self, ch3):
         extensions = ['.gsd', '.hoomdxml', '.lammps', '.lmp']
         for ext in extensions:
             outfile = 'lyhtem' + ext
-            methyl.save(filename=outfile)
-            methyl.save(filename=outfile, overwrite=True)
+            ch3.save(filename=outfile)
+            ch3.save(filename=outfile, overwrite=True)
             with pytest.raises(IOError):
-                methyl.save(filename=outfile, overwrite=False)
+                ch3.save(filename=outfile, overwrite=False)
+
+    @pytest.mark.skipif(not has_foyer, reason="foyer is not installed")
+    def test_save_forcefield(self, methane):
+        exts = ['.gsd', '.hoomdxml', '.lammps', '.lmp', '.top', '.gro',
+                '.mol2', '.pdb', '.xyz']
+        for ext in exts:
+            methane.save('lythem' + ext,
+                         forcefield_name='oplsaa',
+                         overwrite=True)
 
     def test_batch_add(self, ethane, h2o):
         compound = mb.Compound()

--- a/mbuild/tests/test_coordinate_transform.py
+++ b/mbuild/tests/test_coordinate_transform.py
@@ -1,3 +1,5 @@
+import itertools as itt
+
 import numpy as np
 import pytest
 
@@ -20,54 +22,65 @@ class TestCoordinateTransform(BaseTest):
 
     def test_apply_to(self):
         double = CoordinateTransform(T=np.eye(4)*2)
-        A = np.array([[1,2,3],[4,5,6],[7,8,9]])
-        assert (double.apply_to(A) == np.array([[2,4,6],[8,10,12],[14,16,18]])).all()
+        A = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        assert (double.apply_to(A) ==
+                np.array([[2, 4, 6], [8, 10, 12], [14, 16, 18]])).all()
 
     def test_translation(self):
-        translation = Translation((10,10,10))
-        assert (translation.apply_to(np.array([[1,1,1]])) == np.array([11,11,11])).all()
+        translation = Translation((10, 10, 10))
+        assert (translation.apply_to(np.array([[1, 1, 1]])) ==
+                np.array([11, 11, 11])).all()
 
     def test_rotation_around_z(self):
         Z_rotation = RotationAroundZ(np.pi)
-        a = Z_rotation.apply_to(np.array([[2,3,4]]))
-        b = np.array([[-2.,-3.,4.]])
-        assert np.allclose(a, b, atol=1.e-16)
+        a = Z_rotation.apply_to(np.array([[2, 3, 4]]))
+        b = np.array([[-2., -3., 4.]])
+        assert np.allclose(a,  b,  atol=1.e-16)
 
     def test_rotation_around_y(self):
         Y_rotation = RotationAroundY(np.pi)
-        a = Y_rotation.apply_to(np.array([[2,3,4]]))
-        b = np.array([-2,3,-4])
-        assert np.allclose(a, b, atol=1.e-16)
+        a = Y_rotation.apply_to(np.array([[2, 3, 4]]))
+        b = np.array([-2, 3, -4])
+        assert np.allclose(a,  b,  atol=1.e-16)
 
     def test_rotation_around_x(self):
         X_rotation = RotationAroundX(np.pi)
-        a = X_rotation.apply_to(np.array([[2,3,4]]))
-        b = np.array([2,-3,-4])
-        assert np.allclose(a, b, atol=1.e-16)
+        a = X_rotation.apply_to(np.array([[2, 3, 4]]))
+        b = np.array([2, -3, -4])
+        assert np.allclose(a,  b,  atol=1.e-16)
 
     def test_rotation(self):
-        rotation = Rotation(np.pi*2/3, np.array([1,1,1]))
-        a = rotation.apply_to(np.array([[2,3,4]]))
-        b = np.array([4,2,3])
-        assert np.allclose(a, b, atol=1.e-16)
+        rotation = Rotation(np.pi*2/3,  np.array([1, 1, 1]))
+        a = rotation.apply_to(np.array([[2, 3, 4]]))
+        b = np.array([4, 2, 3])
+        assert np.allclose(a,  b,  atol=1.e-16)
 
     def test_change_of_basis(self):
-        change_basis = ChangeOfBasis(np.array([[-2,0,0],[0,-2,0],[0,0,-2]]))
-        assert (change_basis.apply_to(np.array([[2,3,4]])) == np.array([[-1.,-1.5,-2.]])).all()
+        change_basis = ChangeOfBasis(np.array([[-2, 0, 0],
+                                               [0, -2, 0],
+                                               [0, 0, -2]]))
+        assert (change_basis.apply_to(np.array([[2, 3, 4]])) ==
+                np.array([[-1., -1.5, -2.]])).all()
 
     def test_axis_transform(self):
-        origin_transform = AxisTransform(new_origin=np.array([1,1,1]))
-        assert (origin_transform.apply_to(np.array([[1,1,1]])) == np.array([[0,0,0]])).all()
-        orientation_transform = AxisTransform(point_on_x_axis=np.array([0,0,1]),point_on_xy_plane=np.array([0,1,1]))
-        assert (orientation_transform.apply_to(np.array([[2,3,4]])) == np.array([[4,3,-2]])).all()
-        axis_transform = AxisTransform(np.array([1,1,1]),np.array([1,1,2]),np.array([1,2,1]))
-        assert (axis_transform.apply_to(np.array([[2,3,4]])) == np.array([3,2,-1])).all()
+        origin_transform = AxisTransform(new_origin=np.array([1, 1, 1]))
+        assert (origin_transform.apply_to(np.array([[1, 1, 1]])) ==
+                np.array([[0, 0, 0]])).all()
+        orientation_transform = AxisTransform(point_on_x_axis=np.array([0, 0, 1]),
+                                              point_on_xy_plane=np.array([0, 1, 1]))
+        assert (orientation_transform.apply_to(np.array([[2, 3, 4]])) ==
+                np.array([[4, 3, -2]])).all()
+        axis_transform = AxisTransform(np.array([1, 1, 1]),
+                                       np.array([1, 1, 2]),
+                                       np.array([1, 2, 1]))
+        assert (axis_transform.apply_to(np.array([[2, 3, 4]])) ==
+                np.array([3, 2, -1])).all()
 
     def test_rigid_transform(self):
-        A = np.array([[2,3,4]])
-        B = np.array([[3,-4,9]])
-        rigid_transform = RigidTransform(A, B)
-        assert (rigid_transform.apply_to(np.array([[2,3,4]])) == B).all()
+        A = np.array([[2, 3, 4]])
+        B = np.array([[3, -4, 9]])
+        rigid_transform = RigidTransform(A,  B)
+        assert (rigid_transform.apply_to(np.array([[2, 3, 4]])) == B).all()
 
     def test_rotate_0(self, methane):
         before = methane.xyz_with_ports
@@ -226,79 +239,78 @@ class TestCoordinateTransform(BaseTest):
             rotate_around_z(methane, np.pi)
 
     def test_spin_relative_compound_coordinates(self, sixpoints):
-        """Ensure that a compounds's relative coordinates to not change upong spinning"""
-        import itertools as itt
+        """Check compounds's relative coordinates don't change upon spinning"""
         mol1 = mb.clone(sixpoints)
         mol2 = mb.clone(sixpoints)
         force_overlap(move_this=mol2,
-                from_positions=mol2['up'],
-                to_positions=mol1['down'],
-                add_bond=False)
+                      from_positions=mol2['up'],
+                      to_positions=mol1['down'],
+                      add_bond=False)
         mol1_angles_before = np.asarray(
-                [angle(a, b, c)
-                for (a, b, c) in itt.combinations(mol1.xyz, 3)])
+            [angle(a, b, c)
+             for (a, b, c) in itt.combinations(mol1.xyz, 3)])
         mol2_angles_before = np.asarray(
-                [angle(a, b, c)
-                for (a, b, c) in itt.combinations(mol2.xyz, 3)])
+            [angle(a, b, c)
+             for (a, b, c) in itt.combinations(mol2.xyz, 3)])
         spin_axis = (mol2['middle'].xyz - mol1['middle'].xyz).reshape(3)
         spin(mol2, np.pi*0.123456789, spin_axis)
         spin(mol1, -np.pi*0.123456789, spin_axis)
         mol1_angles_after = np.asarray(
-                [angle(a, b, c)
-                for (a, b, c) in itt.combinations(mol1.xyz, 3)])
+            [angle(a, b, c)
+             for (a, b, c) in itt.combinations(mol1.xyz, 3)])
         mol2_angles_after = np.asarray(
-                [angle(a, b, c)
-                for (a, b, c) in itt.combinations(mol2.xyz, 3)])
-        assert(np.allclose(mol1_angles_before, mol1_angles_after, atol=1e-16)
+            [angle(a, b, c)
+             for (a, b, c) in itt.combinations(mol2.xyz, 3)])
+        assert (    np.allclose(mol1_angles_before, mol1_angles_after, atol=1e-16)
                 and np.allclose(mol2_angles_before, mol2_angles_after, atol=1e-16))
 
     def test_equivalence_transform_deprectation_warning(self, ch2):
         ch22 = mb.clone(ch2)
         with pytest.warns(DeprecationWarning):
             mb.equivalence_transform(ch22,
-                    from_positions=ch22['up'],
-                    to_positions=ch2['down'])
+                                     from_positions=ch22['up'],
+                                     to_positions=ch2['down'])
 
     def test_rotate_around_x(self, methane):
         before = methane.xyz_with_ports
         rotate_around_x(methane, np.pi)
         after = methane.xyz_with_ports
-        assert(np.allclose(before[:, 1], -1*after[:, 1], atol=1e-16)
+        assert (    np.allclose(before[:, 1], -1*after[:, 1], atol=1e-16)
                 and np.allclose(before[:, 2], -1*after[:, 2], atol=1e-16))
 
     def test_rotate_around_y(self, ch2):
         before = ch2.xyz_with_ports
         rotate_around_y(ch2, np.pi)
         after = ch2.xyz_with_ports
-        assert(np.allclose(before[:, 0], -1*after[:, 0], atol=1e-16)
+        assert (    np.allclose(before[:, 0], -1*after[:, 0], atol=1e-16)
                 and np.allclose(before[:, 2], -1*after[:, 2], atol=1e-16))
 
     def test_rotate_around_z(self, ch2):
         before = ch2.xyz_with_ports
         rotate_around_z(ch2, np.pi)
         after = ch2.xyz_with_ports
-        assert(np.allclose(before[:, 0], -1*after[:, 0], atol=1e-16)
+        assert (    np.allclose(before[:, 0], -1*after[:, 0], atol=1e-16)
                 and np.allclose(before[:, 1], -1*after[:, 1], atol=1e-16))
 
     def test_rotate_around_x_away_from_origin(self, sixpoints):
         before = sixpoints.xyz_with_ports
         rotate_around_x(sixpoints, np.pi)
         after = sixpoints.xyz_with_ports
-        assert(np.allclose(before[:, 1], -1*after[:, 1], atol=1e-16)
+        assert (    np.allclose(before[:, 1], -1*after[:, 1], atol=1e-16)
                 and np.allclose(before[:, 2], -1*after[:, 2], atol=1e-16))
 
     def test_rotate_around_y_away_from_origin(self, sixpoints):
         before = sixpoints.xyz_with_ports
         rotate_around_y(sixpoints, np.pi)
         after = sixpoints.xyz_with_ports
-        assert(np.allclose(before[:, 0], -1*after[:, 0], atol=1e-16)
+        assert (    np.allclose(before[:, 0], -1*after[:, 0], atol=1e-16)
                 and np.allclose(before[:, 2], -1*after[:, 2], atol=1e-16))
 
     def test_rotate_around_z_away_from_origin(self, sixpoints):
         before = sixpoints.xyz_with_ports
         rotate_around_z(sixpoints, np.pi)
         after = sixpoints.xyz_with_ports
-        assert(np.allclose(before[:, 1], -1*after[:, 1], atol=1e-16)
+        assert (    np.allclose(before[:, 1], -1*after[:, 1], atol=1e-16)
                 and np.allclose(before[:, 0], -1*after[:, 0], atol=1e-16))
 
     def test_equivalence_transform(self, ch2, ch3, methane):
@@ -325,4 +337,5 @@ class TestCoordinateTransform(BaseTest):
         original_center = methane.center
         translate_value = np.array([2, 3, 4])
         translate_to(methane, translate_value)
-        assert (methane.xyz_with_ports == before-original_center+translate_value).all()
+        assert (methane.xyz_with_ports ==
+                before - original_center + translate_value).all()


### PR DESCRIPTION
Note: this slightly changes the gromacs saving behavior. Previously, specifying `.gro` or `.top` would save both. This "feature" has been removed and you will now only get the file that you specified.

Resolves #272 
