### PR TITLE
Add nbval as test requirement for conda build

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -37,6 +37,7 @@ test:
     - ipykernel
     - foyer
     - networkx
+    - nbval
 
   source_files:
     - mbuild/examples/*


### PR DESCRIPTION
### PR Summary:
Add `nbval` as requirement for conda built testing.
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?