### PR TITLE
Add more descriptive error when _clone_bonds fails

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1870,7 +1870,11 @@ class Compound(object):
     def _clone_bonds(self, clone_of=None):
         newone = clone_of[self]
         for c1, c2 in self.bonds():
-            newone.add_bond((clone_of[c1], clone_of[c2]))
+            try:
+                newone.add_bond((clone_of[c1], clone_of[c2]))
+            except KeyError:
+                raise MBuildError("Cloning failed. Compound contains bonds to "
+                                  "Particles outside of its containment hierarchy.")
 
 
 Particle = Compound

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -538,3 +538,10 @@ class TestCompound(BaseTest):
 
         assert np.array_equal(distances, updated_distances)
         assert np.array_equal(orientations, updated_orientations)
+
+    def test_clone_outside_containment(self, ch2, ch3):
+        compound = mb.Compound()
+        compound.add(ch2)
+        mb.force_overlap(ch3, ch3['up'], ch2['up'])
+        with pytest.raises(MBuildError):
+            ch3_clone = mb.clone(ch3)


### PR DESCRIPTION
Cloning of a Compound will fail if it contains bonds to Particles
that reside outside of the Compound's containment hierarchy (as
these Particles are not included in the clone). Rather than simply
raising a KeyError when the bond cloning fails, a more descriptive
error message is now provided.

A unit test has been added to check for this error message.

This resolves #321 