### PR TITLE
Add some issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -21,6 +21,6 @@ Please include a code snippet that can be used to reproduce this bug.
 
 **Software versions**
 
-- Which version mBuild are you using? (`python -c "import mbuild as mb; print(mb.version)"`)
+- Which version of mBuild are you using? (`python -c "import mbuild as mb; print(mb.version)"`)
 - Which version of Python (`python --version`)?
 - Which operating system?

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report a bug in mBuild
+
+---
+
+**Bug summary**
+
+What were you trying to do and what happened instead? Please copy and paste the stack output
+
+
+**Code to reproduce the behavior**
+
+Please include a code snippet that can be used to reproduce this bug.
+
+```python
+# Paste your code here
+#
+#
+```
+
+**Software versions**
+
+- Which version mBuild are you using? (`python -c "import mbuild as mb; print(mb.version)"`)
+- Which version of Python (`python --version`)?
+- Which operating system?

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an improvement to mBuild
+
+---
+
+**Describe the behavior you would like added to mBuild**
+A clear and concise description of what the proposed idea is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/QUESTION.md
@@ -1,0 +1,7 @@
+---
+name: Questions/discussions
+about: For usage questions, important notes, and other discussions.
+
+---
+
+**A summary of the question or discussion topic.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+### PR Summary:
+
+### PR Checklist
+------------
+ - [ ] Includes appropriate unit test(s)
+ - [ ] Appropriate docstring(s) are added/updated
+ - [ ] Code is (approximately) PEP8 compliant
+ - [ ] Issue(s) raised/referenced?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,4 @@
  - [ ] Includes appropriate unit test(s)
  - [ ] Appropriate docstring(s) are added/updated
  - [ ] Code is (approximately) PEP8 compliant
- - [ ] Issue(s) raised/referenced?
+ - [ ] Issue(s) raised/addressed?


### PR DESCRIPTION
This adds a `.github/` folder, which includes templates for PRs and issues. Most is relatively boilerplate, a few important points are:

* The way I structured the issue template allows people to choose between three templates (see [here](https://github.com/MDAnalysis/mdanalysis/issues/new/choose) for how it actually looks from the user's end). This is because "issues" here are really a mix of bug reports, feature requests, usage questions, and other discussions.

* We should probably think about start a contributor's guide. This doesn't need to be big, but establishing some style/linter guidelines (I like PEP8 but I never want to be 100% compliant), showing a MWE, etc.

* If we like this, or something like this, I can do the same thing for foyer. But a contributor's guideline may be better housed in a "everything mosdef" location, since our standards are identical

See the following for reference/inspiration (I stole from some of these):

https://github.blog/2016-02-17-issue-and-pull-request-templates/
https://github.com/matplotlib/matplotlib/tree/master/.github
https://github.com/MDAnalysis/mdanalysis/tree/develop/.github
https://github.com/conda/conda/tree/master/.github