### PR TITLE
Wrap coordinates function

### DIFF
--- a/mbuild/tests/test_utils.py
+++ b/mbuild/tests/test_utils.py
@@ -3,6 +3,7 @@ import difflib
 import numpy as np
 import pytest
 
+import mbuild as mb
 from mbuild.tests.base_test import BaseTest
 from mbuild.utils.io import get_fn, import_
 from mbuild.utils.validation import assert_port_exists
@@ -119,3 +120,14 @@ class TestUtils(BaseTest):
         new_xyz = wrap_coords(xyz, box)
         assert (new_xyz[1,:] == xyz[1,:]).all()
         assert (new_xyz[0,:] == np.array([1,1,1])).all()
+
+    def test_coord_wrap_box(self):
+        xyz = np.array([[3, 3, 1],
+                        [1, 1, 0]])
+
+        box = mb.Box(mins=[-2.0,-2.0,-2.0], maxs=[2.0,2.0,2.0])
+
+        new_xyz = wrap_coords(xyz, box)
+
+        assert (new_xyz[0,:] == np.array([-1,-1,1])).all()
+        assert (new_xyz[1,:] == xyz[1,:]).all()

--- a/mbuild/tests/test_utils.py
+++ b/mbuild/tests/test_utils.py
@@ -7,6 +7,7 @@ from mbuild.tests.base_test import BaseTest
 from mbuild.utils.io import get_fn, import_
 from mbuild.utils.validation import assert_port_exists
 from mbuild.utils.jsutils import overwrite_nglview_default
+from mbuild.utils.geometry import wrap_coords
 
 
 class TestUtils(BaseTest):
@@ -110,3 +111,11 @@ class TestUtils(BaseTest):
                     });
                 """
             ]
+
+    def test_coord_wrap(self):
+        xyz = np.array([[3, 3, 1],
+                        [1, 1, 0]])
+        box = [2,2,2]
+        new_xyz = wrap_coords(xyz, box)
+        (xyz[1,:] == new_xyz[1,:]).all()
+        (new_xyz == np.array([1,1,1])).all()

--- a/mbuild/tests/test_utils.py
+++ b/mbuild/tests/test_utils.py
@@ -117,5 +117,5 @@ class TestUtils(BaseTest):
                         [1, 1, 0]])
         box = [2,2,2]
         new_xyz = wrap_coords(xyz, box)
-        (xyz[1,:] == new_xyz[1,:]).all()
-        (new_xyz == np.array([1,1,1])).all()
+        assert (new_xyz[1,:] == xyz[1,:]).all()
+        assert (new_xyz[0,:] == np.array([1,1,1])).all()

--- a/mbuild/utils/geometry.py
+++ b/mbuild/utils/geometry.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import mbuild as mb
 from mbuild.coordinate_transform import angle
 
 
@@ -62,7 +63,8 @@ def wrap_coords(xyz, box):
     Parameters
     ---------
     xyz : numpy.array of points with shape N x 3
-    box : numpy.array specifing the size of box ie [Lx, Ly, Lz]
+    box : numpy.array specifing the size of box ie [Lx, Ly, Lz] or
+        mb.Box
 
     Returns
     -------
@@ -73,9 +75,15 @@ def wrap_coords(xyz, box):
     Assumes we are wrapping inside the positive octant
     Currently only supports orthorhombic boxes
     """
-    box_arr = np.asarray(box)
-    assert box_arr.shape == (3,)
+    if not isinstance(box, mb.Box):
+        box_arr = np.asarray(box)
+        assert box_arr.shape == (3,)
 
-    wrap_xyz = xyz - 1*np.floor_divide(xyz, box_arr) * box_arr
+        wrap_xyz = xyz - 1*np.floor_divide(xyz, box_arr) * box_arr
+    else:
+        xyz = xyz - box.mins  
+        wrap_xyz = (xyz 
+                - (1*np.floor_divide(xyz, box.lengths) * box.lengths)
+                + box.mins)
 
     return wrap_xyz

