### PR TITLE
Doc fixes

### DIFF
--- a/devtools/travis-ci/create_docs.sh
+++ b/devtools/travis-ci/create_docs.sh
@@ -17,7 +17,7 @@ set -ev
 # we assume that we're running in a virtualenv with all mbuild already installed and tested
 
 # install additional packages required for doc generation
-conda install --yes sphinx numpydoc sphinx sphinx_rtd_theme widgetsnbextension ipywidgets
+conda install --yes sphinx==1.8.5 numpydoc sphinx sphinx_rtd_theme widgetsnbextension ipywidgets
 pip install mock
 
 pushd $DIR/../..

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ extensions = [
 nbsphinx_execute = 'always'
 
 autosummary_generate = True
-autodoc_default_flags = ['members', 'inherited-members']
+autodoc_default_flags = ['members',]
 numpydoc_class_members_toctree = False
 
 # stackoverflow.com/questions/12206334
@@ -95,7 +95,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'mbuild'
-copyright = u'2014-2017, Vanderbilt University'
+copyright = u'2014-2019, Vanderbilt University'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -4,25 +4,25 @@ Recipes
 Monolayer
 ---------
 
-.. autoclass:: mbuild.recipes.Monolayer
+.. autoclass:: mbuild.lib.recipes.monolayer.Monolayer
     :members:
 
 Polymer
 -------
 
-.. autoclass:: mbuild.recipes.Polymer
+.. autoclass:: mbuild.lib.recipes.polymer.Polymer
     :members:
 
 Tiled Compound
 --------------
 
-.. autoclass:: mbuild.recipes.TiledCompound
+.. autoclass:: mbuild.lib.recipes.tiled_compound.TiledCompound
     :members:
 
 Silica Interface
 ----------------
 
-.. autoclass:: mbuild.recipes.SilicaInterface
+.. autoclass:: mbuild.lib.recipes.silica_interface.SilicaInterface
     :members:
 
 Lattice

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -4,25 +4,25 @@ Recipes
 Monolayer
 ---------
 
-.. autoclass:: mbuild.recipes.monolayer.Monolayer
+.. autoclass:: mbuild.recipes.Monolayer
     :members:
 
 Polymer
 -------
 
-.. autoclass:: mbuild.recipes.polymer.Polymer
+.. autoclass:: mbuild.recipes.Polymer
     :members:
 
 Tiled Compound
 --------------
 
-.. autoclass:: mbuild.recipes.tiled_compound.TiledCompound
+.. autoclass:: mbuild.recipes.TiledCompound
     :members:
 
 Silica Interface
 ----------------
 
-.. autoclass:: mbuild.recipes.silica_interface.SilicaInterface
+.. autoclass:: mbuild.recipes.SilicaInterface
     :members:
 
 Lattice


### PR DESCRIPTION
### PR Summary:
The underlying structure of mBuild has changed slightly, especially
regarding the location of our default recipes like `Polymer`, etc.

This change was not included in the documentation, which prevented them
from being rendered. This has now been fixed.

Also, `sphinx`, which is part of the workflow in generating the
documentation we host on the website, underwent some breaking changes
since its 2.0 release. Especially when working with `numpydoc`, many of
the docstrings were mangled and difficult to read. This is now being
pinned within the `conf.py` file located in the `docs` upper level
directory.
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
