### PR TITLE
Run `activate base` before `conda build` in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,5 @@ install:
 build: false
 
 test_script:
+  - activate base
   - conda build --quiet devtools\\conda-recipe

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Features
 ### Misc and Bugfixes
 
+## 0.8.2 (unreleased)
+### Misc and Bugfixes
+* Fixed a bug that prevented Appveyor builds from running (#477)
+
 ## 0.8.1 (2018-11-28)
 ### Features
 * Packing functions can optionally constrain the rotation of `Compounds` when using `fill_box` (#407)


### PR DESCRIPTION
This at least gets it to build the conda package ([before](https://ci.appveyor.com/project/mattwthompson/mbuild/builds/20932129) and [after](https://ci.appveyor.com/project/mattwthompson/mbuild/builds/20932552)). Not sure about the tests at the moment.