### PR TITLE
Fix passing list of mb.Box to fill_region

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -123,7 +123,7 @@ def fill_region(compound, n_compounds, region, overlap=0.2, seed=12345):
     if not isinstance(n_compounds, (list, set)):
         n_compounds = [n_compounds]
     # See if region is a single region or list
-    if type(region) == Box: # Cannot iterate over boxes
+    if isinstance(region, Box): # Cannot iterate over boxes
         region = [region]
     elif not any(isinstance(reg, (list, set, Box)) for reg in region):
         region = [region]

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -122,7 +122,10 @@ def fill_region(compound, n_compounds, region, overlap=0.2, seed=12345):
         compound = [compound]
     if not isinstance(n_compounds, (list, set)):
         n_compounds = [n_compounds]
-    if not any(isinstance(reg, list) for reg in region): # See if region is a single region or list
+    # See if region is a single region or list
+    if type(region) == Box: # Cannot iterate over boxes
+        region = [region]
+    elif not any(isinstance(reg, (list, set)) for reg in region): 
         region = [region]
     region = [_validate_box(reg) for reg in region]
 

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -125,7 +125,7 @@ def fill_region(compound, n_compounds, region, overlap=0.2, seed=12345):
     # See if region is a single region or list
     if type(region) == Box: # Cannot iterate over boxes
         region = [region]
-    elif not any(isinstance(reg, (list, set)) for reg in region): 
+    elif not any(isinstance(reg, (list, set, Box)) for reg in region):
         region = [region]
     region = [_validate_box(reg) for reg in region]
 

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -36,6 +36,16 @@ class TestPacking(BaseTest):
         assert np.max(filled.xyz[:16, 0]) < 4
         assert np.min(filled.xyz[16:, 0]) > 4
 
+    def test_fill_region_multiple_boxes(self, ethane, h2o):
+        box1 = mb.Box(mins=[2, 2, 2], maxs=[4, 4, 4])
+        box2 = mb.Box(mins=[4, 2, 2], maxs=[6, 4, 4])
+        filled = mb.fill_region(compound=[ethane, h2o], n_compounds=[2, 2],
+                                region=[box1, box2])
+        assert filled.n_particles == 2 * 8 + 2 * 3
+        assert filled.n_bonds == 2 * 7 + 2 * 2
+        assert np.max(filled.xyz[:16, 0]) < 4
+        assert np.min(filled.xyz[16:, 0]) > 4
+
     def test_fill_box_multiple(self, ethane, h2o):
         n_solvent = 100
         filled = mb.fill_box([ethane, h2o], [1, 100], box=[4, 4, 4])

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -46,6 +46,16 @@ class TestPacking(BaseTest):
         assert np.max(filled.xyz[:16, 0]) < 4
         assert np.min(filled.xyz[16:, 0]) > 4
 
+    def test_fill_region_multiple_types(self, ethane, h2o):
+        box1 = mb.Box(mins=[2, 2, 2], maxs=[4, 4, 4])
+        box2 = [4, 2, 2, 6, 4, 4]
+        filled = mb.fill_region(compound=[ethane, h2o], n_compounds=[2, 2],
+                                region=[box1, box2])
+        assert filled.n_particles == 2 * 8 + 2 * 3
+        assert filled.n_bonds == 2 * 7 + 2 * 2
+        assert np.max(filled.xyz[:16, 0]) < 4
+        assert np.min(filled.xyz[16:, 0]) > 4
+
     def test_fill_box_multiple(self, ethane, h2o):
         n_solvent = 100
         filled = mb.fill_box([ethane, h2o], [1, 100], box=[4, 4, 4])

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -20,6 +20,14 @@ class TestPacking(BaseTest):
         assert np.min(filled.xyz[:,0]) >= 3
         assert np.max(filled.xyz[:,2]) <= 3
 
+    def test_fill_region_box(self, h2o):
+        mybox = mb.Box([4, 4, 4])
+        filled = mb.fill_region(h2o, n_compounds=50, region=mybox)
+        assert filled.n_particles == 50 * 3
+        assert filled.n_bonds == 50 * 2
+        assert np.min(filled.xyz[:,0]) >= 0
+        assert np.max(filled.xyz[:,2]) <= 4
+
     def test_fill_region_multiple(self, ethane, h2o):
         filled = mb.fill_region(compound=[ethane, h2o], n_compounds=[2, 2],
                                 region=[[2, 2, 2, 4, 4, 4], [4, 2, 2, 6, 4, 4]])


### PR DESCRIPTION
I was sloppy in #311 and I didn't catch the case of passing a list of ```mb.Box``` to ```fill_region```.

h/t @loganguy11