### PR TITLE
Only import MCF writer if networkx is installed

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -28,9 +28,8 @@ from mbuild.formats.hoomdxml import write_hoomdxml
 from mbuild.formats.lammpsdata import write_lammpsdata
 from mbuild.formats.gsdwriter import write_gsd
 from mbuild.formats.par_writer import write_par
-from mbuild.formats.cassandramcf import write_mcf
 from mbuild.periodic_kdtree import PeriodicCKDTree
-from mbuild.utils.io import run_from_ipython, import_
+from mbuild.utils.io import run_from_ipython, import_, has_networkx
 from mbuild.utils.jsutils import overwrite_nglview_default
 from mbuild.coordinate_transform import _translate, _rotate
 
@@ -1912,8 +1911,10 @@ class Compound(object):
                   '.gsd': write_gsd,
                   '.lammps': write_lammpsdata,
                   '.lmp': write_lammpsdata,
-                  '.par': write_par,
-                  '.mcf': write_mcf}
+                  '.par': write_par,}
+        if has_networkx:
+            from mbuild.formats.cassandramcf import write_mcf
+            savers.update({'.mcf': write_mcf})
 
         try:
             saver = savers[extension]


### PR DESCRIPTION
### PR Summary:

Fixes #652 

In an environment that does not have `networkx` (which is currently treated as a test-only requirement), you cannot `import mbuild` on the `master` branch, but you can with these changes.

I did not update the MCF tests because they already depend on `networkx` via `foyer`.
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
