### PR TITLE
Floating point rounding fix for lattice.populate

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -528,4 +528,8 @@ class Lattice(object):
                     'default boxes. Only rectangular lattices are valid '
                     'at this time.')
 
+        # if coordinates are below a certain threshold, set to 0
+        tolerance = 1e-12
+        ret_lattice.xyz_with_ports[ret_lattice.xyz_with_ports <= tolerance] = 0.
+
         return ret_lattice


### PR DESCRIPTION
When populating lattice, there will occasionally
be values near 0 that exhibit rounding errors that
push the values to very small scientific notation
(1e-16+, etc) representation. 

This is not the most accurate and
rounding back to 0 after a threshold "tolerance"
value (1e-12) is reached is desired.