### PR TITLE
Enforce captialization standards in to_parmed()

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2283,16 +2283,16 @@ class Compound(object):
                 atomic_number = None
                 name = ''.join(char for char in atom.name if not char.isdigit())
                 try:
-                    atomic_number = AtomicNum[atom.name.lower().capitalize()]
+                    atomic_number = AtomicNum[atom.name.capitalize()]
                 except KeyError:
-                    element = element_by_name(atom.name.lower().capitalize())
+                    element = element_by_name(atom.name.capitalize())
                     if name not in guessed_elements:
                         warn(
                             'Guessing that "{}" is element: "{}"'.format(
                                 atom, element))
                         guessed_elements.add(name)
                 else:
-                    element = atom.name.lower().capitalize()
+                    element = atom.name.capitalize()
 
                 atomic_number = atomic_number or AtomicNum[element]
                 mass = Mass[element]

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2283,16 +2283,16 @@ class Compound(object):
                 atomic_number = None
                 name = ''.join(char for char in atom.name if not char.isdigit())
                 try:
-                    atomic_number = AtomicNum[atom.name]
+                    atomic_number = AtomicNum[atom.name.lower().capitalize()]
                 except KeyError:
-                    element = element_by_name(atom.name)
+                    element = element_by_name(atom.name.lower().capitalize())
                     if name not in guessed_elements:
                         warn(
                             'Guessing that "{}" is element: "{}"'.format(
                                 atom, element))
                         guessed_elements.add(name)
                 else:
-                    element = atom.name
+                    element = atom.name.lower().capitalize()
 
                 atomic_number = atomic_number or AtomicNum[element]
                 mass = Mass[element]


### PR DESCRIPTION
### PR Summary:
Enforce uppercase,lowercase formatting for element abbreviations
(Si, not SI, Cl not CL).

When converting a `Compound` to a `ParmEd` structure using the
`Compound.to_parmed()` method, there is a lookup section to
infer the elements present in the compound. If the element names are
fully capitalized (which can happen when reading in from certain mol2
files, and others), the inference does not correctly determine the
chemistry. In the above examples SI would be inferred as Sulfur (S), and
CL would be inferred as Carbon (C).

This can induce issues when trying to go from an mBuild Compound, to
a ParmEd structure, to an atomtyped system using Foyer.

This is not a catch-all fix, as non-elemental names that are not
prefaced with an underscore (which they should be, but sometimes this is
missed when making a compound) will undergo this same treatment.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
