### PR TITLE
Raise ValueError when access nonexistent Port

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2458,6 +2458,8 @@ class Compound(object):
         if isinstance(selection, integer_types):
             return list(self.particles())[selection]
         if isinstance(selection, string_types):
+            if selection not in self.labels:
+                raise ValueError('{}[\'{}\'] does not exist.'.format(self.name,selection))
             return self.labels.get(selection)
 
     def __repr__(self):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2459,7 +2459,7 @@ class Compound(object):
             return list(self.particles())[selection]
         if isinstance(selection, string_types):
             if selection not in self.labels:
-                raise ValueError('{}[\'{}\'] does not exist.'.format(self.name,selection))
+                raise MBuildError('{}[\'{}\'] does not exist.'.format(self.name,selection))
             return self.labels.get(selection)
 
     def __repr__(self):

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -263,6 +263,10 @@ class TestCompound(BaseTest):
         with pytest.warns(UserWarning):
             ch3.remove_bond(ch_bond)
 
+    def test_port_does_not_exist(self, ethane):
+        with pytest.raises(MBuildError):
+            ethane['not_port']
+
     def test_center(self, methane):
         assert np.array_equal(methane.center, np.array([0, 0, 0]))
         for orientation in np.identity(3):


### PR DESCRIPTION
Raise ValueError when access non-existent port

### PR Summary:
Raise a ValueError when accessing Port that does not exist responding to issue #505 and #509. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
