### PR TITLE
Drop Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ sudo: false
 
 matrix:
   include:
-    - { os: linux, env: PYTHON_VERSION=2.7 }
     - { os: linux, env: PYTHON_VERSION=3.6 }
     - { os: linux, env: PYTHON_VERSION=3.7 }
-    - { os: osx, env: PYTHON_VERSION=2.7 }
     - { os: osx, env: PYTHON_VERSION=3.6 }
     - { os: osx, env: PYTHON_VERSION=3.7 }
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -47,9 +47,9 @@ in order to get all of the dependencies.
 Supported Python Versions
 -------------------------
 
-Python 2.7, 3.6 and 3.7 are officially supported, including testing during
-development and packaging. Support for Python 2.7 is planned to be dropped in
-late 2019. Other Python versions, such as 3.8 and 3.5 and older, may
+Python 3.6 and 3.7 are officially supported, including testing during
+development and packaging. Support for Python 2.7 has been dropped as of 
+August 6, 2019. Other Python versions, such as 3.8 and 3.5 and older, may
 successfully build and function but no guarantee is made.
 
 Testing your installation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ oset
 parmed
 mdtraj
 foyer
-gsd=1.7
+gsd
 openbabel
 networkx
 pytest >=3.0

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Chemistry',
         'Operating System :: Microsoft :: Windows',


### PR DESCRIPTION
### PR Summary:

Officially dropping Python 2.7. I have tried to remove it from CI and docs but it is likely I missed a file or two. Python versions are not specified in the conda instructions and we already dropped it in Appveyor.

#572 #479

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
