### PR TITLE
Force box values to np.float

### DIFF
--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -18,12 +18,12 @@ class Box(object):
         if lengths is not None:
             assert mins is None and maxs is None
             self._mins = np.array([0.0, 0.0, 0.0])
-            self._maxs = np.array(lengths)
-            self._lengths = np.array(lengths)
+            self._maxs = np.array(lengths, dtype=np.float64)
+            self._lengths = np.array(lengths, dtype=np.float64)
         elif maxs is not None:
             assert mins is not None and lengths is None
-            self._mins = np.array(mins)
-            self._maxs = np.array(maxs)
+            self._mins = np.array(mins, dtype=np.float64)
+            self._maxs = np.array(maxs, dtype=np.float64)
             self._lengths = self.maxs - self.mins
         else:
             raise ValueError("Either provide `lengths` or `mins` and `maxs`."

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -18,12 +18,12 @@ class Box(object):
         if lengths is not None:
             assert mins is None and maxs is None
             self._mins = np.array([0.0, 0.0, 0.0])
-            self._maxs = np.array(lengths, dtype=np.float64)
-            self._lengths = np.array(lengths, dtype=np.float64)
+            self._maxs = np.array(lengths, dtype=np.float)
+            self._lengths = np.array(lengths, dtype=np.float)
         elif maxs is not None:
             assert mins is not None and lengths is None
-            self._mins = np.array(mins, dtype=np.float64)
-            self._maxs = np.array(maxs, dtype=np.float64)
+            self._mins = np.array(mins, dtype=np.float)
+            self._maxs = np.array(maxs, dtype=np.float)
             self._lengths = self.maxs - self.mins
         else:
             raise ValueError("Either provide `lengths` or `mins` and `maxs`."

--- a/mbuild/coordinate_transform.py
+++ b/mbuild/coordinate_transform.py
@@ -253,7 +253,7 @@ def unit_vector(v):
 
 def angle(u, v, w=None):
     """Returns the angle in radians between two vectors. """
-    if w != None:
+    if w is not None:
         u = u - v
         v = w - v
     c = np.dot(u, v) / norm(u) / norm(v)

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -17,3 +17,9 @@ class TestBox(BaseTest):
         assert np.array_equal(box.lengths, np.ones(3))
         assert np.array_equal(box.mins, np.zeros(3))
         assert np.array_equal(box.maxs, np.ones(3))
+
+    def test_dtype(self):
+        box = mb.Box(mins=np.zeros(3), maxs=np.ones(3))
+        assert box.lengths.dtype == np.float64
+        assert box.mins.dtype == np.float64
+        assert box.maxs.dtype == np.float64


### PR DESCRIPTION
Currently, many tests build boxes to include integer arrays.

```
>>> import mbuild as mb
>>> box = mb.Box([4, 4, 4])
>>> box.maxs.dtype
dtype('int64')
```

These changes force `Box.maxs`, `Box.maxs`, and `Box.lengths` to be `dtype=np.float64`.

I know we have discussed a more thorough rework to the `Box` class at some point in the future, but this is important change to fix now. Even though it is minor.