### PR TITLE
Populate lattice particles into children of a higher-level compound

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -406,7 +406,7 @@ class Lattice(object):
 
         return np.asarray([alpha, beta, gamma], dtype=np.float64)
 
-    def populate(self, compound_dict=None, x=1, y=1, z=1):
+    def populate(self, compound_dict=None, parent_dict=None, x=1, y=1, z=1):
         """Expand lattice and create compound from lattice.
 
         populate will expand lattice based on user input. The user must also
@@ -501,6 +501,12 @@ class Lattice(object):
 
         ret_lattice = mb.Compound()
 
+        if parent_dict is not None:
+            unique_parent_names = set(parent_dict.values())
+            for parent_name in unique_parent_names:
+                parent_compound = mb.Compound(name=parent_name)
+                ret_lattice.add(parent_compound)
+
         if compound_dict is None:
             for key_id, all_pos in cell.items():
                 particle = mb.Compound(name=key_id, pos=[0, 0, 0])
@@ -515,7 +521,13 @@ class Lattice(object):
                     for pos in all_pos:
                         tmp_comp = mb.clone(compound_to_move)
                         tmp_comp.translate_to(list(pos))
-                        ret_lattice.add(tmp_comp)
+                        if parent_dict is None:
+                            ret_lattice.add(tmp_comp)
+                        else:
+                            # Find the child (a.k.a. parent) in ret_lattice to add new particle to
+                            parent_to_add_to = [child for child in ret_lattice if child.name == parent_dict[key_id]][0]
+                            parent_to_add_to.add(tmp_comp)
+
                 else:
                     err_type = type(compound_dict.get(key_id))
                     raise TypeError('Invalid type in provided Compound '


### PR DESCRIPTION
This may or may not be a useful feature, but the idea is that we could try to have some control over the hierarchy returned by `Lattice.populate()`. Currently, no matter the complexity or size of the repeat unit, every particle is on the same level of the hierarchy. We already have a dictionary argument that maps compounds **on** lattice points, the idea here is to have another (optional) argument that maps **where** it goes. One such example would be a molecular crystal with multiple components, i.e. an ionic liquid crystal. For example, if you managed to get the crystal structure of an ion pair into an `mb.Lattice`, it would be useful to have it return a hierarchy that keeps track of individual ions and doesn't have every single atom at the same level of the hierarchy. Might be useful for other cases in which residues are important, i.e. block copolymers or some sort of biomolecular crystal.

Existing:
```
box_of_ions
├── particle 1
├── particle 2
├── particle 3
...
├── particle N
```

Proposed (imagine there were ions composed of only two atoms)
```
box_of_ions
├── cation 1
│   ├── particle c1_1
│   ├── particle c1_2
├── anion 1
│   ├── particle a1_1
│   ├── particle a1_2
├── cation 2
│   ├── particle c2_1
│   ├── particle c2_2
├── anion 2
│   ├── particle a2_1
│   ├── particle a2_2
...
├── cation N
│   ├── particle cN_1
│   ├── particle cN_2
├── anion N
│   ├── particle aN_1
│   ├── particle aN_2

```

I think this approach would only go one level deep. Maybe there's a way to get another level deeper, or even arbitrary levels of recursion. But I think this would be a useful feature either way.

If this is a good and feasible idea I will make the code functional, add tests, make sure it works for my systems, etc.