### PR TITLE
Allow fill_box to accept multiple compounds in one call

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -58,9 +58,9 @@ def fill_box(compound, n_compounds, box, overlap=0.2, seed=12345):
         raise IOError(msg)
 
     box = _validate_box(box)
-    if type(compound) != list:
+    if isinstance(compound, (list, set)):
         compound = [compound]
-    if type(n_compounds) != list:
+    if isinstance(n_compounds, (list, set)):
         n_compounds = [n_compounds]
 
     # In angstroms for packmol.
@@ -73,7 +73,6 @@ def fill_box(compound, n_compounds, box, overlap=0.2, seed=12345):
     input_text = PACKMOL_HEADER.format(overlap, filled_pdb, seed)
 
     for comp, m_compounds in zip(compound, n_compounds):
-        print(comp, m_compounds)
         m_compounds = int(m_compounds)
         compound_pdb = tempfile.mkstemp(suffix='.pdb')[1]
         comp.save(compound_pdb, overwrite=True)

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -58,9 +58,9 @@ def fill_box(compound, n_compounds, box, overlap=0.2, seed=12345):
         raise IOError(msg)
 
     box = _validate_box(box)
-    if isinstance(compound, (list, set)) == False:
+    if not isinstance(compound, (list, set)):
         compound = [compound]
-    if isinstance(n_compounds, (list, set)) == False:
+    if not isinstance(n_compounds, (list, set)):
         n_compounds = [n_compounds]
 
     # In angstroms for packmol.
@@ -114,9 +114,9 @@ def solvate(solute, solvent, n_solvent, box, overlap=0.2, seed=12345):
         raise IOError("Packmol not found")
 
     box = _validate_box(box)
-    if isinstance(solvent, (list, set)) == False:
+    if not isinstance(solvent, (list, set)):
         solvent = [solvent]
-    if isinstance(n_solvent, (list, set)) == False:
+    if not isinstance(n_solvent, (list, set)):
         n_solvent = [n_solvent]
 
     # In angstroms for packmol.

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -58,9 +58,9 @@ def fill_box(compound, n_compounds, box, overlap=0.2, seed=12345):
         raise IOError(msg)
 
     box = _validate_box(box)
-    if isinstance(compound, (list, set)):
+    if isinstance(compound, (list, set)) == False:
         compound = [compound]
-    if isinstance(n_compounds, (list, set)):
+    if isinstance(n_compounds, (list, set)) == False:
         n_compounds = [n_compounds]
 
     # In angstroms for packmol.

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -17,12 +17,19 @@ class TestPacking(BaseTest):
         filled = mb.fill_box([ethane, h2o], [1, 100], box=[4, 4, 4])
         assert filled.n_particles == 8 + n_solvent * 3
         assert filled.n_bonds == 7 + n_solvent * 2
+        assert len(filled.children) == 101
 
     def test_solvate(self, ethane, h2o):
         n_solvent = 100
         solvated = mb.solvate(ethane, h2o, n_solvent=n_solvent, box=[4, 4, 4])
         assert solvated.n_particles == 8 + n_solvent * 3
         assert solvated.n_bonds == 7 + n_solvent * 2
+
+    def test_solvate_multiple(self, methane, ethane, h2o):
+        init_box = mb.fill_box(methane, 2, box=[4, 4, 4])
+        solvated = mb.solvate(init_box, [ethane, h2o], [20, 20], box=[4, 4, 4])
+        assert solvated.n_particles == 2*5 + 20*8 + 20*3
+        assert len(solvated.children) == 41
 
     def test_fill_box_seed(self, ethane):
         filled = mb.fill_box(ethane, n_compounds=20, box=[2, 2, 2])

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -12,6 +12,12 @@ class TestPacking(BaseTest):
         assert filled.n_particles == 20 * 8
         assert filled.n_bonds == 20 * 7
 
+    def test_fill_box_multiple(self, ethane, h2o):
+        n_solvent = 100
+        filled = mb.fill_box([ethane, h2o], [1, 100], box=[4, 4, 4])
+        assert filled.n_particles == 8 + n_solvent * 3
+        assert filled.n_bonds == 7 + n_solvent * 2
+
     def test_solvate(self, ethane, h2o):
         n_solvent = 100
         solvated = mb.solvate(ethane, h2o, n_solvent=n_solvent, box=[4, 4, 4])


### PR DESCRIPTION
#253 and potential fix to #353

This would allow us to maintain both types of parent hierarchies (fluid-like systems to be built with ```mb.fill_box``` and protein-like solvation done with ```mb.solvate()```). However, there may be some cases in which calling ```mb.solvate()``` without making a new parent level would be desirable.