### PR TITLE
Improvements to Box class

### DIFF
--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -30,7 +30,7 @@ class Box(object):
                              "You provided: lengths={} mins={} maxs={}".format(lengths, mins, maxs))
         if angles is None:
             angles = np.array([90.0, 90.0, 90.0])
-        elif isinstance(angles, (list, np.array)):
+        elif isinstance(angles, (list, np.ndarray)):
             angles = np.array(angles, dtype=np.float)
         self._angles = angles
 

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -14,7 +14,7 @@ class Box(object):
         Box length in x, y and z directions.
 
     """
-    def __init__(self, lengths=None, mins=None, maxs=None):
+    def __init__(self, lengths=None, mins=None, maxs=None, angles=None):
         if lengths is not None:
             assert mins is None and maxs is None
             self._mins = np.array([0.0, 0.0, 0.0])
@@ -28,6 +28,11 @@ class Box(object):
         else:
             raise ValueError("Either provide `lengths` or `mins` and `maxs`."
                              "You provided: lengths={} mins={} maxs={}".format(lengths, mins, maxs))
+        if angles is None:
+            angles = np.array([90.0, 90.0, 90.0])
+        elif isinstance(angles, (list, np.array)):
+            angles = np.array(angles, dtype=np.float)
+        self._angles = angles
 
     @property
     def mins(self):
@@ -40,6 +45,10 @@ class Box(object):
     @property
     def lengths(self):
         return self._lengths
+
+    @property
+    def angles(self):
+        return self._angles
 
     @mins.setter
     def mins(self, mins):

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -43,18 +43,24 @@ class Box(object):
 
     @mins.setter
     def mins(self, mins):
+        if isinstance(mins, list):
+            mins = np.array(mins, dtype=np.float)
         assert mins.shape == (3, )
         self._mins = mins
         self._lengths = self.maxs - self.mins
 
     @maxs.setter
     def maxs(self, maxes):
+        if isinstance(maxes, list):
+            maxes = np.array(maxes, dtype=np.float)
         assert maxes.shape == (3, )
         self._maxs = maxes
         self._lengths = self.maxs - self.mins
 
     @lengths.setter
     def lengths(self, lengths):
+        if isinstance(lengths, list):
+            lengths = np.array(lengths, dtype=np.float)
         assert lengths.shape == (3, )
         self._maxs += 0.5*lengths - 0.5*self.lengths
         self._mins -= 0.5*lengths - 0.5*self.lengths

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -76,7 +76,7 @@ class Box(object):
         self._lengths = lengths
 
     @angles.setter
-    def angles(self. angles):
+    def angles(self, angles):
         if isinstance(angles, list):
             angles = np.array(angles, dtype=np.float)
         assert angles.shape == (3, )

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -76,4 +76,4 @@ class Box(object):
         self._lengths = lengths
 
     def __repr__(self):
-        return "Box(mins={}, maxs={})".format(self.mins, self.maxs)
+        return "Box(mins={}, maxs={}, angles={})".format(self.mins, self.maxs, self.angles)

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -75,5 +75,12 @@ class Box(object):
         self._mins -= 0.5*lengths - 0.5*self.lengths
         self._lengths = lengths
 
+    @angles.setter
+    def angles(self. angles):
+        if isinstance(angles, list):
+            angles = np.array(angles, dtype=np.float)
+        assert angles.shape == (3, )
+        self._angles = angles
+
     def __repr__(self):
         return "Box(mins={}, maxs={}, angles={})".format(self.mins, self.maxs, self.angles)

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1903,9 +1903,9 @@ class Compound(object):
             unitcell_lengths = np.empty(3)
             for dim, val in enumerate(self.periodicity):
                 if val:
-                    unitcell_lengths[dim] = val + 0.5
+                    unitcell_lengths[dim] = val
                 else:
-                    unitcell_lengths[dim] = box.lengths[dim]
+                    unitcell_lengths[dim] = box.lengths[dim] + 0.5
         else:
             unitcell_lengths = box.lengths
             unitcell_angles = box.angles

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1899,13 +1899,12 @@ class Compound(object):
         # Unitcell information.
         unitcell_angles = [90.0, 90.0, 90.0]
         if box is None:
-            box = self.boundingbox
             unitcell_lengths = np.empty(3)
             for dim, val in enumerate(self.periodicity):
                 if val:
                     unitcell_lengths[dim] = val
                 else:
-                    unitcell_lengths[dim] = box.lengths[dim] + 0.5
+                    unitcell_lengths[dim] = self.boundingbox.lengths[dim] + 0.5
         else:
             unitcell_lengths = box.lengths
             unitcell_angles = box.angles

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2212,6 +2212,7 @@ class Compound(object):
         for dim in range(3):
             box_vector[dim] = box.lengths[dim] * 10
         structure.box = box_vector
+        structure.box[3:6] = box.angles
         return structure
 
     def to_intermol(self, molecule_types=None):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2219,11 +2219,13 @@ class Compound(object):
             box.maxs = np.asarray(box_vec_max)
 
         box_vector = np.empty(6)
-        box_vector[3] = box_vector[4] = box_vector[5] = 90.0
+        if box.angles is not None:
+            box_vector[3:6] = box.angles
+        else:
+            box_vector[3] = box_vector[4] = box_vector[5] = 90.0
         for dim in range(3):
             box_vector[dim] = box.lengths[dim] * 10
         structure.box = box_vector
-        structure.box[3:6] = box.angles
         return structure
 
     def to_intermol(self, molecule_types=None):

--- a/mbuild/formats/gsdwriter.py
+++ b/mbuild/formats/gsdwriter.py
@@ -54,8 +54,23 @@ def write_gsd(structure, filename, ref_distance=1.0, ref_mass=1.0,
 
     gsd_file.configuration.step = 0
     gsd_file.configuration.dimensions = 3
-    gsd_file.configuration.box = np.hstack((structure.box[:3] / ref_distance,
-                                            np.zeros(3)))
+
+    # Write box information
+    if np.allclose(structure.box[3:6], np.array([90, 90, 90])):
+        gsd_file.configuration.box = np.hstack((structure.box[:3] / ref_distance,
+                                                np.zeros(3)))
+    else:
+        a, b, c = structure.box[0:3] / ref_distance
+        alpha, beta, gamma = np.radians(structure.box[3:6])
+
+        lx = a
+        xy = b * np.cos(gamma)
+        xz = c * np.cos(beta)
+        ly = np.sqrt(b**2 - xy**2)
+        yz = (b*c*np.cos(alpha) - xy*xz) / ly
+        lz = np.sqrt(c**2 - xz**2 - yz**2)
+
+        gsd_file.configuration.box = np.array([lx, ly, lz, xy, xz, yz])
 
     _write_particle_information(gsd_file, structure, xyz, ref_distance,
             ref_mass, ref_energy, rigid_bodies)

--- a/mbuild/formats/hoomdxml.py
+++ b/mbuild/formats/hoomdxml.py
@@ -82,9 +82,7 @@ def write_hoomdxml(structure, filename, ref_distance=1.0, ref_mass=1.0,
         xml_file.write('<?xml version="1.2" encoding="UTF-8"?>\n')
         xml_file.write('<hoomd_xml version="1.2">\n')
         xml_file.write('<configuration time_step="0">\n')
-        xml_file.write(
-                '<box units="sigma"  Lx="{}" Ly="{}" Lz="{}"/>\n'.format(
-                    *structure.box[:3] / ref_distance))
+        _write_box_information(xml_file, structure, ref_distance)
         _write_particle_information(xml_file, structure, xyz, forcefield,
                 ref_distance, ref_mass, ref_energy)
         _write_bond_information(xml_file, structure, ref_distance, ref_energy)
@@ -291,3 +289,32 @@ def _write_rigid_information(xml_file, rigid_bodies):
                 body = -1
             xml_file.write('{}\n'.format(int(body)))
         xml_file.write('</body>\n')
+
+def _write_box_information(xml_file, structure, ref_distance):
+    """Write box information.
+
+    Parameters
+    ----------
+    xml_file : file object
+        The file object of the hoomdxml file being written
+    structure : parmed.Structure
+        Parmed structure object
+    ref_energy : float, default=1.0
+        Reference energy for conversion to reduced units
+
+    """
+    if np.allclose(structure.box[3:6], np.array([90, 90, 90])):
+        box_str = '<box units="sigma"  Lx="{}" Ly="{}" Lz="{}"/>\n'
+        xml_file.write(box_str.format(*structure.box[:3] / ref_distance))
+    else:
+        a, b, c = structure.box[0:3] / ref_distance
+        alpha, beta, gamma = np.radians(structure.box[3:6])
+
+        lx = a
+        xy = b * np.cos(gamma)
+        xz = c * np.cos(beta)
+        ly = np.sqrt(b**2 - xy**2)
+        yz = (b*c*np.cos(alpha) - xy*xz) / ly
+        lz = np.sqrt(c**2 - xz**2 - yz**2)
+        box_str = '<box units="sigma"  Lx="{}" Ly="{}" Lz="{}" xy="{}" xz="{}" yz="{}"/>\n'
+        xml_file.write(box_str.format(lx, ly, lz, xy, xz, yz))

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -18,6 +18,10 @@ class TestBox(BaseTest):
         assert np.array_equal(box.mins, np.zeros(3))
         assert np.array_equal(box.maxs, np.ones(3))
 
+    def test_init_angles(self):
+        box = mb.Box(mins=np.zeros(3), maxs=np.ones(3), angles=[40.0, 50.0, 60.0])
+        assert np.array_equal(box.angles, [40.0, 50.0, 60.0])
+
     def test_dtype(self):
         box = mb.Box(mins=np.zeros(3), maxs=np.ones(3))
         assert box.lengths.dtype == np.float64

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -51,10 +51,9 @@ class TestBox(BaseTest):
         assert (box.maxs - box.mins == np.ones(3)).all()
         assert (box.lengths == np.ones(3)).all()
         box.maxs = [3, 3, 3]
-        assert (box.maxs == 2 * np.ones(3)).all()
+        assert (box.maxs == 3 * np.ones(3)).all()
         assert (box.maxs - box.mins == 2 * np.ones(3)).all()
         assert (box.lengths == 2 * np.ones(3)).all()
-        box = mb.Box(mins=np.zeros(3), maxs=np.ones(3))
         box.lengths = [4, 4, 4]
-        assert (box.lengths == 3 * np.ones(3)).all()
-        assert (box.maxs - box.mins == 3 * np.ones(3)).all()
+        assert (box.lengths == 4 * np.ones(3)).all()
+        assert (box.maxs - box.mins == 4 * np.ones(3)).all()

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -48,6 +48,11 @@ class TestBox(BaseTest):
         assert (box.lengths == 2 * np.ones(3)).all()
         assert (box.maxs - box.mins == 2 * np.ones(3)).all()
 
+    def test_angles_setter(self):
+        box = mb.Box(mins=np.zeros(3), maxs=np.ones(3), angles=90*np.ones(3))
+        box.angles = np.array([60.0, 120.0, 60.0])
+        assert (box.angles == np.array([60.0, 120.0, 60.0])).all()
+
     def test_setters_with_lists(self):
         box = mb.Box(mins=np.zeros(3), maxs=2 * np.ones(3))
         box.mins = [1, 1, 1]

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -43,3 +43,18 @@ class TestBox(BaseTest):
         box.lengths = 2 * np.ones(3)
         assert (box.lengths == 2 * np.ones(3)).all()
         assert (box.maxs - box.mins == 2 * np.ones(3)).all()
+
+    def test_setters_with_lists(self):
+        box = mb.Box(mins=np.zeros(3), maxs=2 * np.ones(3))
+        box.mins = [1, 1, 1]
+        assert (box.mins == np.ones(3)).all()
+        assert (box.maxs - box.mins == np.ones(3)).all()
+        assert (box.lengths == np.ones(3)).all()
+        box.maxs = [3, 3, 3]
+        assert (box.maxs == 2 * np.ones(3)).all()
+        assert (box.maxs - box.mins == 2 * np.ones(3)).all()
+        assert (box.lengths == 2 * np.ones(3)).all()
+        box = mb.Box(mins=np.zeros(3), maxs=np.ones(3))
+        box.lengths = [4, 4, 4]
+        assert (box.lengths == 3 * np.ones(3)).all()
+        assert (box.maxs - box.mins == 3 * np.ones(3)).all()

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -23,3 +23,23 @@ class TestBox(BaseTest):
         assert box.lengths.dtype == np.float64
         assert box.mins.dtype == np.float64
         assert box.maxs.dtype == np.float64
+
+    def test_mins_setter(self):
+        box = mb.Box(mins=np.zeros(3), maxs=2 * np.ones(3))
+        box.mins = np.ones(3)
+        assert (box.mins == np.ones(3)).all()
+        assert (box.maxs - box.mins == np.ones(3)).all()
+        assert (box.lengths == np.ones(3)).all()
+
+    def test_maxs_setter(self):
+        box = mb.Box(mins=np.zeros(3), maxs=np.ones(3))
+        box.maxs = 2 * np.ones(3)
+        assert (box.maxs == 2 * np.ones(3)).all()
+        assert (box.maxs - box.mins == 2 * np.ones(3)).all()
+        assert (box.lengths == 2 * np.ones(3)).all()
+
+    def test_lengths_setter(self):
+        box = mb.Box(mins=np.zeros(3), maxs=np.ones(3))
+        box.lengths = 2 * np.ones(3)
+        assert (box.lengths == 2 * np.ones(3)).all()
+        assert (box.maxs - box.mins == 2 * np.ones(3)).all()

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -497,6 +497,13 @@ class TestCompound(BaseTest):
         with pytest.warns(UserWarning):
             _ = compound.to_parmed()
 
+    def test_parmed_box(self, h2o):
+        compound = mb.Compound()
+        compound.add(h2o)
+        tilted_box = mb.Box(lengths=[2.0, 2.0, 2.0], angles=[60.0, 80.0, 100.0])
+        structure = compound.to_parmed(box=tilted_box)
+        assert all(structure.box == [20.0, 20.0, 20.0, 60.0, 80.0, 100.0])
+
     def test_min_periodic_dist(self, ethane):
         compound = mb.Compound(ethane)
         C_pos = np.array([atom.pos for atom in list(compound.particles_by_name('C'))])

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -398,6 +398,15 @@ class TestCompound(BaseTest):
         traj = system.to_trajectory()
         assert traj.n_chains == 1
 
+    def test_mdtraj_box(self, h2o):
+        compound = mb.Compound()
+        compound.add(h2o)
+        tilted_box = mb.Box(lengths=[2.0, 2.0, 2.0], angles=[60.0, 80.0, 100.0])
+        trajectory = compound.to_trajectory(box=tilted_box)
+        assert (trajectory.unitcell_lengths == [2.0, 2.0, 2.0]).all()
+        assert (trajectory.unitcell_angles == [60.0, 80.0, 100.0]).all()
+        print(trajectory.unitcell_vectors)
+
     @pytest.mark.skipif(not has_intermol, reason="InterMol is not installed")
     def test_intermol_conversion1(self, ethane, h2o):
         compound = mb.Compound([ethane, h2o])

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -358,6 +358,29 @@ class TestCompound(BaseTest):
         assert traj.n_chains == 1
         assert traj.n_residues == 1
 
+    def test_box_mdtraj(self, ethane):
+        assert np.allclose(ethane.periodicity, np.zeros(3))
+        traj_boundingbox = ethane.to_trajectory()
+        assert np.allclose(
+            traj_boundingbox.unitcell_lengths,
+            ethane.boundingbox.lengths + 0.5
+        )
+
+        ethane.periodicity = [4.0, 5.0, 6.0]
+        assert ethane.periodicity is not None
+        traj_periodicity = ethane.to_trajectory()
+        assert np.allclose(
+            traj_periodicity.unitcell_lengths,
+            ethane.periodicity
+        )
+
+        box = mb.Box(mins=np.zeros(3), maxs=8.0*np.zeros(3))
+        traj_box = ethane.to_trajectory(box=box)
+        assert np.allclose(
+            traj_box.unitcell_lengths,
+            box.lengths
+        )
+
     def test_resnames_mdtraj(self, h2o, ethane):
         system = mb.Compound([h2o, mb.clone(h2o), ethane])
         traj = system.to_trajectory(residues=['Ethane', 'H2O'])

--- a/mbuild/tests/test_hoomdxml.py
+++ b/mbuild/tests/test_hoomdxml.py
@@ -21,7 +21,6 @@ class TestHoomdXML(BaseTest):
     def test_save_triclinic_box_(self, ethane):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]), angles=[60, 70, 80])
         ethane.save(filename='triclinic-box.hoomdxml', box=box)
-        ethane.save(filename='/Users/mwt/triclinic-box.hoomdxml', box=box)
 
     def test_rigid(self, benzene):
         n_benzenes = 10

--- a/mbuild/tests/test_hoomdxml.py
+++ b/mbuild/tests/test_hoomdxml.py
@@ -18,6 +18,11 @@ class TestHoomdXML(BaseTest):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]))
         ethane.save(filename='ethane-box.hoomdxml', box=box)
 
+    def test_save_triclinic_box_(self, ethane):
+        box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]), angles=[60, 70, 80])
+        ethane.save(filename='triclinic-box.hoomdxml', box=box)
+        ethane.save(filename='/Users/mwt/triclinic-box.hoomdxml', box=box)
+
     def test_rigid(self, benzene):
         n_benzenes = 10
         benzene.name = 'Benzene'

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -17,6 +17,10 @@ class TestLammpsData(BaseTest):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]))
         ethane.save(filename='ethane-box.lammps', forcefield_name='oplsaa', box=box)
 
+    def test_save_triclinic_box(self, ethane):
+        box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]), angles=[60, 70, 80])
+        ethane.save(filename='triclinic-box.lammps', forcefield_name='oplsaa', box=box)
+
     @pytest.mark.parametrize('atom_style, n_columns', [('full', 7), ('atomic', 5), ('molecular', 6), ('charge', 6)])
     def test_writing_atom_styles(self, ethane, atom_style, n_columns):
         ethane.save(filename='ethane.lammps', atom_style=atom_style)


### PR DESCRIPTION
The `Box` class has not been touched in a while and needs some additions.

The scope I plan to include

- [x] Add angle attribute(s) 

- [x]  Update writers and converters that may store angles differently 

    - [x] `to_parmed` 

    - [x] `to_trajectory` 
    - [x] `write_lammpsdata` 
    - [x] `write_gsd`
     - [x] `write_hoomdxml`

- [x] Allow lists to be passed to setters 

~~- [ ] Fix for #365~~

- [x] Add Tests for the above

I am not planning to add `box` attribute to `mb.Compound`.

Note that unless we want to move `Compound.periodicity` into a `Compound.box` attribute, the `from_parmed` and `from_trajectory` functions will not read angle information in.