### PR TITLE
Fix bug in energy_minimization where bonds were being interpreted incorrectly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
   - source devtools/travis-ci/install.sh
   - conda config --set always_yes yes --set changeps1 no
-  - conda env create -q -n test-environment python=$PYTHON_VERSION -f environment.yml
+  - conda env create -n test-environment python=$PYTHON_VERSION -f environment.yml
   - source activate test-environment
   - pip install -e .
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - numpy
 - scipy
 - packmol=1.0.0
-- nglview>=0.6
+- nglview>=0.6.2.3
 - oset
 - parmed
 - mdtraj

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1185,12 +1185,12 @@ class Compound(object):
         tmp_dir = tempfile.mkdtemp()
         original = clone(self)
         self._kick()
-        self.save(os.path.join(tmp_dir,'un-minimized.pdb'))
+        self.save(os.path.join(tmp_dir,'un-minimized.mol2'))
         obConversion = openbabel.OBConversion()
-        obConversion.SetInAndOutFormats("pdb", "mol2")
+        obConversion.SetInAndOutFormats("mol2", "mol2")
         mol = openbabel.OBMol()
 
-        obConversion.ReadFile(mol, os.path.join(tmp_dir, "un-minimized.pdb"))
+        obConversion.ReadFile(mol, os.path.join(tmp_dir, "un-minimized.mol2"))
 
         ff = openbabel.OBForceField.FindForceField(forcefield)
         if ff is None:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -16,6 +16,7 @@ import numpy as np
 from oset import oset as OrderedSet
 import parmed as pmd
 from parmed.periodic_table import AtomicNum, element_by_name, Mass
+import simtk.openmm.app.element as elem
 from six import integer_types, string_types
 
 from mbuild.bond_graph import BondGraph
@@ -1182,6 +1183,14 @@ class Compound(object):
         """
         openbabel = import_('openbabel')
 
+        for particle in self.particles():
+            try:
+                elem.get_by_symbol(particle.name)
+            except KeyError:
+                raise MBuildError("Element name {} not recognized. Cannot "
+                                  "perform minimization."
+                                  "".format(particle.name)) from None
+
         tmp_dir = tempfile.mkdtemp()
         original = clone(self)
         self._kick()
@@ -1214,13 +1223,7 @@ class Compound(object):
         ff.UpdateCoordinates(mol)
 
         obConversion.WriteFile(mol, os.path.join(tmp_dir, 'minimized.mol2'))
-        try:
-            self.update_coordinates(os.path.join(tmp_dir, 'minimized.mol2'))
-        except ValueError:
-            for i, particle in enumerate(self.particles()):
-                particle.pos = original.xyz[i]
-            warn("Minimization failed (perhaps your Compound contains non-"
-                 "element types). Coordinates not updated.", RuntimeWarning)
+        self.update_coordinates(os.path.join(tmp_dir, 'minimized.mol2'))
 
     def save(self, filename, show_ports=False, forcefield_name=None,
              forcefield_files=None, box=None, overwrite=False, residues=None,

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -535,7 +535,7 @@ class TestCompound(BaseTest):
     def test_energy_minimization_non_element(self, octane):
         for particle in octane.particles():
             particle.name = 'Q'
-        with pytest.warns(RuntimeWarning):
+        with pytest.raises(MBuildError):
             octane.energy_minimization()
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel package not installed")


### PR DESCRIPTION
The PDB writer we are using from ParmEd does not write bonds, and since a temporary PDB file was being used in energy_minimization the bonds were being lost. OpenBabel was then inferring bonding from the atom spacing. The type of the temporary file has been switched to MOL2 which solves this problem.

As a side note, the bond order is still being inferred from the atom spacing.  This is something that a future PR may be able to fix by inferring bond order from the local chemistry.