### PR TITLE
Update Appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
   - conda config --add channels mosdef
   - conda update -y --all
   - activate
-  - conda install -y conda-build jinja2
+  - conda install -y python=%PYTHON_VERSION% conda-build jinja2
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ build: false
 
 test_script:
   - activate base
-  - conda build --python %PYTHON_VERSION% devtools\\conda-recipe
+  - conda build devtools\\conda-recipe --python=%PYTHON_VERSION% 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,11 @@ install:
   - conda config --add channels janschulz
   - conda config --add channels conda-forge
   - conda config --add channels mosdef
-  - conda update -yq --all
-  - conda install -yq conda-build jinja2
+  - conda update -y --all
+  - conda install -y conda-build jinja2
 
 build: false
 
 test_script:
   - activate base
-  - conda build --quiet devtools\\conda-recipe
+  - conda build devtools\\conda-recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,11 @@ environment:
     - PYTHON: "C:\\Miniconda36-x64"
       CONDA_PY: "36"
       ARCH: "64"
+      PYTHON_VERSION: "3.6"
     - PYTHON: "C:\\Miniconda36-x64"
       CONDA_PY: "37"
       ARCH: "64"
+      PYTHON_VERSION: "3.7"
 
 install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ build: false
 
 test_script:
   - activate base
-  - conda build devtools\\conda-recipe
+  - conda build --python %PYTHON_VERSION% devtools\\conda-recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ environment:
     PYTHONUNBUFFERED: 1
 
   matrix:
-    - PYTHON: "C:\\Miniconda36-x64"
+    - PYTHON: "C:\\Miniconda3-x64"
       CONDA_PY: "36"
       ARCH: "64"
       PYTHON_VERSION: "3.6"
-    - PYTHON: "C:\\Miniconda36-x64"
+    - PYTHON: "C:\\Miniconda3-x64"
       CONDA_PY: "37"
       ARCH: "64"
       PYTHON_VERSION: "3.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ install:
   - conda config --add channels conda-forge
   - conda config --add channels mosdef
   - conda update -y --all
+  - activate
   - conda install -y conda-build jinja2
 
 build: false

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,7 +30,6 @@ test:
     - jupyter
     - nbformat
     - ipykernel
-    - ipyext
     - foyer
     - networkx
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -10,6 +10,7 @@ build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
   script_env:
     - CONDA_PY
+  script: activate
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -8,7 +8,9 @@ source:
 build:
   noarch: python
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
-  script: activate; python setup.py install --single-version-externally-managed --record record.txt
+  script_env:
+    - CONDA_PY
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
 
   commands:
     - set LNAME=mosdef
+    - activate
     - pytest -v --pyargs mbuild
 
 about:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
 build:
   noarch: python
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: activate; python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:


### PR DESCRIPTION
### PR Summary:

Might fix #552. The problem was `ipyext` was still in the conda recipe and it has not been updated for [years](https://anaconda.org/janschulz/ipyext/files) and lacks a version with Python newer than 3.5, so when it tried to install dependencies it was forced to downgrade to Python 3.5. We have the tests marked as flaky (note this is only relevant to pytest, not conda) and are not installing them with Travis.  Because Travis just installs the package from source and does not try to `conda build` it and we only interact with `conda build` when packaging, this bug went unnoticed. We also made some changes to the Appveyor recipe to be more verbose so we can better understand logs in the future.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
