### PR TITLE
Increase timeout for examples tests to 60 seconds

### DIFF
--- a/mbuild/examples/test_examples.py
+++ b/mbuild/examples/test_examples.py
@@ -47,8 +47,8 @@ def run_notebook(nb):
         if cell.cell_type != 'code':
             continue
         kc.execute(cell.source)
-        # wait for finish, maximum 20s
-        reply = shell.get_msg(timeout=20)['content']
+        # wait for finish, maximum 60s
+        reply = shell.get_msg(timeout=60)['content']
         if reply['status'] == 'error':
             failures += 1
             print("\nFAILURE:")


### PR DESCRIPTION
Travis has been failing occasionally due to timing out on the examples tests.  Checking to see if increasing the wait time before timing out solves this issue.