### PR TITLE
Revert back to Mdtraj readers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Miniconda3-x64"
-      CONDA_PY: "34"
+      CONDA_PY: "27"
       ARCH: "64"
     - PYTHON: "C:\\Miniconda3-x64"
       CONDA_PY: "35"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Miniconda3-x64"
-      CONDA_PY: "27"
-      ARCH: "64"
-    - PYTHON: "C:\\Miniconda3-x64"
       CONDA_PY: "35"
       ARCH: "64"
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -76,6 +76,8 @@ def load(filename, relative_to_module=None, compound=None, coords_only=False,
         compound = Compound()
 
     if use_parmed:
+        warn("use_parmed set to True.  Bonds may be inferred from inter-particle "
+             "distances and standard residue templates!")
         structure = pmd.load_file(filename, structure=True, **kwargs)
         compound.from_parmed(structure, coords_only=coords_only)
     else:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -79,7 +79,7 @@ def load(filename, relative_to_module=None, compound=None, coords_only=False,
         structure = pmd.load_file(filename, structure=True, **kwargs)
         compound.from_parmed(structure, coords_only=coords_only)
     else:
-        traj = mdtraj.load(filename, **kwargs)
+        traj = md.load(filename, **kwargs)
         compound.from_trajectory(traj, frame=-1, coords_only=coords_only)
 
     if rigid:
@@ -1495,7 +1495,7 @@ class Compound(object):
             else:
                 unitcell_lengths[dim] = box.lengths[dim]
 
-        return mdtraj.Trajectory(xyz, top, unitcell_lengths=unitcell_lengths,
+        return md.Trajectory(xyz, top, unitcell_lengths=unitcell_lengths,
                              unitcell_angles=np.array([90, 90, 90]))
 
     def _to_topology(self, atom_list, chains=None, residues=None):

--- a/mbuild/tests/base_test.py
+++ b/mbuild/tests/base_test.py
@@ -162,3 +162,8 @@ class BaseTest:
         mb.translate(ch['b'], [0, 0.07, 0]) 
         mb.rotate_around_z(ch['b'], -120.0 * (np.pi/180.0))
         return ch
+
+    @pytest.fixture
+    def silane(self):
+        from mbuild.lib.moieties import Silane
+        return Silane()

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -618,3 +618,6 @@ class TestCompound(BaseTest):
         with pytest.raises(KeyError):
             mb.load(get_fn('benzene-nonelement.mol2'))
         mb.load(get_fn('benzene-nonelement.mol2'), use_parmed=True)
+
+    def test_siliane_bond_number(self, silane):
+        assert silane.n_bonds == 4

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1,6 +1,5 @@
 import os
 
-from foyer.exceptions import ValidationWarning
 import numpy as np
 import parmed as pmd
 import pytest

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -30,15 +30,12 @@ class TestCompound(BaseTest):
         box_attributes = ['mins', 'maxs', 'lengths']
         custom_box = mb.Box([.8, .8, .8])
         for ext in extensions:
-            use_mdtraj = False
-            if ext == '.hoomdxml':
-                use_mdtraj = True
             outfile_padded = 'padded_methyl' + ext
             outfile_custom = 'custom_methyl' + ext
             ch3.save(filename=outfile_padded, box=None, overwrite=True)
             ch3.save(filename=outfile_custom, box=custom_box, overwrite=True)
-            padded_ch3 = mb.load(outfile_padded, use_mdtraj=use_mdtraj)
-            custom_ch3 = mb.load(outfile_custom, use_mdtraj=use_mdtraj)
+            padded_ch3 = mb.load(outfile_padded)
+            custom_ch3 = mb.load(outfile_custom)
             for attr in box_attributes:
                 pad_attr = getattr(padded_ch3.boundingbox, attr)
                 custom_attr = getattr(custom_ch3.boundingbox, attr)
@@ -619,5 +616,5 @@ class TestCompound(BaseTest):
 
     def test_load_mol2_mdtraj(self):
         with pytest.raises(KeyError):
-            mb.load(get_fn('benzene-nonelement.mol2'), use_mdtraj=True)
-        mb.load(get_fn('benzene-nonelement.mol2'))
+            mb.load(get_fn('benzene-nonelement.mol2'))
+        mb.load(get_fn('benzene-nonelement.mol2'), use_parmed=True)

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -125,12 +125,6 @@ except ImportError:
     has_gsd = False
 
 try:
-    import mdtraj
-    has_mdtraj = True
-except ImportError:
-    has_mdtraj = False
-
-try:
     import openbabel
     has_openbabel = True
 except ImportError:


### PR DESCRIPTION
ParmEd's PDB reader (and possibly other readers) infer bonds from inter-particle distances and standard residue templates.  This can lead to undesired topologies, such as in #362.  Reverting back to MDTraj's readers seems to be the best course of action for now, although the option to use ParmEd's readers is provided as this can be desired in certain cases (see #349 ).