### PR TITLE
Reduce the length of some unit tests

### DIFF
--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -166,7 +166,7 @@ class TestCompound(BaseTest):
         assert struct.residues[1].number ==  2
 
     def test_save_residue_map(self, methane):
-        filled = mb.fill_box(methane, n_compounds=100, box=[0, 0, 0, 4, 4, 4])
+        filled = mb.fill_box(methane, n_compounds=10, box=[0, 0, 0, 4, 4, 4])
         t0 = time.time()
         filled.save('filled.mol2', forcefield_name='oplsaa', residues='Methane')
         t1 = time.time()
@@ -1000,19 +1000,19 @@ class TestCompound(BaseTest):
        assert 'LIG1' in cmpd.children[0].name
 
     @pytest.mark.skipif(not has_openbabel, reason="Pybel is not installed")
-    def test_from_pybel_monolayer(self):
+    def test_from_pybel_molecule(self):
         pybel = import_('pybel')
-        monolayer = list(pybel.readfile('pdb', get_fn('monolayer.pdb')))[0]
+        chol = list(pybel.readfile('pdb', get_fn('cholesterol.pdb')))[0]
         # TODO: Actually store the box information
         cmpd = mb.Compound()
-        cmpd.from_pybel(monolayer)
-        assert monolayer.OBMol.NumAtoms() == cmpd.n_particles
-        assert monolayer.OBMol.NumBonds() == cmpd.n_bonds
-        first_atom = monolayer.OBMol.GetAtom(1)
+        cmpd.from_pybel(chol)
+        assert chol.OBMol.NumAtoms() == cmpd.n_particles
+        assert chol.OBMol.NumBonds() == cmpd.n_bonds
+        first_atom = chol.OBMol.GetAtom(1)
         assert np.allclose(cmpd[0].pos, [first_atom.GetX()/10, first_atom.GetY()/10, first_atom.GetZ()/10])
         #assert np.allclose(box.lengths,
-        #        [monolayer.unitcell.GetA()/10, monolayer.unitcell.GetB()/10,
-        #            monolayer.unitcell.GetC()/10],
+        #        [chol.unitcell.GetA()/10, chol.unitcell.GetB()/10,
+        #            chol.unitcell.GetC()/10],
         #        rtol=1e-3)
 
     @pytest.mark.skipif(not has_openbabel, reason="Pybel is not installed")


### PR DESCRIPTION
### PR Summary:

I just wanted to take a quick stab at reducing the length of some of our unit tests, particularly the longer ones.
<details><summary>Before:</summary>

<p>


```
=================================== slowest 20 test durations ===================================
41.93s call     mbuild/tests/test_compound.py::TestCompound::test_from_pybel_monolayer
15.81s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/solvate/solvate.ipynb]
8.83s call     mbuild/tests/test_compound.py::TestCompound::test_save_residue_map
4.97s call     mbuild/tests/test_compound.py::TestCompound::test_save_forcefield
4.86s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/pmpc/pmpc_brush_layer.ipynb]
4.44s call     mbuild/tests/test_silica_interface.py::TestSilicaInterface::test_seed
4.42s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/alkane_monolayer/alkane_monolayer.ipynb]
4.02s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/tnp/tnp.ipynb]
4.01s call     mbuild/tests/test_compound.py::TestCompound::test_energy_minimize_openmm
3.97s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/bilayer/bilayer.ipynb]
3.69s call     mbuild/tests/test_tiled_compound.py::TestTiledCompound::test_2d_replication
3.13s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/alkane/alkane.ipynb]
3.11s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/coarse_graining/hexane_box.ipynb]
3.08s call     mbuild/tests/test_compound.py::TestCompound::test_energy_minimize_openmm_xml
2.82s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/coarse_graining/cg_hexane.ipynb]
2.54s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/reload/reload.ipynb]
2.46s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/lennard_jones/monolj.ipynb]
2.12s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/ethane/ethane.ipynb]
2.05s call     mbuild/tests/test_silica_interface.py::TestSilicaInterface::test_silica_interface
1.97s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/alkane_monolayer/alkylsilane.ipynb]
============= 396 passed, 3 skipped, 13 xpassed, 263 warnings in 173.91s (0:02:53) ==============

```
</p>
</details>


<details><summary>Now:</summary>
<p>


```
============================================== slowest 20 test durations ==============================================
14.74s call     mbuild/tests/test_compound.py::TestCompound::test_save_references
11.83s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/solvate/solvate.ipynb]
5.42s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/alkane_monolayer/alkane_monolayer.ipynb]
4.93s call     mbuild/tests/test_compound.py::TestCompound::test_save_forcefield
4.67s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/tnp/tnp.ipynb]
4.58s call     mbuild/tests/test_silica_interface.py::TestSilicaInterface::test_seed
4.45s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/pmpc/pmpc_brush_layer.ipynb]
3.85s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/alkane_monolayer/alkylsilane.ipynb]
3.78s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/bilayer/bilayer.ipynb]
3.34s call     mbuild/tests/test_tiled_compound.py::TestTiledCompound::test_2d_replication
3.33s call     mbuild/tests/test_compound.py::TestCompound::test_energy_minimize_openmm
3.06s call     mbuild/tests/test_compound.py::TestCompound::test_energy_minimize_openmm_xml
2.99s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/coarse_graining/hexane_box.ipynb]
2.84s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/ethane/ethane.ipynb]
2.28s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/reload/reload.ipynb]
2.26s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/lennard_jones/monolj.ipynb]
2.09s call     mbuild/tests/test_silica_interface.py::TestSilicaInterface::test_silica_interface
2.05s call     mbuild/tests/test_json_formats.py::TestJSONFormats::test_nested_compound
1.98s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/alkane/alkane.ipynb]
1.90s call     mbuild/examples/test_examples.py::test_examples[mbuild/examples/coarse_graining/cg_hexane.ipynb]
======================== 396 passed, 3 skipped, 13 xpassed, 264 warnings in 135.13s (0:02:15) =========================
```
</p>
</details>

This takes almost a minute off of the tests for me locally, CI may be a little slower. Going through some others to see if I can trim a few more seconds off. Removing the examples will be more impactful once I have the other repo set up.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
