### PR TITLE
Fixed unnecessary pybel import in mb.load()

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -87,7 +87,6 @@ def load(filename_or_object, relative_to_module=None, compound=None, coords_only
     except ImportError:
         pass
 
-    print(type_dict)
     if isinstance(filename_or_object, Compound):
         return filename_or_object
     for type in type_dict:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -72,18 +72,24 @@ def load(filename_or_object, relative_to_module=None, compound=None, coords_only
     compound : mb.Compound
 
     """
-    pybel = import_('pybel')
-
     # If compound doesn't exist, we will initialize one
     if compound is None:
         compound = Compound()
 
     # First check if we are loading from an existing parmed or trajectory structure
-    type_dict = {
-        pmd.Structure:compound.from_parmed,
-        md.Trajectory:compound.from_trajectory,
-        pybel.Molecule:compound.from_pybel,
-    }
+    try:
+        import pybel
+        type_dict = {
+            pmd.Structure:compound.from_parmed,
+            md.Trajectory:compound.from_trajectory,
+            pybel.Molecule:compound.from_pybel,
+        }
+    except ImportError:
+        type_dict = {
+            pmd.Structure:compound.from_parmed,
+            md.Trajectory:compound.from_trajectory,
+        }
+
     if isinstance(filename_or_object, Compound):
         return filename_or_object
     for type in type_dict:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -77,19 +77,17 @@ def load(filename_or_object, relative_to_module=None, compound=None, coords_only
         compound = Compound()
 
     # First check if we are loading from an existing parmed or trajectory structure
+    type_dict = {
+        pmd.Structure:compound.from_parmed,
+        md.Trajectory:compound.from_trajectory,
+    }
     try:
         import pybel
-        type_dict = {
-            pmd.Structure:compound.from_parmed,
-            md.Trajectory:compound.from_trajectory,
-            pybel.Molecule:compound.from_pybel,
-        }
+        type_dict.update({pybel.Molecule:compound.from_pybel})
     except ImportError:
-        type_dict = {
-            pmd.Structure:compound.from_parmed,
-            md.Trajectory:compound.from_trajectory,
-        }
+        pass
 
+    print(type_dict)
     if isinstance(filename_or_object, Compound):
         return filename_or_object
     for type in type_dict:


### PR DESCRIPTION
### PR Summary:
Fixes #575. Obviates the need to install Openbabel, which is not a required package.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
