### PR TITLE
Lattice hotfix

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -396,8 +396,8 @@ class Lattice(object):
         b_dot_c = np.dot(self.lattice_vectors[1], self.lattice_vectors[2])
         a_dot_c = np.dot(self.lattice_vectors[0], self.lattice_vectors[2])
 
-        alpha_raw = a_dot_c / (vector_magnitudes[1] * vector_magnitudes[2])
-        beta_raw = b_dot_c / (vector_magnitudes[0] * vector_magnitudes[2])
+        alpha_raw = b_dot_c / (vector_magnitudes[1] * vector_magnitudes[2])
+        beta_raw = a_dot_c / (vector_magnitudes[0] * vector_magnitudes[2])
         gamma_raw = a_dot_b / (vector_magnitudes[0] * vector_magnitudes[1])
 
         alpha = np.arccos(np.clip(alpha_raw, -1.0, 1.0)) * degreeConvsersion

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -396,8 +396,8 @@ class Lattice(object):
         b_dot_c = np.dot(self.lattice_vectors[1], self.lattice_vectors[2])
         a_dot_c = np.dot(self.lattice_vectors[0], self.lattice_vectors[2])
 
-        alpha_raw = a_dot_c / (vector_magnitudes[0] * vector_magnitudes[2])
-        beta_raw = b_dot_c / (vector_magnitudes[1] * vector_magnitudes[2])
+        alpha_raw = a_dot_c / (vector_magnitudes[1] * vector_magnitudes[2])
+        beta_raw = b_dot_c / (vector_magnitudes[0] * vector_magnitudes[2])
         gamma_raw = a_dot_b / (vector_magnitudes[0] * vector_magnitudes[1])
 
         alpha = np.arccos(np.clip(alpha_raw, -1.0, 1.0)) * degreeConvsersion

--- a/mbuild/tests/test_lattice.py
+++ b/mbuild/tests/test_lattice.py
@@ -126,25 +126,29 @@ class TestLattice(BaseTest):
                                 ([97, 3, 120])
                              ]
                              )
-    def test_proper_angles(self, angles):
+    def test_improper_angles(self, angles):
         with pytest.raises(ValueError):
             mb.Lattice(lattice_spacing=[1, 1, 1], angles=angles)
 
     @pytest.mark.parametrize("vectors, angles",
                              [
                                 ([[1, 0, 0], [0, 1, 0], [0, 0, 1]],
-                                    [90, 90, 90])
+                                    [90, 90, 90]),
+                                ([[1.0, 0.0, 0.0],
+                                  [-0.45399049973954675, 0.8910065241883679, 0.0],
+                                  [-0.034899496702500955, -0.037369475398893195, 0.9986919181801381]],
+                                    [91, 92, 117])
                              ]
                              )
     def test_proper_angles(self, vectors, angles):
         testlattice = mb.Lattice(lattice_spacing=[1, 1, 1],
-                                  lattice_vectors=vectors)
+                                 lattice_vectors=vectors)
         np.testing.assert_allclose(testlattice.angles,
                                    np.asarray(angles, dtype=np.float64),
                                    rtol=1e-05, atol=1e-08, equal_nan=False)
 
     @pytest.mark.parametrize("x, y, z",
-                              [
+                             [
                                 (None, 1, 0),
                                 (1, None, 1),
                                 (1, 1, None),


### PR DESCRIPTION
Alpha beta angles were swapped
When generating a lattice that is non-rectangular in the alpha and beta
dimensions from provided lattice_vectors, the alpha and beta bravais
angles would not be in the correct order.

Expected
lattice.angles returns [alpha, beta, gamma]

actual
lattice.angles returns [beta, alpha, gamma]

There was an incorrect array access that caused this issue.

Credit to @witteaj  for spotting this issue when working with triclinic lattice systems. 