### PR TITLE
Add density as an argument to fill_box

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -45,12 +45,12 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2, se
     If `n_compounds` and `box` are not None, the specified number of
     n_compounds will be inserted into a box of the specified size.
 
-    If `n_compounds` and `density` are not None, the box corresponding box
-    size will be calculated internally.
+    If `n_compounds` and `density` are not None, the corresponding box
+    size will be calculated internally. In this case, `n_compounds`
+    must be an int and not a list of int.
 
     If `box` and `density` are not None, the box corresponding number of
-    compounds will be calculated internally. In this case, `n_compounds`
-    must be an int and not a list of int.
+    compounds will be calculated internally.
 
     Parameters
     ----------

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -49,7 +49,7 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2, se
     size will be calculated internally. In this case, `n_compounds`
     must be an int and not a list of int.
 
-    If `box` and `density` are not None, the box corresponding number of
+    If `box` and `density` are not None, the corresponding number of
     compounds will be calculated internally.
 
     Parameters

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -40,13 +40,26 @@ end structure
 def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2, seed=12345):
     """Fill a box with a compound using packmol.
 
+    Two arguments of `n_compounds, box, and density` must be specified.
+
+    If `n_compounds` and `box` are not None, the specified number of
+    n_compounds will be inserted into a box of the specified size.
+
+    If `n_compounds` and `density` are not None, the box corresponding box
+    size will be calculated internally.
+
+    If `box` and `density` are not None, the box corresponding number of
+    compounds will be calculated internally. In this case, `n_compounds`
+    must be an int and not a list of int.
+
     Parameters
     ----------
     compound : mb.Compound or list of mb.Compound
     n_compounds : int or list of int
     box : mb.Box
-    overlap : float
-    density : float
+    overlap : float, units nm
+    density : float, units kg/nm^3
+
     Returns
     -------
     filled : mb.Compound
@@ -60,6 +73,11 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2, se
             msg = (msg + " If packmol is already installed, make sure that the "
                          "packmol.exe is on the path.")
         raise IOError(msg)
+
+    arg_count = 3 - [n_compounds, box, density].count(None)
+    if arg_count != 2:
+        msg = "Exactly 2 of n_compounds, box, and density must be specified. {} were given.".format(arg_count)
+        raise ValueError(msg)
 
     if box is not None:
         box = _validate_box(box)

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -58,7 +58,7 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2, se
     n_compounds : int or list of int
     box : mb.Box
     overlap : float, units nm
-    density : float, units kg/nm^3
+    density : float, units kg/m^3
 
     Returns
     -------

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -76,7 +76,8 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2, se
 
     arg_count = 3 - [n_compounds, box, density].count(None)
     if arg_count != 2:
-        msg = "Exactly 2 of n_compounds, box, and density must be specified. {} were given.".format(arg_count)
+        msg = ("Exactly 2 of `n_compounds`, `box`, and `density` "
+            "must be specified. {} were given.".format(arg_count))
         raise ValueError(msg)
 
     if box is not None:
@@ -88,15 +89,20 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2, se
 
     if density is not None:
         if box is None and n_compounds is not None:
-            total_mass = np.sum([n*np.sum([a.mass for a in c.to_parmed().atoms]) for c,n in zip(compound, n_compounds)])
-            L = (total_mass/density)**(1/3)*1.1841763 # Conversion from amu/(kg/m^3) to nm
+            total_mass = np.sum([n*np.sum([a.mass for a in c.to_parmed().atoms])
+                for c,n in zip(compound, n_compounds)])
+            # Conversion from (amu/(kg/m^3))**(1/3) to nm
+            L = (total_mass/density)**(1/3)*1.1841763
             box = _validate_box(Box(3*[L]))
         if n_compounds is None and box is not None:
             if len(compound) > 1:
-                msg = "Determing n_compounds from system density currently supports systems with only one compound type"
+                msg = ("Determing `n_compounds` from `density` and `box` "
+                    "currently only supported for systems with one "
+                    "compound type.")
                 raise ValueError(msg)
             else:
                 compound_mass = np.sum([a.mass for a in compound[0].to_parmed().atoms])
+                # Conversion from kg/m^3 / amu * nm^3 to dimensionless units
                 n_compounds = [int(density/compound_mass*np.prod(box.lengths)*.60224)]
 
     # In angstroms for packmol.

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -5,6 +5,8 @@ import tempfile
 from distutils.spawn import find_executable
 from subprocess import Popen, PIPE
 
+import numpy as np
+
 from mbuild.compound import Compound
 from mbuild.exceptions import MBuildError
 from mbuild.box import Box
@@ -35,7 +37,7 @@ end structure
 """
 
 
-def fill_box(compound, n_compounds, box, overlap=0.2, seed=12345):
+def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2, seed=12345):
     """Fill a box with a compound using packmol.
 
     Parameters
@@ -44,11 +46,13 @@ def fill_box(compound, n_compounds, box, overlap=0.2, seed=12345):
     n_compounds : int or list of int
     box : mb.Box
     overlap : float
-
+    density : float
     Returns
     -------
     filled : mb.Compound
-
+    
+    TODO : Support aspect ratios in generated boxes
+    TODO : Support ratios of n_compounds
     """
     if not PACKMOL:
         msg = "Packmol not found."