--- a/mbuild/utils/geometry.py
+++ b/mbuild/utils/geometry.py
@@ -63,8 +63,10 @@ def wrap_coords(xyz, box):
     Parameters
     ---------
     xyz : numpy.array of points with shape N x 3
-    box : numpy.array specifing the size of box ie [Lx, Ly, Lz] or
-        mb.Box
+    box : numpy.array or list or mb.Box
+        array or list should have shape (3,) corresponding to box lengths.
+        If array or list is passed, box is assumed to be positive octant
+        If mb.box is passed, box can be arbitrarily centered
 
     Returns
     -------
@@ -72,7 +74,6 @@ def wrap_coords(xyz, box):
 
     Notes
     -----
-    Assumes we are wrapping inside the positive octant
     Currently only supports orthorhombic boxes
     """
     if not isinstance(box, mb.Box):

--- a/mbuild/utils/geometry.py
+++ b/mbuild/utils/geometry.py
@@ -66,17 +66,17 @@ def wrap_coords(xyz, box):
 
     Returns
     -------
-    xyz : numpy.array of points with shape N x 3
+    wrap_xyz : numpy.array of points with shape N x 3
 
     Notes
     -----
     Assumes we are wrapping inside the positive octant
+    Currently only supports orthorhombic boxes
     """
-    for atom_xyz in xyz:
-        if atom_xyz[0] < 0: atom_xyz[0]+= box[0]
-        if atom_xyz[1] < 0: atom_xyz[1]+= box[1]
-        if atom_xyz[2] < 0: atom_xyz[2]+= box[2]
-        if atom_xyz[0] > box[0]: atom_xyz[0]-= box[0]
-        if atom_xyz[1] > box[1]: atom_xyz[1]-= box[1]
-        if atom_xyz[2] > box[2]: atom_xyz[2]-= box[2]
-    return xyz
+    box_arr = np.asarray(box)
+    assert box_arr.shape == (3,)
+
+    wrap_xyz = np.array([coord + -1 * np.floor_divide(coord, box_arr) * box_arr
+        for coord in xyz]) 
+
+    return wrap_xyz

--- a/mbuild/utils/geometry.py
+++ b/mbuild/utils/geometry.py
@@ -55,3 +55,28 @@ def coord_shift(xyz, box):
         xyz += box_max
 
     return xyz
+
+def wrap_coords(xyz, box):
+    """ Wrap coordinates inside box
+
+    Parameters
+    ---------
+    xyz : numpy.array of points with shape N x 3
+    box : numpy.array specifing the size of box ie [Lx, Ly, Lz]
+
+    Returns
+    -------
+    xyz : numpy.array of points with shape N x 3
+
+    Notes
+    -----
+    Assumes we are wrapping inside the positive octant
+    """
+    for atom_xyz in xyz:
+        if atom_xyz[0] < 0: atom_xyz[0]+= box[0]
+        if atom_xyz[1] < 0: atom_xyz[1]+= box[1]
+        if atom_xyz[2] < 0: atom_xyz[2]+= box[2]
+        if atom_xyz[0] > box[0]: atom_xyz[0]-= box[0]
+        if atom_xyz[1] > box[1]: atom_xyz[1]-= box[1]
+        if atom_xyz[2] > box[2]: atom_xyz[2]-= box[2]
+    return xyz

--- a/mbuild/utils/geometry.py
+++ b/mbuild/utils/geometry.py
@@ -76,7 +76,6 @@ def wrap_coords(xyz, box):
     box_arr = np.asarray(box)
     assert box_arr.shape == (3,)
 
-    wrap_xyz = np.array([coord + -1 * np.floor_divide(coord, box_arr) * box_arr
-        for coord in xyz]) 
+    wrap_xyz = xyz - 1*np.floor_divide(xyz, box_arr) * box_arr
 
     return wrap_xyz


### PR DESCRIPTION
### PR Summary:
This PR introduces a utility function to wrap XYZ coordinates into a specified box, assuming positive octant. This helps for creating structures + XYZ within HOOMD libraries

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
