### PR TITLE
Add argument to save() to output force field references

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1224,7 +1224,7 @@ class Compound(object):
 
     def save(self, filename, show_ports=False, forcefield_name=None,
              forcefield_files=None, box=None, overwrite=False, residues=None,
-             output_refs=False, **kwargs):
+             references_file=None, **kwargs):
         """Save the Compound to a file.
 
         Parameters
@@ -1294,7 +1294,7 @@ class Compound(object):
             from foyer import Forcefield
             ff = Forcefield(forcefield_files=forcefield_files,
                             name=forcefield_name)
-            structure = ff.apply(structure, output_refs=output_refs)
+            structure = ff.apply(structure, references_file=references_file)
 
         if box is None:
             box = self.boundingbox

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1224,7 +1224,7 @@ class Compound(object):
 
     def save(self, filename, show_ports=False, forcefield_name=None,
              forcefield_files=None, box=None, overwrite=False, residues=None,
-             **kwargs):
+             output_refs=False, **kwargs):
         """Save the Compound to a file.
 
         Parameters
@@ -1294,7 +1294,7 @@ class Compound(object):
             from foyer import Forcefield
             ff = Forcefield(forcefield_files=forcefield_files,
                             name=forcefield_name)
-            structure = ff.apply(structure)
+            structure = ff.apply(structure, output_refs=output_refs)
 
         if box is None:
             box = self.boundingbox

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1247,6 +1247,12 @@ class Compound(object):
             overlapping atoms.
         overwrite : bool, optional, default=False
             Overwrite if the filename already exists
+        residues : str or list of str
+            Labels of residues in the Compound. Residues are assigned by
+            checking against Compound.name.
+        references_file : str, optional, default=None
+            Specify a filename to write references for the forcefield that is
+            to be applied.  References are written in BibTeX format.
 
         Other Parameters
         ----------------
@@ -1435,8 +1441,9 @@ class Compound(object):
             Include all port atoms when converting to trajectory.
         chains : mb.Compound or list of mb.Compound
             Chain types to add to the topology
-        residues : mb.Compound or list of mb.Compound
-            Residue types to add to the topology
+        residues : str or list of str
+            Labels of residues in the Compound. Residues are assigned by
+            checking against Compound.name.
 
         Returns
         -------
@@ -1477,8 +1484,9 @@ class Compound(object):
             Atoms to include in the topology
         chains : mb.Compound or list of mb.Compound
             Chain types to add to the topology
-        residues : mb.Compound or list of mb.Compound
-            Residue types to add to the topology
+        residues : str or list of str
+            Labels of residues in the Compound. Residues are assigned by
+            checking against Compound.name.
 
         Returns
         -------
@@ -1630,6 +1638,9 @@ class Compound(object):
         ----------
         title : str, optional, default=self.name
             Title/name of the ParmEd Structure
+        residues : str or list of str
+            Labels of residues in the Compound. Residues are assigned by
+            checking against Compound.name.
 
         Returns
         -------

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -50,6 +50,11 @@ class TestCompound(BaseTest):
         assert struct.residues[0].name == 'CH3'
         assert struct.residues[1].name == 'H2O'
 
+    def test_save_references(self, methane):
+        methane.save('methyl.mol2', forcefield_name='oplsaa', 
+                     references_file='methane.bib')
+        assert os.path.isfile('methane.bib')
+
     def test_batch_add(self, ethane, h2o):
         compound = mb.Compound()
         compound.add([ethane, h2o])

--- a/mbuild/tests/test_gsd.py
+++ b/mbuild/tests/test_gsd.py
@@ -2,7 +2,7 @@ import mbuild as mb
 import numpy as np
 import pytest
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import has_foyer, has_gsd
+from mbuild.utils.io import has_gsd
 
 
 class TestGSD(BaseTest):
@@ -12,12 +12,10 @@ class TestGSD(BaseTest):
         ethane.save(filename='ethane.gsd')
 
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
-    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_forcefield(self, ethane):
         ethane.save(filename='ethane-opls.gsd', forcefield_name='oplsaa')
 
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
-    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_box(self, ethane):
         box = mb.Box(lengths=np.array([2.0,2.0,2.0]))
         ethane.save(filename='ethane-box.gsd', forcefield_name='oplsaa',box=box)

--- a/mbuild/tests/test_hoomdxml.py
+++ b/mbuild/tests/test_hoomdxml.py
@@ -4,7 +4,6 @@ import xml.etree.ElementTree
 
 import mbuild as mb
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import has_foyer
 
 
 class TestHoomdXML(BaseTest):
@@ -12,7 +11,6 @@ class TestHoomdXML(BaseTest):
     def test_save(self, ethane):
         ethane.save(filename='ethane.hoomdxml')
 
-    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_forcefield(self, ethane):
         ethane.save(filename='ethane-opls.hoomdxml', forcefield_name='oplsaa')
 

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -3,7 +3,6 @@ import pytest
 
 import mbuild as mb
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import has_foyer
 
 
 class TestLammpsData(BaseTest):
@@ -11,11 +10,9 @@ class TestLammpsData(BaseTest):
     def test_save(self, ethane):
         ethane.save(filename='ethane.lammps')
 
-    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_forcefield(self, ethane):
         ethane.save(filename='ethane-opls.lammps', forcefield_name='oplsaa')
 
-    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_box(self, ethane):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]))
         ethane.save(filename='ethane-box.lammps', forcefield_name='oplsaa', box=box)


### PR DESCRIPTION
A filename can be passed to the save function to output references for the force field that is being applied.  References are written in BibTeX format.