### PR TITLE
Add information to website concerning how to cite mBuild

### DIFF
--- a/docs/citing_mbuild.rst
+++ b/docs/citing_mbuild.rst
@@ -1,0 +1,29 @@
+=============
+Citing mBuild
+=============
+
+If you use mBuild for your research, please cite `our paper <http://doi.org/10.1007%2F978-981-10-1128-3_5>`_:
+
+**ACS**
+
+    Klein, C.; Sallai, J.; Jones, T. J.; Iacovella, C. R.; McCabe, C.; Cummings, P. T. A Hierarchical, Component Based Approach to Screening Properties of Soft Matter. In *Foundations of Molecular Modeling and Simulation. Molecular Modeling and Simulation (Applications and Perspectives)*; Snurr, R. Q., Adjiman, C. S., Kofke, D. A., Eds.; Springer, Singapore, 2016; pp 79-92.
+
+**BibTeX**
+
+.. code-block:: bibtex
+
+    @Inbook{Klein2016mBuild,
+        author      = "Klein, Christoph and Sallai, János and Jones, Trevor J. and Iacovella, Christopher R. and McCabe, Clare and Cummings, Peter T.",
+        editor      = "Snurr, Randall Q and Adjiman, Claire S. and Kofke, David A.",
+        title       = "A Hierarchical, Component Based Approach to Screening Properties of Soft Matter",
+        bookTitle   = "Foundations of Molecular Modeling and Simulation: Select Papers from FOMMS 2015",
+        year        = "2016",
+        publisher   = "Springer Singapore",
+        address     = "Singapore",
+        pages       = "79--92",
+        isbn        = "978-981-10-1128-3",
+        doi         = "10.1007/978-981-10-1128-3_5",
+        url         = "https://doi.org/10.1007/978-981-10-1128-3_5"
+    }
+
+Download as :download:`BibTeX <files/mbuild_citation.bib>` or :download:`RIS <files/mbuild_citation.ris>`

--- a/docs/files/mbuild_citation.bib
+++ b/docs/files/mbuild_citation.bib
@@ -1,0 +1,14 @@
+@Inbook{Klein2016,
+    author      = "Klein, Christoph and Sallai, J{\'a}nos and Jones, Trevor J. and Iacovella, Christopher R. and McCabe, Clare and Cummings, Peter T.",
+    editor      = "Snurr, Randall Q and Adjiman, Claire S. and Kofke, David A.",
+    title       = "A Hierarchical, Component Based Approach to Screening Properties of Soft Matter",
+    bookTitle   = "Foundations of Molecular Modeling and Simulation: Select Papers from FOMMS 2015",
+    year        = "2016",
+    publisher   = "Springer Singapore",
+    address     = "Singapore",
+    pages       = "79--92",
+    abstract    = "In prior work, Sallai, et al. introduced the concept and algorithms of building molecular topologies through the use of a hierarchical data structure and the use of an affine coordinate transformation to connect molecular components. In this work, we expand upon the original concept and present a refined version of this software, termed                 mBuild              , which is a general tool for constructing arbitrarily complex input configurations for molecular simulation in a programmatic fashion. Basic molecular components are connected using an equivalence operator which reduces and often removes the need for users to explicitly rotate and translate components as they assemble systems. Additionally, the programmatic nature of this approach and integration with the scientific Python ecosystem seamlessly exposes high-level variables that users can tune to alter the chemical composition of their systems, such as mixtures of polymers of different chain lengths and surface patterning. Leveraging these features, we demonstrate how                 mBuild               serves as a stepping stone towards screening and performing optimizations in chemical parameter space of complex materials by performing automated screening studies of monolayer systems as a function of graft type, degree of polymerization, and surface density.",
+    isbn        = "978-981-10-1128-3",
+    doi         = "10.1007/978-981-10-1128-3_5",
+    url         = "https://doi.org/10.1007/978-981-10-1128-3_5"
+}

--- a/docs/files/mbuild_citation.ris
+++ b/docs/files/mbuild_citation.ris
@@ -1,0 +1,24 @@
+TY  - CHAP
+AU  - Klein, Christoph
+AU  - Sallai, János
+AU  - Jones, Trevor J.
+AU  - Iacovella, Christopher R.
+AU  - McCabe, Clare
+AU  - Cummings, Peter T.
+ED  - Snurr, Randall Q
+ED  - Adjiman, Claire S.
+ED  - Kofke, David A.
+PY  - 2016
+DA  - 2016//
+TI  - A Hierarchical, Component Based Approach to Screening Properties of Soft Matter
+BT  - Foundations of Molecular Modeling and Simulation: Select Papers from FOMMS 2015
+SP  - 79
+EP  - 92
+PB  - Springer Singapore
+CY  - Singapore
+AB  - In prior work, Sallai, et al. introduced the concept and algorithms of building molecular topologies through the use of a hierarchical data structure and the use of an affine coordinate transformation to connect molecular components. In this work, we expand upon the original concept and present a refined version of this software, termed                 mBuild              , which is a general tool for constructing arbitrarily complex input configurations for molecular simulation in a programmatic fashion. Basic molecular components are connected using an equivalence operator which reduces and often removes the need for users to explicitly rotate and translate components as they assemble systems. Additionally, the programmatic nature of this approach and integration with the scientific Python ecosystem seamlessly exposes high-level variables that users can tune to alter the chemical composition of their systems, such as mixtures of polymers of different chain lengths and surface patterning. Leveraging these features, we demonstrate how                 mBuild               serves as a stepping stone towards screening and performing optimizations in chemical parameter space of complex materials by performing automated screening studies of monolayer systems as a function of graft type, degree of polymerization, and surface density.
+SN  - 978-981-10-1128-3
+UR  - https://doi.org/10.1007/978-981-10-1128-3_5
+DO  - 10.1007/978-981-10-1128-3_5
+ID  - Klein2016
+ER  - 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,3 +67,8 @@ different licenses. See those files for their specific terms.
    :hidden:
 
    recipes
+
+.. toctree::
+   :hidden:
+
+   citing_mbuild


### PR DESCRIPTION
An additional tab has been added to the website that details how to properly cite mBuild. A link to the mBuild paper is provided alongside ACS and BibTeX citations. Downloadable BibTex and RIS
files are also included.