### PR TITLE
Update dependency requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - conda config --add channels bioconda
   - conda config --add channels conda-forge
   - conda config --add channels mosdef
-  - conda create -n test-environment python=$PYTHON_VERSION --file requirements.txt
+  - conda create -n test-environment python=$PYTHON_VERSION --file requirements-dev.txt
   - source activate test-environment
   - pip install -e .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,5 @@ install:
 build: false
 
 test_script:
+  - activate base
   - conda build --quiet devtools\\conda-recipe

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Features
 ### Misc and Bugfixes
 
+## 0.8.2 (unreleased)
+### Misc and Bugfixes
+* Fixed a bug that prevented Appveyor builds from running (#477)
+
 ## 0.8.1 (2018-11-28)
 ### Features
 * Packing functions can optionally constrain the rotation of `Compounds` when using `fill_box` (#407)

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,32 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Features
 ### Misc and Bugfixes
 
+## 0.8.1 (2018-11-28)
+### Features
+* Packing functions can optionally constrain the rotation of `Compounds` when using `fill_box` (#407)
+* Additional lammps datafile support (#412)
+    * Add functionality for `atomic`, `charge`, and `molecular` atom_styles
+    * Fix `atomic` and `molecular` atom-styles
+    * Add optional `atom-style` argument to `save` function
+    * Add tests to check for correct `Atoms` format
+* A `Compound` can be generated from a SMILES string if the user has [Open Babel](http://openbabel.org/wiki/Main_Page) installed (#430)
+* The [website](https://mosdef-hub.github.io/mbuild/) was updated with details how to properly cite mBuild (#421)
+* OpenMM can now be used for energy minimization (#416)
+* A simple xyz file reader was added (#423)
+* Defaults in `Compound.visualize` have been improved (#438)
+* mBuild boxes can now store angles (#448)
+* mBuild boxes can now be passed to various writers (#448)
+* A changelog is now included in the root directory (#454)
+
+### Misc and Bugfixes
+* Switched from OpenMM to MDTraj to check for element existence (#408)
+* Changed bilayer notebook to use `Compound` methods for object manipulation (#406)
+* Added test to ensure that users can provide a custom forcefield XML file when applying a forcefield to a `Compound` (#431)
+* An error is now generated if the miniconda MD5 sum does not match when performing tests (#409)
+* LAMMPS box values are now written appropriately in Angstroms (#459)
+* Coordinates in HOOMDXML and GSD files are now correctly written in the range [L /2 to L] (#452)
+* A bug in the ordering of some Bravais angles of some non-rectangular lattices has been fixed (#450)
+
 ## 0.8.0 (2018-01-18)
 ### Features
 * Improved packing API

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - oset
     - parmed
     - mdtraj 1.9.1
-    - foyer
 
 test:
   requires:
@@ -32,6 +31,7 @@ test:
     - ipykernel
     - ipyext
     - pytest-ignore-flaky
+    - foyer
 
   source_files:
     - mbuild/examples/*

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - nglview >=0.6
     - oset
     - parmed
-    - mdtraj
+    - mdtraj 1.9.1
     - foyer
 
 test:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1445,9 +1445,10 @@ class Compound(object):
 
 
         """
-        from foyer import Forcefield
+        foyer = import_('foyer')
+
         to_parmed = self.to_parmed()
-        ff = Forcefield(forcefield_files=forcefield_files, name=forcefield_name)
+        ff = foyer.Forcefield(forcefield_files=forcefield_files, name=forcefield_name)
         to_parmed = ff.apply(to_parmed)
 
         from simtk.openmm.app.simulation import Simulation
@@ -1727,9 +1728,9 @@ class Compound(object):
                                    show_ports=show_ports)
         # Apply a force field with foyer if specified
         if forcefield_name or forcefield_files:
-            from foyer import Forcefield
-            ff = Forcefield(forcefield_files=forcefield_files,
-                            name=forcefield_name, debug=forcefield_debug)
+            foyer = import_('foyer')
+            ff = foyer.Forcefield(forcefield_files=forcefield_files,
+                                  name=forcefield_name, debug=forcefield_debug)
             structure = ff.apply(structure, references_file=references_file)
             structure.combining_rule = combining_rule
 

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -9,7 +9,7 @@ import foyer
 import mbuild as mb
 from mbuild.exceptions import MBuildError
 from mbuild.utils.geometry import calc_dihedral
-from mbuild.utils.io import get_fn, has_intermol, has_openbabel
+from mbuild.utils.io import get_fn, has_foyer, has_intermol, has_openbabel
 from mbuild.tests.base_test import BaseTest
 
 class TestCompound(BaseTest):
@@ -52,6 +52,7 @@ class TestCompound(BaseTest):
             with pytest.raises(IOError):
                 ch3.save(filename=outfile, overwrite=False)
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_forcefield(self, methane):
         exts = ['.gsd', '.hoomdxml', '.lammps', '.lmp', '.top', '.gro',
                 '.mol2', '.pdb', '.xyz']
@@ -60,6 +61,7 @@ class TestCompound(BaseTest):
                          forcefield_name='oplsaa',
                          overwrite=True)
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_forcefield_with_file(self, methane):
         exts = ['.gsd', '.hoomdxml', '.lammps', '.lmp', '.top', '.gro',
                 '.mol2', '.pdb', '.xyz']
@@ -83,11 +85,13 @@ class TestCompound(BaseTest):
         assert struct.residues[0].number ==  1
         assert struct.residues[1].number ==  2
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_references(self, methane):
         methane.save('methyl.mol2', forcefield_name='oplsaa',
                      references_file='methane.bib')
         assert os.path.isfile('methane.bib')
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_combining_rule(self, methane):
         combining_rules = ['lorentz', 'geometric']
         gmx_rules = {'lorentz': 2, 'geometric': 3}
@@ -668,12 +672,13 @@ class TestCompound(BaseTest):
         assert np.array_equal(distances, updated_distances)
         assert np.array_equal(orientations, updated_orientations)
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_energy_minimize_openmm(self, octane):
         octane.energy_minimize(forcefield='oplsaa')
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_energy_minimize_openmm_xml(self, octane):
         octane.energy_minimize(forcefield=get_fn('small_oplsaa.xml'))
-
 
     def test_clone_outside_containment(self, ch2, ch3):
         compound = mb.Compound()

--- a/mbuild/tests/test_gsd.py
+++ b/mbuild/tests/test_gsd.py
@@ -4,7 +4,7 @@ import mbuild as mb
 import numpy as np
 import pytest
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import has_gsd
+from mbuild.utils.io import has_foyer, has_gsd
 
 
 class TestGSD(BaseTest):
@@ -13,19 +13,23 @@ class TestGSD(BaseTest):
     def test_save(self, ethane):
         ethane.save(filename='ethane.gsd')
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     def test_save_forcefield(self, ethane):
         ethane.save(filename='ethane-opls.gsd', forcefield_name='oplsaa')
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     def test_save_box(self, ethane):
         box = mb.Box(lengths=np.array([2.0,2.0,2.0]))
         ethane.save(filename='ethane-box.gsd', forcefield_name='oplsaa',box=box)
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_save_triclinic_box_(self, ethane):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]), angles=[60, 70, 80])
         ethane.save(filename='triclinic-box.gsd', forcefield_name='oplsaa', box=box)
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     def test_particles(self, ethane):
         from collections import OrderedDict
@@ -65,6 +69,7 @@ class TestGSD(BaseTest):
         assert np.array_equal(types_from_gsd, unique_types)
         assert np.array_equal(typeids_from_gsd, expected_typeids)
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     def test_box(self, ethane):
         import gsd, gsd.pygsd
@@ -99,7 +104,7 @@ class TestGSD(BaseTest):
         assert np.isclose(np.cos(np.radians(70)), xz / c)
         assert np.isclose(np.cos(np.radians(80)), xy / b)
 
-
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     def test_rigid(self, benzene):
         import gsd, gsd.pygsd
@@ -115,6 +120,7 @@ class TestGSD(BaseTest):
         for gsd_body, expected_body in zip(rigid_bodies, expected_bodies):
             assert gsd_body == expected_body
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     def test_bonded(self, ethane):
         from foyer import Forcefield
@@ -190,6 +196,7 @@ class TestGSD(BaseTest):
         assert np.array_equal(dihedral_atoms, expected_dihedral_atoms)
         assert np.array_equal(dihedral_typeids, np.zeros(n_dihedrals))
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     def test_units(self, ethane):
         import gsd, gsd.pygsd

--- a/mbuild/tests/test_hoomdxml.py
+++ b/mbuild/tests/test_hoomdxml.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree
 
 import mbuild as mb
 from mbuild.tests.base_test import BaseTest
+from mbuild.utils.io import has_foyer
 
 
 class TestHoomdXML(BaseTest):
@@ -11,6 +12,7 @@ class TestHoomdXML(BaseTest):
     def test_save(self, ethane):
         ethane.save(filename='ethane.hoomdxml')
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_save_forcefield(self, ethane):
         ethane.save(filename='ethane-opls.hoomdxml', forcefield_name='oplsaa')
 
@@ -38,6 +40,7 @@ class TestHoomdXML(BaseTest):
             assert rigid_bodies.count(body_id) == 6
         assert rigid_bodies.count(-1) == n_benzenes * 6
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_number_in_each_section(self, box_of_benzenes):
         box_of_benzenes.save(filename='benzene.hoomdxml', forcefield_name='oplsaa')
         xml_file = xml.etree.ElementTree.parse('benzene.hoomdxml').getroot()

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -3,6 +3,7 @@ import pytest
 
 import mbuild as mb
 from mbuild.tests.base_test import BaseTest
+from mbuild.utils.io import has_foyer
 
 
 class TestLammpsData(BaseTest):
@@ -10,9 +11,11 @@ class TestLammpsData(BaseTest):
     def test_save(self, ethane):
         ethane.save(filename='ethane.lammps')
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_save_forcefield(self, ethane):
         ethane.save(filename='ethane-opls.lammps', forcefield_name='oplsaa')
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_save_box(self, ethane):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]))
         ethane.save(filename='ethane-box.lammps', forcefield_name='oplsaa', box=box)

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -65,6 +65,18 @@ or from source following instructions at:
 
 MESSAGES['pybel'] = MESSAGES['openbabel']
 
+MESSAGES['foyer'] = '''
+The code at {filename}:{line_number} requires the "foyer" package
+
+foyer can be installed using:
+
+# conda install -c mosdef foyer
+
+or
+
+# pip install foyer
+'''
+
 
 def import_(module):
     """Import a module, and issue a nice message to stderr if the module isn't installed.
@@ -132,6 +144,13 @@ try:
     del openbabel
 except ImportError:
     has_openbabel = False
+
+try:
+    import foyer
+    has_foyer = True
+    del foyer
+except ImportError:
+    has_foyer = False
 
 
 def get_fn(name):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,19 @@
+numpy
+scipy
+packmol=1.0.0
+nglview>=0.6.2.3
+oset
+parmed
+mdtraj
+foyer
+gsd
+openbabel
+pytest >=3.0
+jupyter
+nbformat
+ipykernel
+ipyext
+python-coveralls
+pytest-cov
+pytest-faulthandler
+pytest-ignore-flaky

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,10 @@ packmol=1.0.0
 nglview>=0.6.2.3
 oset
 parmed
-mdtraj
+# TODO: Remove pinning of mdtraj version once mol2 reader issues have been resolved.
+#       https://github.com/mdtraj/mdtraj/pull/1378
+#       Once this has been released in a new MDTraj version, this can be removed.
+mdtraj==1.9.1
 foyer
 gsd
 openbabel
@@ -14,6 +17,15 @@ nbformat
 ipykernel
 ipyext
 python-coveralls
-pytest-cov
+# TODO: Remove the pinning of the pytest-cov version again once issue
+#       https://github.com/z4r/python-coveralls/issues/66
+#       is resolved.
+#       Background: pytest-cov 2.6.0 has increased the version
+#       requirement for the coverage package from >=3.7.1 to
+#       >=4.4, which is in conflict with the version requirement
+#       defined by the python-coveralls package for coverage==4.0.3.
+# This fix from:
+# https://github.com/pywbem/pywbem/commit/d85a3e73e08d2846073087733b790b5a8864d93f
+pytest-cov>=2.4.0,<2.6
 pytest-faulthandler
 pytest-ignore-flaky

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,10 @@ packmol=1.0.0
 nglview>=0.6.2.3
 oset
 parmed
-mdtraj
+# TODO: Remove pinning of mdtraj version once mol2 reader issues have been resolved.
+#       https://github.com/mdtraj/mdtraj/pull/1378
+#       Once this has been released in a new MDTraj version, this can be removed.
+mdtraj==1.9.1
 foyer
 gsd
 openbabel
@@ -14,6 +17,15 @@ nbformat
 ipykernel
 ipyext
 python-coveralls
-pytest-cov
+# TODO: Remove the pinning of the pytest-cov version again once issue
+#       https://github.com/z4r/python-coveralls/issues/66
+#       is resolved.
+#       Background: pytest-cov 2.6.0 has increased the version
+#       requirement for the coverage package from >=3.7.1 to
+#       >=4.4, which is in conflict with the version requirement
+#       defined by the python-coveralls package for coverage==4.0.3.
+# This fix from:
+# https://github.com/pywbem/pywbem/commit/d85a3e73e08d2846073087733b790b5a8864d93f
+pytest-cov>=2.4.0,<2.6
 pytest-faulthandler
 pytest-ignore-flaky

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,7 @@ packmol=1.0.0
 nglview>=0.6.2.3
 oset
 parmed
+# TODO: Remove pinning of mdtraj version once mol2 reader issues have been resolved.
+#       https://github.com/mdtraj/mdtraj/pull/1378
+#       Once this has been released in a new MDTraj version, this can be removed.
 mdtraj==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,28 +4,4 @@ packmol=1.0.0
 nglview>=0.6.2.3
 oset
 parmed
-# TODO: Remove pinning of mdtraj version once mol2 reader issues have been resolved.
-#       https://github.com/mdtraj/mdtraj/pull/1378
-#       Once this has been released in a new MDTraj version, this can be removed.
 mdtraj==1.9.1
-foyer
-gsd
-openbabel
-pytest >=3.0
-jupyter
-nbformat
-ipykernel
-ipyext
-python-coveralls
-# TODO: Remove the pinning of the pytest-cov version again once issue
-#       https://github.com/z4r/python-coveralls/issues/66
-#       is resolved.
-#       Background: pytest-cov 2.6.0 has increased the version
-#       requirement for the coverage package from >=3.7.1 to
-#       >=4.4, which is in conflict with the version requirement
-#       defined by the python-coveralls package for coverage==4.0.3.
-# This fix from:
-# https://github.com/pywbem/pywbem/commit/d85a3e73e08d2846073087733b790b5a8864d93f
-pytest-cov>=2.4.0,<2.6
-pytest-faulthandler
-pytest-ignore-flaky

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import subprocess
 from setuptools import setup, find_packages
 
 #####################################
-VERSION = "0.8.0"
+VERSION = "0.8.1"
 ISRELEASED = True
 if ISRELEASED:
     __version__ = VERSION


### PR DESCRIPTION
We've had issues with a dependency loop due to `mbuild` and `foyer` both having each other as a required dependency. To fix this, and to make MoSDeF more modular, this PR separates `foyer` out as an optional dependency, though still required for development and testing.

To specify that `foyer` is required for testing, this PR also separates out from our `requirements.txt` file a `requirements-dev.txt` file that lists all packages required for development and testing of `mbuild`. `requirements.txt` now contains only the subset of packages that are required to actually use `mbuild`.