### PR TITLE
Use conda-forge instead of the glotzer channel

### DIFF
--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -36,7 +36,7 @@ The code at {filename}:{line_number} requires the "gsd" package
 
 gsd can be installed with conda using:
 
-# conda install -c glotzer gsd
+# conda install -c conda-forge gsd
 '''
 
 MESSAGES['nglview'] = '''


### PR DESCRIPTION
Glotzer group doesn't maintain their conda channel and instead use `conda-forge`

### PR Summary:

### PR Checklist
------------
 - [x ] Includes appropriate unit test(s)
 - [ x] Appropriate docstring(s) are added/updated
 - [x ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
