### PR TITLE
Update box.py

### DIFF
--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -28,11 +28,12 @@ class Box(object):
             self._maxs = np.array(maxs, dtype=np.float)
             self._lengths = self.maxs - self.mins
         else:
-            warn(
-                "Provided `lengths` and `mins` and/or `maxs`. Only `lengths` "
-                "is being used. You provided: "
-                "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
-            )
+            if mins is not None or maxs is not None:
+                warn(
+                    "Provided `lengths` and `mins` and/or `maxs`. Only `lengths` "
+                    "is being used. You provided: "
+                    "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
+                )
             self._mins = np.array([0.0, 0.0, 0.0])
             self._maxs = np.array(lengths, dtype=np.float)
             self._lengths = np.array(lengths, dtype=np.float)


### PR DESCRIPTION
Silence warning if only lengths is provided.

### PR Summary:
Added check whether mins and maxs had been defined before warning the user that they would not be used.

### PR Checklist
------------
 - [n/a] Includes appropriate unit test(s)
 - [n/a] Appropriate docstring(s) are added/updated
 - [yes] Code is (approximately) PEP8 compliant
 - [no] Issue(s) raised/addressed?
