### PR TITLE
Attempt to fix coverage dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,15 @@ nbformat
 ipykernel
 ipyext
 python-coveralls
-pytest-cov
+# TODO: Remove the pinning of the pytest-cov version again once issue
+#       https://github.com/z4r/python-coveralls/issues/66
+#       is resolved.
+#       Background: pytest-cov 2.6.0 has increased the version
+#       requirement for the coverage package from >=3.7.1 to
+#       >=4.4, which is in conflict with the version requirement
+#       defined by the python-coveralls package for coverage==4.0.3.
+# This fix from:
+# https://github.com/pywbem/pywbem/commit/d85a3e73e08d2846073087733b790b5a8864d93f
+pytest-cov>=2.4.0,<2.6
 pytest-faulthandler
 pytest-ignore-flaky


### PR DESCRIPTION
Currently, the most recent version of python-coveralls requires
`coverage==4.0.3`, while pytest-cov requires `Coverage>=4.4`.

The current fix seems to be to pin `pytest-cov` to a previous
version. This can be changed once:
https://github.com/z4r/python-coveralls/issues/66

has been resolved.