### PR TITLE
Draft of a contributors guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 Contributions are welcomed via [pull requests on GitHub](https://github.com/mosdef-hub/mbuild/pulls). Developers and/or 
-users will review requested changes and make comments. This The rest of this file will serve as a set of general guidelines
+users will review requested changes and make comments. The rest of this file will serve as a set of general guidelines
 for contributors.
 
 # Features
 
 ## Implement functionality in a general and flexible fashion
 
-mBuild is designed to be general and flexible, not limited to single chemistries, file formats, simulations engines, or 
-simulation methods. Additions to core features shoudl attempt to provide something that is applicable to a variety of 
-use-cases and not  just the one thing you might need it to do for your research. But some specific features targetted toward 
+mBuild is designed to be general and flexible, not limited to single chemistries, file formats, simulation engines, or 
+simulation methods. Additions to core features should attempt to provide something that is applicable to a variety of 
+use-cases and not targeted at only the focus area of your research. However, some specific features targeted toward 
 a limited use case may be appropriate. Speak to the developers before writing your code and they will help you make design 
 choices that allow flexibility.
 
@@ -19,8 +19,8 @@ Please try to keep the `master` branch of your fork up-to-date with the `master`
 
 ## Propose a single set of related changes
 
-Small changes are preferred over large changes. A major contribution can be broken down into smaller PRs. Large PRs that 
-affect many parts of the codebase can be harder to review and cause merge conflicts if they drag on for long periods of time. 
+Small changes are preferred over large changes. A major contribution can often be broken down into smaller PRs. Large PRs that 
+affect many parts of the codebase can be harder to review and are more likely to cause merge conflicts.
 
 # Source code
 
@@ -35,7 +35,7 @@ adherence is not necessary):
 
 ## Document code with comments
 
-All public-facing functions should have doscstrings using the numpy style. This includes concise paragraph-style description
+All public-facing functions should have docstrings using the numpy style. This includes concise paragraph-style description
 of what the class or function does, relevant limitations and known issues, and descriptions of arguments. Internal functions
 can have simple one-liner docstrings.
 
@@ -46,4 +46,5 @@ can have simple one-liner docstrings.
 
 All new functionality in mBuild should be tested with automatic unit tests that execute in a few seconds. These tests 
 should attempt to cover all options that the user can select. All or most of the added lines of source code should be 
-covered by unit test(s).
+covered by unit test(s). We currently use [pytest](https://docs.pytest.org/en/latest/), which can be executed simply by calling
+`pytest` from the root directory of the package.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,14 @@ affect many parts of the codebase can be harder to review and are more likely to
 
 ## Use a consistent style
 
-It is important to have a consistent style throughout the source code. The following criteria are recommended (but strict
-adherence is not necessary):
+It is important to have a consistent style throughout the source code. The following criteria are desired:
 
-* Lines to 80 characters
-* General consistent with [PEP8](https://www.python.org/dev/peps/pep-0008)
-* The use of linters such as [Black](https://github.com/ambv/black) or [pycodestyle](https://github.com/PyCQA/pycodestyle) 
+* Lines wrapped to 80 characters
+* Lines are indented with spaces
+* Lines do not end with whitespace
+* For other details, refer to [PEP8](https://www.python.org/dev/peps/pep-0008)
+
+To help with the above, there are tools such as [flake8](https://pypi.org/project/flake8/) and [Black](https://github.com/ambv/black).
 
 ## Document code with comments
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+Contributions are welcomed via [pull requests on GitHub](https://github.com/mosdef-hub/mbuild/pulls). Developers and/or 
+users will review requested changes and make comments. This The rest of this file will serve as a set of general guidelines
+for contributors.
+
+# Features
+
+## Implement functionality in a general and flexible fashion
+
+mBuild is designed to be general and flexible, not limited to single chemistries, file formats, simulations engines, or 
+simulation methods. Additions to core features shoudl attempt to provide something that is applicable to a variety of 
+use-cases and not  just the one thing you might need it to do for your research. But some specific features targetted toward 
+a limited use case may be appropriate. Speak to the developers before writing your code and they will help you make design 
+choices that allow flexibility.
+
+# Version control
+
+We currently use the "standard" Pull Request model. Contributions should be implemented on feature branches of forks.
+Please try to keep the `master` branch of your fork up-to-date with the `master` branch of the main repository.
+
+## Propose a single set of related changes
+
+Small changes are preferred over large changes. A major contribution can be broken down into smaller PRs. Large PRs that 
+affect many parts of the codebase can be harder to review and cause merge conflicts if they drag on for long periods of time. 
+
+# Source code
+
+## Use a consistent style
+
+It is important to have a consistent style throughout the source code. The following criteria are recommended (but strict
+adherence is not necessary):
+
+* Lines to 80 characters
+* General consistent with [PEP8](https://www.python.org/dev/peps/pep-0008)
+* The use of linters such as [Black](https://github.com/ambv/black) or [pycodestyle](https://github.com/PyCQA/pycodestyle) 
+
+## Document code with comments
+
+All public-facing functions should have doscstrings using the numpy style. This includes concise paragraph-style description
+of what the class or function does, relevant limitations and known issues, and descriptions of arguments. Internal functions
+can have simple one-liner docstrings.
+
+
+# Tests
+
+## Write unit tests
+
+All new functionality in mBuild should be tested with automatic unit tests that execute in a few seconds. These tests 
+should attempt to cover all options that the user can select. All or most of the added lines of source code should be 
+covered by unit test(s).


### PR DESCRIPTION
This is largely based off of [HOOMD's CONTRIBUTING.md](https://github.com/glotzerlab/hoomd-blue/blob/maint/CONTRIBUTING.md) and in the spirit of small PRs I opened it separately instead of adding it to #498, even though they tie in to each other.

* Do we want one for each package or one for the entire project (or both)?

* What other code standards do we want to suggest?

You can see the rendered markdown on [my fork](https://github.com/mattwthompson/mbuild/blob/contributors-guide/CONTRIBUTING.md)