### PR TITLE
Use MDTraj to check element existence instead of OpenMM

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ import mock
 
 MOCK_MODULES = ['numpy',
                 'mdtraj',
+                'mdtraj.core',
                 'nglview',
                 'oset',
                 'parmed',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ import mock
 
 MOCK_MODULES = ['numpy',
                 'mdtraj',
-                'mdtraj.core',
+                'mdtraj.core.element',
                 'nglview',
                 'oset',
                 'parmed',

--- a/docs/sphinxext/notebook_sphinxext.py
+++ b/docs/sphinxext/notebook_sphinxext.py
@@ -5,9 +5,8 @@ from __future__ import print_function
 import os
 import shutil
 
-from sphinx.util.compat import Directive
 from docutils import nodes
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import Directive, directives
 import nbformat
 from nbconvert import HTMLExporter, PythonExporter
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -12,11 +12,11 @@ import tempfile
 from warnings import warn
 
 import mdtraj as md
+from mdtraj.core.element import get_by_symbol
 import numpy as np
 from oset import oset as OrderedSet
 import parmed as pmd
 from parmed.periodic_table import AtomicNum, element_by_name, Mass
-import simtk.openmm.app.element as elem
 from six import integer_types, string_types
 
 from mbuild.bond_graph import BondGraph
@@ -1230,7 +1230,7 @@ class Compound(object):
 
         for particle in self.particles():
             try:
-                elem.get_by_symbol(particle.name)
+                get_by_symbol(particle.name)
             except KeyError:
                 raise MBuildError("Element name {} not recognized. Cannot "
                                   "perform minimization."
@@ -1549,7 +1549,6 @@ class Compound(object):
         mdtraj.Topology : Details on the mdtraj Topology object
 
         """
-        from mdtraj.core.element import get_by_symbol
         from mdtraj.core.topology import Topology
 
         if isinstance(chains, string_types):


### PR DESCRIPTION
In #334 a check was added within the `energy_minimization` routine to ensure all particles featured a proper element name (otherwise OpenBabel would return a not-so-helpful error). However, this check added a dependency on OpenMM which was not added to the conda build recipe. I've fixed this here by replacing the "element check" we were using OpenMM for with an equivalent check that uses MDTraj.