### PR TITLE
Don't populate empty lists for hoomd snapshot

### DIFF
--- a/mbuild/formats/hoomd_snapshot.py
+++ b/mbuild/formats/hoomd_snapshot.py
@@ -117,30 +117,35 @@ def to_hoomdsnapshot(structure,  ref_distance=1.0, ref_mass=1.0,
     hoomd_snapshot.particles.charge[:] = scaled_charges
     hoomd_snapshot.particles.body[:] = rigid_bodies
 
-    hoomd_snapshot.bonds.resize(n_bonds)
-    hoomd_snapshot.bonds.types[:] = unique_bond_types
-    hoomd_snapshot.bonds.typeid[:] = bond_typeids
-    hoomd_snapshot.bonds.group[:] = bond_groups
+    if n_bonds > 0:
+        hoomd_snapshot.bonds.resize(n_bonds)
+        hoomd_snapshot.bonds.types[:] = unique_bond_types
+        hoomd_snapshot.bonds.typeid[:] = bond_typeids
+        hoomd_snapshot.bonds.group[:] = bond_groups
 
-    hoomd_snapshot.angles.resize(n_angles)
-    hoomd_snapshot.angles.types[:] = unique_angle_types
-    hoomd_snapshot.angles.typeid[:] = angle_typeids
-    hoomd_snapshot.angles.group[:] = np.reshape(angle_groups, (-1, 3))
+    if n_angles > 0:
+        hoomd_snapshot.angles.resize(n_angles)
+        hoomd_snapshot.angles.types[:] = unique_angle_types
+        hoomd_snapshot.angles.typeid[:] = angle_typeids
+        hoomd_snapshot.angles.group[:] = np.reshape(angle_groups, (-1, 3))
 
-    hoomd_snapshot.dihedrals.resize(n_dihedrals)
-    hoomd_snapshot.dihedrals.types[:] = unique_dihedral_types
-    hoomd_snapshot.dihedrals.typeid[:] = dihedral_typeids
-    hoomd_snapshot.dihedrals.group[:] = np.reshape(dihedral_groups, (-1,4))
+    if n_dihedrals > 0:
+        hoomd_snapshot.dihedrals.resize(n_dihedrals)
+        hoomd_snapshot.dihedrals.types[:] = unique_dihedral_types
+        hoomd_snapshot.dihedrals.typeid[:] = dihedral_typeids
+        hoomd_snapshot.dihedrals.group[:] = np.reshape(dihedral_groups, (-1,4))
 
-    hoomd_snapshot.impropers.resize(n_impropers)
-    hoomd_snapshot.impropers.types[:] = unique_improper_types
-    hoomd_snapshot.impropers.typeid[:] = improper_typeids
-    hoomd_snapshot.impropers.group[:] = np.reshape(improper_groups, (-1,4))
+    if n_impropers > 0:
+        hoomd_snapshot.impropers.resize(n_impropers)
+        hoomd_snapshot.impropers.types[:] = unique_improper_types
+        hoomd_snapshot.impropers.typeid[:] = improper_typeids
+        hoomd_snapshot.impropers.group[:] = np.reshape(improper_groups, (-1,4))
 
-    hoomd_snapshot.pairs.resize(n_pairs)
-    hoomd_snapshot.pairs.types[:] = pair_types
-    hoomd_snapshot.pairs.typeid[:] = pair_typeid
-    hoomd_snapshot.pairs.group[:] = np.reshape(pairs, (-1,2))
+    if n_pairs > 0:
+        hoomd_snapshot.pairs.resize(n_pairs)
+        hoomd_snapshot.pairs.types[:] = pair_types
+        hoomd_snapshot.pairs.typeid[:] = pair_typeid
+        hoomd_snapshot.pairs.group[:] = np.reshape(pairs, (-1,2))
 
     return hoomd_snapshot, ref_values
 

--- a/mbuild/tests/test_hoomd.py
+++ b/mbuild/tests/test_hoomd.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree
 
 import mbuild as mb
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import has_foyer, has_hoomd, import_
+from mbuild.utils.io import get_fn, has_foyer, has_hoomd, import_
 
 
 @pytest.mark.skipif(not has_hoomd, reason="HOOMD is not installed")
@@ -91,6 +91,23 @@ class TestHoomd(BaseTest):
         assert isinstance(sim_forces[5], bond_force.harmonic)
         assert isinstance(sim_forces[6], angle_force.harmonic)
         assert isinstance(sim_forces[7], dihedral_force.opls)
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    def test_lj_to_hoomdsimulation(self):
+        hoomd = import_("hoomd")
+        hoomd_simulation = import_("mbuild.formats.hoomd_simulation")
+        forcefield = import_("foyer.forcefield")
+        box = mb.Compound()
+        box.add(mb.Compound(name='Ar', pos=[1,1,1]))
+        box.add(mb.Compound(name='Ar', pos=[1,1,1]))
+        ff = forcefield.Forcefield(forcefield_files=get_fn('lj.xml'))
+        structure = ff.apply(box)
+        structure.box = [10, 10, 10, 90, 90, 90]
+        hoomd_simulation.create_hoomd_simulation(structure)
+        sim_forces = hoomd.context.current.forces
+        pair_force = import_("hoomd.md.pair")
+
+        assert isinstance(sim_forces[0], pair_force.lj)
 
 
 class TestHoomdXML(BaseTest):

--- a/mbuild/tests/test_hoomd.py
+++ b/mbuild/tests/test_hoomd.py
@@ -17,6 +17,17 @@ class TestHoomd(BaseTest):
         assert snap.bonds.N == 7
         assert snap.angles.N == 0
 
+    def test_particles_to_snapshot(self):
+        hoomd_snapshot = import_("mbuild.formats.hoomd_snapshot")
+        part = mb.Compound(name='Ar')
+        box = mb.fill_box(part, n_compounds=10, box=mb.Box([5,5,5]))
+        snap, _ = hoomd_snapshot.to_hoomdsnapshot(box)
+
+        assert snap.particles.N == 10
+        assert snap.bonds.N == 0
+        assert snap.angles.N == 0
+
+
     def test_bad_input_to_snapshot(self):
         hoomd_snapshot = import_("mbuild.formats.hoomd_snapshot")
         with pytest.raises(ValueError):

--- a/mbuild/utils/reference/lj.xml
+++ b/mbuild/utils/reference/lj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ForceField >
+  <!--XML units: kJ/mol for energies, nm for lengths, and radians for angles.-->
+  <AtomTypes>
+    <Type name="Ar" class="Ar" element="Ar" mass="39.948" def="[Ar]" desc="LJ Argon"/>
+  </AtomTypes>
+  <HarmonicBondForce>
+  </HarmonicBondForce>
+  <HarmonicAngleForce/>
+  <RBTorsionForce>
+  </RBTorsionForce>
+  <NonbondedForce coulomb14scale="0.0" lj14scale="0.0">
+    <Atom type="Ar" charge="0" sigma="0.34" epsilon="1.00"/>
+  </NonbondedForce>
+</ForceField>


### PR DESCRIPTION
### PR Summary:
For systems with no bonds, creating a hoomd snapshot will error because it will try to cast an empty list into a multi-dimensional numpy array. This PR is a quick fix to ensure there are bonds, angles, or dihedrals before trying to do any shape-casting

