### PR TITLE
Update gitignore for protobuf generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ mbuild/version.py
 
 #virtual env
 .env/
+
+# protobuf generated py file
+compound_pb2.py


### PR DESCRIPTION
### PR Summary:

Since adding support for protobuf as a way to serialize mb.Compounds,
the `protoc` compiler will generate a python file `compound_pb2.py`.

This file is not to be included in version control, since it is
generated on the user's machine.

This commit adds the `protoc` compiled `compound_pb2.py` file to the
gitignore to minimize confusion for anyone unfamiliar with protobuf.

Addresses #601 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
