### PR TITLE
Pin GSD to 1.7 for Python 2.7 support

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ oset
 parmed
 mdtraj
 foyer
-gsd
+gsd=1.7
 openbabel
 networkx
 pytest >=3.0


### PR DESCRIPTION
### PR Summary:

This morning, @joaander bumped GSD from 1.7 to 1.8, which dropped Python 2.7. This, in my opinion, is enough reason to stop supporting Python 2.7 (see #479). However, to make one final release that does, we need to pin GSD to 1.7. Normally we might not have to, but something was weird in GSD's conda recipe that built a 1.8-py27 version on anaconda.org despite it not being supported (Josh said he is looking into it)

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
