### PR TITLE
Print out residue indices to lammps data file

### DIFF
--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -492,7 +492,7 @@ def write_lammpsdata(structure, filename, atom_style='full',
         for i,coords in enumerate(xyz):
             data.write(atom_line.format(
                 index=i+1,type_index=unique_types.index(types[i])+1,
-                zero=0,charge=charges[i],
+                zero=structure.atoms[i].residue.idx,charge=charges[i],
                 x=coords[0],y=coords[1],z=coords[2]))
 
         if atom_style in ['full', 'molecular']:

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -108,13 +108,13 @@ class TestLammpsData(BaseTest):
         structure = ethane.to_parmed() + methane.to_parmed()
         n_atoms = len(structure.atoms)
         write_lammpsdata(structure, 'compound.lammps')
-        #structure.save(filename='compound.lammps')
         res_list = list()
         with open('compound.lammps', 'r') as f:
-            for line in f:
+            for i,line in enumerate(f):
                 if 'Atoms' in line:
-                    f.readline()
-                    for i in range(n_atoms):
-                        res_list.append(f.readline().rstrip().split()[1])
+                    break
+        atom_lines = open('compound.lammps', 'r').readlines()[i+2:i+n_atoms+2]
+        for line in atom_lines:
+            res_list.append(line.rstrip().split()[1])
 
         assert set(res_list) == set(['1', '0'])

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -103,3 +103,18 @@ class TestLammpsData(BaseTest):
                     first_atom_line = next(f)
                     columns = first_atom_line.split("\t")
                     assert len(columns) == n_columns
+
+    def test_resid(self, ethane, methane):
+        structure = ethane.to_parmed() + methane.to_parmed()
+        n_atoms = len(structure.atoms)
+        write_lammpsdata(structure, 'compound.lammps')
+        #structure.save(filename='compound.lammps')
+        res_list = list()
+        with open('compound.lammps', 'r') as f:
+            for line in f:
+                if 'Atoms' in line:
+                    f.readline()
+                    for i in range(n_atoms):
+                        res_list.append(f.readline().rstrip().split()[1])
+
+        assert set(res_list) == set(['1', '0'])


### PR DESCRIPTION
### PR Summary:
Addressing #568, the proper residue indices are being written out to the LAMMPS data files.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
