### PR TITLE
Drop glotzer and bioconda channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels omnia
   - conda config --add channels janschulz
-  - conda config --add channels glotzer
-  - conda config --add channels bioconda
   - conda config --add channels conda-forge
   - conda config --add channels mosdef
   - conda create -n test-environment python=$PYTHON_VERSION --file requirements-dev.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,6 @@ install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - conda config --add channels omnia
   - conda config --add channels janschulz
-  - conda config --add channels glotzer
-  - conda config --add channels bioconda
   - conda config --add channels conda-forge
   - conda config --add channels mosdef
   - conda update -yq --all


### PR DESCRIPTION
### PR Summary:

This PR drops the `glotzer` and `bioconda` channels from the testing scripts. Each channel previously included dependencies that are now hosted on `conda-forge`. The `glotzer` channel was used for `gsd` (#489) and `bioconda` was used for `nglview`.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