@@ -57,11 +61,25 @@ def fill_box(compound, n_compounds, box, overlap=0.2, seed=12345):
                          "packmol.exe is on the path.")
         raise IOError(msg)
 
-    box = _validate_box(box)
+    if box is not None:
+        box = _validate_box(box)
     if not isinstance(compound, (list, set)):
         compound = [compound]
-    if not isinstance(n_compounds, (list, set)):
+    if n_compounds is not None and not isinstance(n_compounds, (list, set)):
         n_compounds = [n_compounds]
+
+    if density is not None:
+        if box is None and n_compounds is not None:
+            total_mass = np.sum([n*np.sum([a.mass for a in c.to_parmed().atoms]) for c,n in zip(compound, n_compounds)])
+            L = (total_mass/density)**(1/3)*1.1841763 # Conversion from amu/(kg/m^3) to nm
+            box = _validate_box(Box(3*[L]))
+        if n_compounds is None and box is not None:
+            if len(compound) > 1:
+                msg = "Determing n_compounds from system density currently supports systems with only one compound type"
+                raise ValueError(msg)
+            else:
+                compound_mass = np.sum([a.mass for a in compound[0].to_parmed().atoms])
+                n_compounds = [int(density/compound_mass*np.prod(box.lengths)*.60224)]
 
     # In angstroms for packmol.
     box_mins = box.mins * 10
@@ -91,6 +109,7 @@ def fill_box(compound, n_compounds, box, overlap=0.2, seed=12345):
         for _ in range(m_compounds):
             filled.add(clone(comp))
     filled.update_coordinates(filled_pdb)
+    filled.periodicity = np.asarray(box.lengths, dtype=np.float32)
     return filled
 
 

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -12,6 +12,14 @@ class TestPacking(BaseTest):
         assert filled.n_particles == 50 * 3
         assert filled.n_bonds == 50 * 2
 
+    def test_fill_box_density_box(self, h2o):
+        filled = mb.fill_box(h2o, n_compounds=1000, density=1000)
+        assert [3.1 < period < 3.11 for period in packed.periodicity]
+
+    def test_fill_box_density_box(self, h2o):
+        filled = mb.fill_box(h2o, box=mb.Box([3.1, 3.1, 3.1]), density=1000)
+        assert 2900 < filled.n_particles < 3100
+
     def test_fill_region(self, h2o):
         filled = mb.fill_region(h2o, n_compounds=50,
                                 region=[3, 2, 2, 4, 4, 3])

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -14,11 +14,12 @@ class TestPacking(BaseTest):
 
     def test_fill_box_density_box(self, h2o):
         filled = mb.fill_box(h2o, n_compounds=1000, density=1000)
-        assert [3.1 < period < 3.11 for period in filled.periodicity]
+        assert [3.1042931 < period < 3.1042932 for period in filled.periodicity]
 
     def test_fill_box_density_n_compounds(self, h2o):
-        filled = mb.fill_box(h2o, box=mb.Box([3.1, 3.1, 3.1]), density=1000)
-        assert 2900 < filled.n_particles < 3100
+        filled = mb.fill_box(h2o, density=1000,
+                             box=mb.Box([3.1042931, 3.1042931, 3.1042931]))
+        assert filled.n_particles == 3000
 
     def test_fill_region(self, h2o):
         filled = mb.fill_region(h2o, n_compounds=50,

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -14,9 +14,9 @@ class TestPacking(BaseTest):
 
     def test_fill_box_density_box(self, h2o):
         filled = mb.fill_box(h2o, n_compounds=1000, density=1000)
-        assert [3.1 < period < 3.11 for period in packed.periodicity]
+        assert [3.1 < period < 3.11 for period in filled.periodicity]
 
-    def test_fill_box_density_box(self, h2o):
+    def test_fill_box_density_n_compounds(self, h2o):
         filled = mb.fill_box(h2o, box=mb.Box([3.1, 3.1, 3.1]), density=1000)
         assert 2900 < filled.n_particles < 3100
 


### PR DESCRIPTION
Added rudimentary support support for specifying density while packing system.

* If passed ```n_compounds``` and ```density``` but no ```box```, it computes the size of a corresponding cubic box. This should currently work for multiple compounds.

* If passed ```box``` and ```density```, it computes the corresponding ```n_compounds ```. This currently does not work for multiple compounds.

* If passed ```box``` and ```n_compounds``` but not ```density (and after the above cases compute the missing variable) the packing proceeds as before.

Support I intend to add in the future:

* Aspect ratio for computed boxes, i.e. packing set quantities of compounds into a box with dimensions ```[L, 3L, L]```
* Composition ratio, i.e. packing ethane and water into a box of set size at a 2:1 ratio