### PR TITLE
Try to import pybel in a openbabel 2/3 compatible manner

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -83,7 +83,7 @@ def load(filename_or_object, relative_to_module=None, compound=None, coords_only
         md.Trajectory:compound.from_trajectory,
     }
     try:
-        import pybel
+        pybel = import_('pybel')
         type_dict.update({pybel.Molecule:compound.from_pybel})
     except ImportError:
         pass

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -948,7 +948,7 @@ class TestCompound(BaseTest):
 
     @pytest.mark.skipif(not has_openbabel, reason="Pybel is not installed")
     def test_from_pybel(self):
-        import pybel
+        pybel = import_('pybel')
         benzene = list(pybel.readfile('mol2', get_fn('benzene.mol2')))[0]
         cmpd = mb.Compound()
         cmpd.from_pybel(benzene)
@@ -972,7 +972,7 @@ class TestCompound(BaseTest):
 
     @pytest.mark.skipif(not has_openbabel, reason="Pybel is not installed")
     def test_from_pybel_residues(self):
-       import pybel
+       pybel = import_('pybel')
        pybel_mol = list(pybel.readfile('mol2', get_fn('methyl.mol2')))[0]
        cmpd = mb.Compound()
        cmpd.from_pybel(pybel_mol)
@@ -980,7 +980,7 @@ class TestCompound(BaseTest):
 
     @pytest.mark.skipif(not has_openbabel, reason="Pybel is not installed")
     def test_from_pybel_monolayer(self):
-        import pybel
+        pybel = import_('pybel')
         monolayer = list(pybel.readfile('pdb', get_fn('monolayer.pdb')))[0]
         # TODO: Actually store the box information
         cmpd = mb.Compound()

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -8,7 +8,7 @@ import pytest
 import mbuild as mb
 from mbuild.exceptions import MBuildError
 from mbuild.utils.geometry import calc_dihedral
-from mbuild.utils.io import get_fn, has_foyer, has_intermol, has_openbabel, has_networkx
+from mbuild.utils.io import get_fn, import_, has_foyer, has_intermol, has_openbabel, has_networkx
 from mbuild.tests.base_test import BaseTest
 
 class TestCompound(BaseTest):

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -99,6 +99,10 @@ def import_(module):
     >>> # module from, etc) if the import fails
     >>> import tables
     >>> tables = import_('tables')
+
+    Notes
+    -----
+    The pybel/openbabel
     """
     if module == 'pybel':
         try:

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -44,7 +44,7 @@ The code at {filename}:{line_number} requires the "nglview" package
 
 nglview can be installed using:
 
-# conda install -c bioconda nglview
+# conda install -c conda-forge nglview
 
 or
 
@@ -56,7 +56,7 @@ The code at {filename}:{line_number} requires the "openbabel" package
 
 openbabel can be installed with conda using:
 
-# conda install -c bioconda openbabel
+# conda install -c conda-forge openbabel
 
 or from source following instructions at:
 

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -23,6 +23,7 @@ import os
 from pkg_resources import resource_filename
 import sys
 import textwrap
+import warnings
 from unittest import SkipTest
 
 
@@ -114,8 +115,9 @@ def import_(module):
             pass
         try:
             pybel = importlib.import_module('pybel')
-            raise DeprecationWarning('openbabel 2.0 detected and will be '
-                    'dropped in a future release. Consider upgrading to 3.x.')
+            msg = ('openbabel 2.0 detected and will be dropped in a future '
+                   'release. Consider upgrading to 3.x.')
+            warnings.warn(msg, DeprecationWarning)
             return pybel
         except ModuleNotFoundError:
             pass

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -102,7 +102,10 @@ def import_(module):
 
     Notes
     -----
-    The pybel/openbabel
+    The pybel/openbabel block is meant to resolve compatibility between
+    openbabel 2.x and 3.0.  There may be other breaking changes but the change
+    in importing them is the major one we are aware of. For details, see
+    https://open-babel.readthedocs.io/en/latest/UseTheLibrary/migration.html#python-module
     """
     if module == 'pybel':
         try:
@@ -110,7 +113,10 @@ def import_(module):
         except ModuleNotFoundError:
             pass
         try:
-            return importlib.import_module('pybel')
+            pybel = importlib.import_module('pybel')
+            raise DeprecationWarning('openbabel 2.0 detected and will be '
+                    'dropped in a future release. Consider upgrading to 3.x.')
+            return pybel
         except ModuleNotFoundError:
             pass
     try:

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -100,6 +100,15 @@ def import_(module):
     >>> import tables
     >>> tables = import_('tables')
     """
+    if module == 'pybel':
+        try:
+            return importlib.import_module('openbabel.pybel')
+        except ModuleNotFoundError:
+            pass
+        try:
+            return importlib.import_module('pybel')
+        except ModuleNotFoundError:
+            pass
     try:
         return importlib.import_module(module)
     except ImportError as e:


### PR DESCRIPTION
### PR Summary:

Fixes #607 (I hope). From what we can tell so far, the only breaking change to openbabel 3.0.0 is how `pybel` is imported. It looks like if we replace `import pybel` with `from openbabel import pybel` we can continue. This PR proposes a clause in `import_` that does this checking and imports `pybel` in the appropriate manner by checking each. I have tested this locally with both openbabel versions. The advantage to this approach is that we might not need to pin or enforce openbabel versions; the downside is that the code is a little ugly and it might not cover all breaking changes.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
