### PR TITLE
Write LAMMPS box values in angstroms, not nm

### DIFF
--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -131,9 +131,12 @@ def write_lammpsdata(structure, filename, atom_style='full'):
         # Box data
         if np.allclose(box.angles, np.array([90, 90, 90])):
             for i,dim in enumerate(['x','y','z']):
-                data.write('{0:.6f} {1:.6f} {2}lo {2}hi\n'.format(box.mins[i],box.maxs[i],dim))
+                data.write('{0:.6f} {1:.6f} {2}lo {2}hi\n'.format(
+                    10.0 * box.mins[i],
+                    10.0 * box.maxs[i],
+                    dim))
         else:
-            a, b, c = box.lengths
+            a, b, c = 10.0 * box.lengths
             alpha, beta, gamma = np.radians(box.angles)
 
             lx = a
@@ -143,7 +146,7 @@ def write_lammpsdata(structure, filename, atom_style='full'):
             yz = (b*c*np.cos(alpha) - xy*xz) / ly
             lz = np.sqrt(c**2 - xz**2 - yz**2)
 
-            xlo, ylo, zlo = box.mins
+            xlo, ylo, zlo = 10.0 * box.mins
             xhi = xlo + lx
             yhi = ylo + ly
             zhi = zlo + lz


### PR DESCRIPTION
After #448, box coordinates in LAMMPS data files are being written in nm instead of Angstroms. This fixes that.

Not that an alternative solution would be to simply not convert from Angstroms to nm when converting `structure.box` to `mb.Box` [here](https://github.com/mosdef-hub/mbuild/blob/0cdb42f1b10dcccb1eaf227df00e14cd831394b8/mbuild/formats/lammpsdata.py#L55). However, while it should work and use a couple fewer characters of code, I think it is bad practice to use inconsistent units internally.