### PR TITLE
Drop Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ sudo: false
 matrix:
   include:
     - { os: linux, env: PYTHON_VERSION=2.7 }
-    - { os: linux, env: PYTHON_VERSION=3.5 }
     - { os: linux, env: PYTHON_VERSION=3.6 }
     - { os: osx, env: PYTHON_VERSION=2.7 }
-    - { os: osx, env: PYTHON_VERSION=3.5 }
     - { os: osx, env: PYTHON_VERSION=3.6 }
 
 env:
@@ -35,4 +33,4 @@ script:
 after_success:
   - coveralls
   - codecov
-  - if [[ $PYTHON_VERSION == 3.5 ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then source devtools/travis-ci/update_gh_pages.sh; fi
+  - if [[ $PYTHON_VERSION == 3.6 ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then source devtools/travis-ci/update_gh_pages.sh; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Miniconda36-x64"
-      CONDA_PY: "35"
-      ARCH: "64"
-    - PYTHON: "C:\\Miniconda36-x64"
       CONDA_PY: "36"
       ARCH: "64"
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,9 +46,9 @@ in order to get all of the dependencies.
 Supported Python Versions
 -------------------------
 
-Python 2.7, 3.5 and 3.6 are officially supported, including testing during
+Python 2.7 and 3.6 are officially supported, including testing during
 development and packaging. Support for Python 2.7 is planned to be dropped in
-late 2019. Other Python versions, such as 3.7 and 3.4 and older, may
+late 2019. Other Python versions, such as 3.7 and 3.5 and older, may
 successfully build and function but no guarantee is made.
 
 Testing your installation


### PR DESCRIPTION
### PR Summary:
The plan for a while (#479) has been to drop Python 2.7 when it causes more headaches than it's worth (which is any, given that we don't thin anybody still uses it). But, ironically, Python 3.5 has caused problems sooner (#531 #539) because `conda-forge` has moved on from packaging projects for it.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
