### PR TITLE
Changes to charge attribute and charge neutrality warning

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -214,6 +214,7 @@ class Compound(object):
                 raise MBuildError('Cannot set the charge of a Compound containing '
                                   'subcompounds.')
             self.add(subcompounds)
+            self._charge = 0.0
         else:
             self._charge = charge
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1701,7 +1701,7 @@ class Compound(object):
             atomic_number = atomic_number or AtomicNum[element]
             mass = Mass[element]
             pmd_atom = pmd.Atom(atomic_number=atomic_number, name=atom.name,
-                                mass=mass)
+                                mass=mass, charge=atom.charge)
             pmd_atom.xx, pmd_atom.xy, pmd_atom.xz = atom.pos * 10  # Angstroms
 
             residue = atom_residue_map[atom]

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1317,6 +1317,11 @@ class Compound(object):
                             name=forcefield_name)
             structure = ff.apply(structure)
 
+        total_charge = sum([atom.charge for atom in structure])
+        if round(total_charge, 4) != 0.0:
+            warn('System is not charge neutral. Total charge is {}.'
+                 ''.format(total_charge))
+
         # Provide a warning if rigid_ids are not sequential from 0
         if self.contains_rigid:
             unique_rigid_ids = sorted(set([p.rigid_id

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -211,7 +211,7 @@ class Compound(object):
         # self.add() must be called after labels and children are initialized.
         if subcompounds:
             if charge:
-                raise MBuildError('Cannot set the charge of a Compound containing 
+                raise MBuildError('Cannot set the charge of a Compound containing '
                                   'subcompounds.')
             self.add(subcompounds)
         else:
@@ -1866,11 +1866,11 @@ class Compound(object):
         newone.name = deepcopy(self.name)
         newone.periodicity = deepcopy(self.periodicity)
         newone._pos = deepcopy(self._pos)
-        newone.charge = deepcopy(self.charge)
         newone.port_particle = deepcopy(self.port_particle)
         newone._check_if_contains_rigid_bodies = deepcopy(self._check_if_contains_rigid_bodies)
         newone._contains_rigid = deepcopy(self._contains_rigid)
         newone._rigid_id = deepcopy(self._rigid_id)
+        newone._charge = deepcopy(self._charge)
         if hasattr(self, 'index'):
             newone.index = deepcopy(self.index)
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -196,8 +196,6 @@ class Compound(object):
         else:
             self._pos = np.zeros(3)
 
-        self.charge = charge
-
         self.parent = None
         self.children = OrderedSet()
         self.labels = OrderedDict()
@@ -212,7 +210,12 @@ class Compound(object):
 
         # self.add() must be called after labels and children are initialized.
         if subcompounds:
+            if charge:
+                raise MBuildError('Cannot set the charge of a Compound containing 
+                                  'subcompounds.')
             self.add(subcompounds)
+        else:
+            self._charge = charge
 
     def particles(self, include_ports=False):
         """Return all Particles of the Compound.
@@ -332,6 +335,18 @@ class Compound(object):
         for particle in self.particles():
             if particle.name == name:
                 yield particle
+
+    @property
+    def charge(self):
+        return sum([particle._charge for particle in self.particles()])
+
+    @charge.setter
+    def charge(self, value):
+        if self._contains_only_ports():
+            self._charge = value
+        else:
+            raise AttributeError("charge is immutable for Compounds that are "
+                                 "not at the bottom of the containment hierarchy.")
 
     @property
     def rigid_id(self):

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -522,6 +522,42 @@ class TestCompound(BaseTest):
         assert np.array_equal(distances, updated_distances)
         assert np.array_equal(orientations, updated_orientations)
 
+    def test_charge(self, ch2, ch3):
+        compound = mb.Compound(charge=2.0)
+        assert compound.charge == 2.0
+        compound2 = mb.Compound()
+        assert compound2.charge == 0.0
+
+        ch2[0].charge = 0.5
+        ch2[1].charge = -0.25
+        ch3[0].charge = 1.0
+        compound.add([ch2, ch3])
+        assert compound.charge == 1.25
+        assert ch2.charge == 0.25
+        assert compound[0].charge == 0.5
+
+        with pytest.raises(AttributeError):
+            compound.charge = 2.0
+
+    def test_charge_subcompounds(self, ch2, ch3):
+        ch2[0].charge = 0.5
+        ch2[1].charge = -0.25
+        compound = mb.Compound(subcompounds=ch2)
+        assert compound.charge == 0.25
+
+        with pytest.raises(MBuildError):
+            compound = mb.Compound(subcompounds=ch3, charge=1.0)
+
+    def test_charge_neutrality_warn(self, benzene):
+        benzene[0].charge = 0.25
+        with pytest.warns(UserWarning):
+            benzene.save('charge-test.mol2')
+
+        with pytest.warns(None) as record_warnings:
+            benzene.save('charge-test.mol2', forcefield_name='oplsaa', 
+                         overwrite=True)
+        assert len(record_warnings) == 0
+
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel package not installed")
     def test_energy_minimization(self, octane):
         octane.energy_minimization()
@@ -576,29 +612,3 @@ class TestCompound(BaseTest):
         mb.force_overlap(ch3, ch3['up'], ch2['up'])
         with pytest.raises(MBuildError):
             ch3_clone = mb.clone(ch3)
-
-    def test_charge(self, ch2, ch3):
-        compound = mb.Compound(charge=2.0)
-        assert compound.charge == 2.0
-        compound2 = mb.Compound()
-        assert compound2.charge == 0.0
-
-        ch2[0].charge = 0.5
-        ch2[1].charge = -0.25
-        ch3[0].charge = 1.0
-        compound.add([ch2, ch3])
-        assert compound.charge == 1.25
-        assert ch2.charge == 0.25
-        assert compound[0].charge == 0.5
-
-        with pytest.raises(AttributeError):
-            compound.charge = 2.0
-
-    def test_charge_subcompounds(self, ch2, ch3):
-        ch2[0].charge = 0.5
-        ch2[1].charge = -0.25
-        compound = mb.Compound(subcompounds=ch2)
-        assert compound.charge == 0.25
-
-        with pytest.raises(MBuildError):
-            compound = mb.Compound(subcompounds=ch3, charge=1.0)

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -577,3 +577,28 @@ class TestCompound(BaseTest):
         with pytest.raises(MBuildError):
             ch3_clone = mb.clone(ch3)
 
+    def test_charge(self, ch2, ch3):
+        compound = mb.Compound(charge=2.0)
+        assert compound.charge == 2.0
+        compound2 = mb.Compound()
+        assert compound2.charge == 0.0
+
+        ch2[0].charge = 0.5
+        ch2[1].charge = -0.25
+        ch3[0].charge = 1.0
+        compound.add([ch2, ch3])
+        assert compound.charge == 1.25
+        assert ch2.charge == 0.25
+        assert compound[0].charge == 0.5
+
+        with pytest.raises(AttributeError):
+            compound.charge = 2.0
+
+    def test_charge_subcompounds(self, ch2, ch3):
+        ch2[0].charge = 0.5
+        ch2[1].charge = -0.25
+        compound = mb.Compound(subcompounds=ch2)
+        assert compound.charge == 0.25
+
+        with pytest.raises(MBuildError):
+            compound = mb.Compound(subcompounds=ch3, charge=1.0)


### PR DESCRIPTION
The charge attribute now returns either the partial charge on the Compound (if it resides at the bottom of the containment hierarchy) or the sum of the partial charges of all Particles a Compound contains.

A warning is now raised if a save() is called on a Compound that is not charge neutral.  The total charge on the Compound is checked after force field application (if one is specified).

This resolves #280 