### PR TITLE
Change how we label proxies in their compound names

### DIFF
--- a/mbuild/coarse_graining.py
+++ b/mbuild/coarse_graining.py
@@ -29,7 +29,7 @@ class Proxy(Compound):
         if compound.name == 'G':
             name = 'G'
         else:
-            name = compound.name + ' (proxy) '
+            name = compound.name + '_PROXY'
         super(Proxy, self).__init__(name=name)
 
         self.wrapped = compound


### PR DESCRIPTION
### PR Summary:

Fixes #603 by changing how we name proxy "compounds." Previously we appended ` (proxy)` to the name but that was causing issues when writing and then reading to MOL2 files (note that this was because of space, not the parentheses). We tested this by visualizing the CG hexane notebook using `backend='nglview'` and it worked. This might hopefully prevent other issues related to saving CG systems to MOL2 from popping up.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
