### PR TITLE
Provide segfault trace for pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - conda config --add channels janschulz
   - conda config --add channels glotzer
   - conda config --add channels bioconda
+  - conda config --add channels conda-forge
   - conda config --add channels mosdef
   - conda create -n test-environment python=$PYTHON_VERSION --file requirements.txt
   - source activate test-environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ ipykernel
 ipyext
 python-coveralls
 pytest-cov
+pytest-faulthandler


### PR DESCRIPTION
Currently all python 3.5 osx builds on Travis are
failing at the collection stage of pytest due to
a SIGABRT signal being raised.

We currently do not have a way to interpret where this
is occuring since we cannot replicate on any osx 3.5
machines in the office.

There is a pytest plugin called `pytest-faulthandler` that
enables the `faulthandler` module for pytest.

This should provide a more verbose output when the system recieves
a signal like this in the future.