### PR TITLE
Fix triclinic box coordinates for Lammps

### DIFF
--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -158,9 +158,14 @@ def write_lammpsdata(structure, filename, atom_style='full'):
             zlo_bound = zlo
             zhi_bound = zhi
 
-            data.write('{0} {1} {2}\n'.format(xlo_bound, xhi_bound, xy))
-            data.write('{0} {1} {2}\n'.format(ylo_bound, yhi_bound, xz))
-            data.write('{0} {1} {2}\n'.format(zlo_bound, zhi_bound, yz))
+            data.write('{0:.6f} {1:.6f} xlo xhi\n'.format(
+                xlo_bound, xhi_bound))
+            data.write('{0:.6f} {1:.6f} ylo yhi\n'.format(
+                ylo_bound, yhi_bound))
+            data.write('{0:.6f} {1:.6f} zlo zhi\n'.format(
+                zlo_bound, zhi_bound))
+            data.write('{0:.6f} {1:.6f} {2:6f} xy xz yz\n'.format(
+                xy, xz, yz))
 
         # Mass data
         masses = [atom.mass for atom in structure.atoms]


### PR DESCRIPTION
The format that `lammpsdata.py` was writing out triclinic box coordinates was previously incorrect.  Correcting this now allows for Lammps data files with triclinic boxes to be loaded.  