### PR TITLE
Skip a test that requires foyer

### DIFF
--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -20,6 +20,7 @@ class TestLammpsData(BaseTest):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]))
         ethane.save(filename='ethane-box.lammps', forcefield_name='oplsaa', box=box)
 
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_save_triclinic_box(self, ethane):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]), angles=[60, 70, 80])
         ethane.save(filename='triclinic-box.lammps', forcefield_name='oplsaa', box=box)


### PR DESCRIPTION
### PR Summary:

This PR adds a `@pytest.mark.skipif` that was preventing me from packing a release with conda. See two tests earlier in this file for context; missing this one was oversight and this change is a patch. It was not found on CI because CI uses `requirements-dev.txt` and (it seems) `conda build` does not.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
