### PR TITLE
Fix 404 error with Avogadro Link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Example system
 --------------
 
 Components in dashed boxes are drawn by hand using, e.g.,
-`Avogadro <http://avogadro.cc/wiki/Main_Page>`_ or generated elsewhere. Each
+`Avogadro <http://avogadro.cc>`_ or generated elsewhere. Each
 component is wrapped as a simple python class with user defined attachment
 sites, or ports. That's the hard part! Now mBuild can do the rest. Each component
 further down the hierarchy is, again, a simple python class that describes


### PR DESCRIPTION
Avogadro link in the docs was dead. Updated to general landing page for Avogadro.