### PR TITLE
Add argument to save() to specify combining rule

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1256,7 +1256,7 @@ class Compound(object):
 
     def save(self, filename, show_ports=False, forcefield_name=None,
              forcefield_files=None, box=None, overwrite=False, residues=None,
-             references_file=None, **kwargs):
+             references_file=None, combining_rule='lorentz', **kwargs):
         """Save the Compound to a file.
 
         Parameters
@@ -1286,6 +1286,11 @@ class Compound(object):
         references_file : str, optional, default=None
             Specify a filename to write references for the forcefield that is
             to be applied. References are written in BiBTeX format.
+        combining_rule : str, optional, default='lorentz'
+            Specify the combining rule for nonbonded interactions. Only relevant
+            when the `foyer` package is used to apply a forcefield. Valid
+            options are 'lorentz' and 'geometric', specifying Lorentz-Berthelot
+            and geometric combining rules respectively.
 
         Other Parameters
         ----------------
@@ -1333,6 +1338,7 @@ class Compound(object):
             ff = Forcefield(forcefield_files=forcefield_files,
                             name=forcefield_name)
             structure = ff.apply(structure, references_file=references_file)
+            structure.combining_rule = combining_rule
 
         total_charge = sum([atom.charge for atom in structure])
         if round(total_charge, 4) != 0.0:

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -77,6 +77,18 @@ class TestCompound(BaseTest):
                      references_file='methane.bib')
         assert os.path.isfile('methane.bib')
 
+    def test_save_combining_rule(self, methane):
+        combining_rules = ['lorentz', 'geometric']
+        gmx_rules = {'lorentz': 2, 'geometric': 3}
+        for combining_rule in combining_rules:
+            methane.save('methane.top', forcefield_name='oplsaa',
+                         combining_rule=combining_rule, overwrite=True)
+            with open('methane.top') as fp:
+                for i, line in enumerate(fp):
+                    if i == 18:
+                        gmx_rule = int(line.split()[1])
+                        assert gmx_rule == gmx_rules[combining_rule]
+
     def test_batch_add(self, ethane, h2o):
         compound = mb.Compound()
         compound.add([ethane, h2o])


### PR DESCRIPTION
An argument has been added to `Compound.save()` allowing the user to specify the combining rule used for nonbonded interactions (either `'lorentz'` or `'geometric'`, for Lorentz-Berthelot or geometric combining rules, respectively).

This should resolve #358 