### PR TITLE
Fix travis by not installing md5sha1sum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ulimit -n 1024; fi
   - source devtools/travis-ci/install.sh
   - conda config --set always_yes yes --set changeps1 no


### PR DESCRIPTION
### PR Summary:

The recipe we inherited includes a `brew install md5sha1sum` step to check the hash of what we installed. At some point in time (I will not investigate this) this may have gotten merged into macOS (see [1](https://stackoverflow.com/a/57133600/4248961)) and [below](https://api.travis-ci.org/v3/job/628478750/log.txt)). My first guess of simply removing the above install line seems to have worked on my fork ...

```
[0K$ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi

==> Downloading https://homebrew.bintray.com/bottles/md5sha1sum-0.9.5_1.high_sierra.bottle.tar.gz

==> Pouring md5sha1sum-0.9.5_1.high_sierra.bottle.tar.gz

Error: The `brew link` step did not complete successfully

The formula built, but is not symlinked into /usr/local

Could not symlink bin/md5sum

Target /usr/local/bin/md5sum

is a symlink belonging to coreutils. You can unlink it:

  brew unlink coreutils



To force the link and overwrite all conflicting files:

  brew link --overwrite md5sha1sum



To list all files that would be deleted:

  brew link --overwrite --dry-run md5sha1sum



Possible conflicting files are:

/usr/local/bin/md5sum -> /usr/local/Cellar/coreutils/8.31/bin/md5sum

/usr/local/bin/sha1sum -> /usr/local/Cellar/coreutils/8.31/bin/sha1sum

==> Summary

ðŸº  /usr/local/Cellar/md5sha1sum/0.9.5_1: 8 files, 41.9KB

travis_time:end:00f53914:start=1577049835253099000,finish=1577049842677471000,duration=7424372000,event=install
[0K[31;1mThe command "if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi" failed and exited with 1 during .[0m



Your build has been stopped.
