### PR TITLE
Use vector image for the gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## mBuild: a hierarchical, component based molecule builder
 
-[![Gitter chat](https://badges.gitter.im/mosdef-hub/gitter.png)](https://gitter.im/mosdef-hub/Lobby)
+[![Gitter chat](https://badges.gitter.im/mosdef-hub/gitter.svg)](https://gitter.im/mosdef-hub/Lobby)
 [![Linux Build Status](https://travis-ci.org/mosdef-hub/mbuild.svg?branch=master)](https://travis-ci.org/mosdef-hub/mbuild)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/x4aiyeio2c1xf3vx/branch/master?svg=true)](https://ci.appveyor.com/project/ctk3b/mbuild-o0viu/branch/master)
 [![PyPI Version](https://badge.fury.io/py/mbuild.svg)](https://pypi.python.org/pypi/mbuild)


### PR DESCRIPTION
### PR Summary:
Our README badge for Gitter was a `png` file, which rendered in low quality on higher fidelity screens. This update uses a vector graphic `svg` instead, which scales based on resolution. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
