### PR TITLE
Try to install pytest-azurepipelines. Closes #637

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
 
       - bash: |
           source activate test-environment
-          conda install pytest-azurepipelines
+          pip install pytest-azurepipelines
           python -m pytest -v --nbval --nbval-lax --pyargs mbuild --cov=mbuild --no-coverage-upload
         displayName: Run Tests
         
@@ -124,7 +124,7 @@ jobs:
 
       - script: |
           call activate test-environment
-          conda install pytest-azurepipelines
+          python -m pip install pytest-azurepipelines
           python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report=html --pyargs mbuild --no-coverage-upload
         displayName: Run Tests
 
@@ -165,6 +165,6 @@ jobs:
 
       - bash: |
           source activate bleeding-test-environment
-          conda install pytest-azurepipelines
+          pip install pytest-azurepipelines
           python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report= --pyargs mbuild --no-coverage-upload
         displayName: Run Tests


### PR DESCRIPTION
This patch tries to install `pytest-azurepipelines` using pip. 
