### PR TITLE
Move `Forcefield` import into `energy_minimize` method

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -11,7 +11,6 @@ import sys
 import tempfile
 from warnings import warn
 
-from foyer import Forcefield
 import mdtraj as md
 from mdtraj.core.element import get_by_symbol
 import numpy as np
@@ -1416,6 +1415,7 @@ class Compound(object):
 
 
         """
+        from foyer import Forcefield
         to_parmed = self.to_parmed()
         ff = Forcefield(forcefield_files=forcefield_files, name=forcefield_name)
         to_parmed = ff.apply(to_parmed)


### PR DESCRIPTION
In #416, `from foyer import Forcefield` was added to the top of `compound.py`. This ends up leading to issues with a dependency loop where the following occurs if trying to import Foyer (having both the latest development versions of mBuild and Foyer):
```
>>> import foyer
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/summeraz/src/github/mosdef-hub/foyer/foyer/__init__.py", line 1, in <module>
    from foyer.forcefield import Forcefield
  File "/Users/summeraz/src/github/mosdef-hub/foyer/foyer/forcefield.py", line 17, in <module>
    import mbuild as mb
  File "/Users/summeraz/src/github/mosdef-hub/mbuild/mbuild/__init__.py", line 2, in <module>
    from mbuild.coarse_graining import coarse_grain
  File "/Users/summeraz/src/github/mosdef-hub/mbuild/mbuild/coarse_graining.py", line 3, in <module>
    from mbuild.compound import Compound
  File "/Users/summeraz/src/github/mosdef-hub/mbuild/mbuild/compound.py", line 14, in <module>
    from foyer import Forcefield
ImportError: cannot import name 'Forcefield'
```

This PR simply moves the `Forcefield` import inside the `energy_minimize` method.