### PR TITLE
Add gitter badge for mosdef-hub/Lobby 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## mBuild: a hierarchical, component based molecule builder
 
+[![Gitter chat](https://badges.gitter.im/mosdef-hub/gitter.png)](https://gitter.im/mosdef-hub/Lobby)
 [![Linux Build Status](https://travis-ci.org/mosdef-hub/mbuild.svg?branch=master)](https://travis-ci.org/mosdef-hub/mbuild)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/x4aiyeio2c1xf3vx/branch/master?svg=true)](https://ci.appveyor.com/project/ctk3b/mbuild-o0viu/branch/master)
 [![PyPI Version](https://badge.fury.io/py/mbuild.svg)](https://pypi.python.org/pypi/mbuild)


### PR DESCRIPTION
Now that we have a gitter channel, we need to make it easily accessible from the github repos.