### PR TITLE
fixes issues #437

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 * When writing hoomdxml files, units will now be in kJ/mol & nm instead of kcal/mol & ang, so particle positions will be different by a factor of 10.
 ### Features
+* When saving hoomdxml files, `auto_scale=True` will scale reference units from max forcefield parameters.
 ### Misc and Bugfixes
 
 ## 0.8.2 (2018-1-8)

--- a/mbuild/formats/hoomdxml.py
+++ b/mbuild/formats/hoomdxml.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from math import floor, radians
 
 import numpy as np
+import operator
 
 from mbuild import Box
 from mbuild.utils.conversion import RB_to_OPLS
@@ -14,7 +15,8 @@ __all__ = ['write_hoomdxml']
 
 @breaking_change("See PR#463 on github")
 def write_hoomdxml(structure, filename, ref_distance=1.0, ref_mass=1.0,
-                   ref_energy=1.0, rigid_bodies=None, shift_coords=True):
+                   ref_energy=1.0, rigid_bodies=None, shift_coords=True,
+                   auto_scale=False):
     """Output a HOOMD XML file.
 
     Parameters
@@ -36,6 +38,9 @@ def write_hoomdxml(structure, filename, ref_distance=1.0, ref_mass=1.0,
         particle is not part of any rigid body.
     shift_coords : bool, optional, default=True
         Shift coordinates from (0, L) to (-L/2, L/2) if necessary.
+    auto_scale : bool, optional, default=False
+        Automatically use largest sigma value as ref_distance, largest mass value
+        as ref_mass and largest epsilon value as ref_energy.
 
     Notes
     -----
@@ -79,10 +84,18 @@ def write_hoomdxml(structure, filename, ref_distance=1.0, ref_mass=1.0,
 
     """
     ref_distance *= 10  # Parmed unit hack
-    ref_energy /= 4.184 # Parmed unit hack
+    ref_energy /= 4.184  # Parmed unit hack
     forcefield = True
     if structure[0].type == '':
         forcefield = False
+    if auto_scale and forcefield:
+        ref_mass = max([atom.mass for atom in structure.atoms])
+        pair_coeffs = list(set((atom.type,
+                                atom.epsilon,
+                                atom.sigma) for atom in structure.atoms))
+        ref_energy = max(pair_coeffs, key=operator.itemgetter(1))[1]
+        ref_distance = max(pair_coeffs, key=operator.itemgetter(2))[2]
+
     xyz = np.array([[atom.xx, atom.xy, atom.xz] for atom in structure.atoms])
     if shift_coords:
         xyz = coord_shift(xyz, structure.box[:3])
@@ -90,6 +103,8 @@ def write_hoomdxml(structure, filename, ref_distance=1.0, ref_mass=1.0,
     with open(filename, 'w') as xml_file:
         xml_file.write('<?xml version="1.2" encoding="UTF-8"?>\n')
         xml_file.write('<hoomd_xml version="1.2">\n')
+        xml_file.write('<!-- ref_distance (nm) ref_mass (amu) ref_energy (kJ/mol) -->\n')
+        xml_file.write('<!-- {} {} {} -->\n'.format(ref_distance, ref_mass, ref_energy))
         xml_file.write('<configuration time_step="0">\n')
         _write_box_information(xml_file, structure, ref_distance)
         _write_particle_information(xml_file, structure, xyz, forcefield,

--- a/mbuild/formats/hoomdxml.py
+++ b/mbuild/formats/hoomdxml.py
@@ -41,6 +41,17 @@ def write_hoomdxml(structure, filename, ref_distance=1.0, ref_mass=1.0,
         Automatically use largest sigma value as ref_distance, largest mass value
         as ref_mass and largest epsilon value as ref_energy.
 
+    Returns
+    -------
+    ReferenceValues : namedtuple
+        Values used in scaling
+
+    Example
+    -------
+    ref_values = ethane.save(filename='ethane-opls.hoomdxml', forcefield_name='oplsaa', auto_scale=True)
+    print(ref_values.mass, ref_values.distance, ref_values.energy)
+
+
     Notes
     -----
     The following elements are always written:

--- a/mbuild/formats/hoomdxml.py
+++ b/mbuild/formats/hoomdxml.py
@@ -1,11 +1,10 @@
 from __future__ import division
-from copy import deepcopy
-from math import floor, radians
+from math import radians
+from collections import namedtuple
 
 import numpy as np
 import operator
 
-from mbuild import Box
 from mbuild.utils.conversion import RB_to_OPLS
 from mbuild.utils.geometry import coord_shift
 from mbuild.utils.decorators import breaking_change
@@ -115,6 +114,10 @@ def write_hoomdxml(structure, filename, ref_distance=1.0, ref_mass=1.0,
         _write_rigid_information(xml_file, rigid_bodies)
         xml_file.write('</configuration>\n')
         xml_file.write('</hoomd_xml>')
+
+    ReferenceValues = namedtuple("ref_values", ["distance", "mass", "energy"])
+
+    return ReferenceValues(ref_distance, ref_mass, ref_energy)
 
 
 def _write_particle_information(xml_file, structure, xyz, forcefield,

--- a/mbuild/tests/test_hoomdxml.py
+++ b/mbuild/tests/test_hoomdxml.py
@@ -62,3 +62,16 @@ class TestHoomdXML(BaseTest):
         for atom in mb.load('benzene.hoomdxml'):
             assert atom.pos.max() < 20
             assert atom.pos.min() > -20
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    def test_auto_scale_forcefield(self, ethane):
+        ethane.save(filename='ethane-opls.hoomdxml', forcefield_name='oplsaa', auto_scale=True)
+        xml_file = xml.etree.ElementTree.parse('ethane-opls.hoomdxml').getroot()
+        masses = xml_file[0].find('mass').text.splitlines()
+        # We use 1 and 5 since the first element of masses is empty
+        assert masses[1] == "1.0"
+        assert masses[5] == "1.0"
+        pair_coeffs = [_.split("\t") for _ in xml_file[0].find('pair_coeffs').text.splitlines()]
+        # The first element is empty, the next element should be ['opls_135', '1.0000', '1.0000']
+        assert pair_coeffs[1][1] == "1.0000"
+        assert pair_coeffs[1][2] == "1.0000"


### PR DESCRIPTION
This creates a new parameter for `write_hoomdxml` that enables automatic scaling for reference values of mass, energy, and distance. When saving, we also return a named tuple so these auto values can be used programmatically. 