### PR TITLE
Remove duplicate visualization in py3dmol

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1237,14 +1237,6 @@ class Compound(object):
                                 'color':'grey'},
                         'sphere': {'scale': 0.3,
                                     'colorscheme':modified_color_scheme}})
-        if show_ports:
-            for p in self.particles(include_ports=True):
-                if p.port_particle:
-                    view.addSphere({
-                        'center': {'x':p.pos[0], 'y':p.pos[1], 'z':p.pos[2]},
-                        'radius' :0.4,
-                        'color': '0x991f00',
-                        'alpha': 0.9})
         view.zoomTo()
 
         return view

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1246,7 +1246,6 @@ class Compound(object):
                         'color': '0x991f00',
                         'alpha': 0.9})
         view.zoomTo()
-        view.show()
 
         return view
 


### PR DESCRIPTION
Using py3dmol to visualize compounds, the image appears twice - we call `view.show()` which will show the image, but the returned object will also appear in a jupyternotebook. I think the most appropriate fix is to remove the `view.show()` call

EDIT: I'm using this PR to squash miscellaneous bugs in py3dmol visualization
- [x] Duplicate visualization
- [x] Duplicate (and incorrect) visualizing of ports
### PR Summary:
This PR addresses the use of py3Dmol and showing duplicate images in jupyternotebooks. The issue was an additional `show` method being called. Very minor bugfix
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
