### PR TITLE
Update gsdwriter.py

### DIFF
--- a/mbuild/formats/gsdwriter.py
+++ b/mbuild/formats/gsdwriter.py
@@ -11,7 +11,7 @@ __all__ = ['write_gsd']
 
 def write_gsd(structure, filename, ref_distance=1.0, ref_mass=1.0,
               ref_energy=1.0, rigid_bodies=None, shift_coords=True,
-              write_special_pairs=True):
+              write_special_pairs=True, **kwargs):
     """Output a GSD file (HOOMD v2 default data format).
 
     Parameters


### PR DESCRIPTION
We pass some extra kwargs that the writer doesn't understand sometime like `write_ff`

```
>           saver(filename=filename, structure=structure, **kwargs)
E           TypeError: write_gsd() got an unexpected keyword argument 'write_ff'
```

### PR Summary:

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
