### PR TITLE
Change keyword for par file

### DIFF
--- a/mbuild/formats/par_writer.py
+++ b/mbuild/formats/par_writer.py
@@ -88,7 +88,7 @@ def write_par(structure, filename):
                 dihedral[0], dihedral[1], dihedral[2], dihedral[3],
                 dihedral[4].phi_k, dihedral[4].per, dihedral[4].phase))
 
-        f.write("\nIMPROPERS\n")
+        f.write("\nIMPROPER\n")
         unique_impropers = set()
         for improper in structure.impropers:
             unique_impropers.add(


### PR DESCRIPTION
### PR Summary:
When parmed writes a PAR file for CHARMM simulations, the keyword is `IMPROPERS`. However, PAR files for NAMD/GOMC use the keyword `IMPROPER`. This PR defaults the mbuild par-writer to using `IMPROPER`

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
