### PR TITLE
Marking examples tests as flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - pip install -e .
 
 script:
-  - python -m pytest -v --cov=mbuild  --cov-report= --pyargs mbuild
+  - python -m pytest --ignore-flaky -v --cov=mbuild  --cov-report= --pyargs mbuild
 
 after_success:
   - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
   - conda config --add channels janschulz
   - conda config --add channels glotzer
   - conda config --add channels bioconda
+  - conda config --add channels conda-forge
   - conda config --add channels mosdef
   - conda update -yq --all
   - conda install -yq conda-build jinja2

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -31,13 +31,14 @@ test:
     - nbformat
     - ipykernel
     - ipyext
+    - pytest-ignore-flaky
 
   source_files:
     - mbuild/examples/*
 
   commands:
     - set LNAME=mosdef
-    - py.test -v --pyargs mbuild
+    - pytest --ignore-flaky -v --pyargs mbuild
 
 about:
   home: http://mosdef-hub.github.io/mbuild

--- a/mbuild/examples/test_examples.py
+++ b/mbuild/examples/test_examples.py
@@ -19,6 +19,7 @@ EXAMPLE_NOTEBOOKS = [f for f in glob.glob('mbuild/examples/*/*.ipynb')]
 @pytest.mark.skipif(sys.platform in ['win32'],
                     reason="Not testing examples on Appveyor")
 @pytest.mark.parametrize("filepath", EXAMPLE_NOTEBOOKS)
+@pytest.mark.flaky("filepath", EXAMPLE_NOTEBOOKS)
 def test_examples(filepath):
     check_one_notebook(filepath)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ipyext
 python-coveralls
 pytest-cov
 pytest-faulthandler
+pytest-ignore-flaky


### PR DESCRIPTION
Discovered in #390 there seems to be a timeout issue with the Jupyter notebook tests. It looks like MDTraj ran into a similar issue and resolved it in mdtraj/mdtraj#1315 by using [pytest-ignore-flaky](https://pypi.python.org/pypi/pytest-ignore-flaky) to mark these tests as flaky and ignoring if they fail. @justinGilmer and I have implemented a similar fix here.