### PR TITLE
Add a function that returns a "populated lattice" box

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -452,6 +452,34 @@ class Lattice(object):
 
         return np.asarray([alpha, beta, gamma], dtype=np.float64)
 
+    def _sanitize_populate_args(self, x, y, z):
+
+        error_dict = {0: 'X', 1: 'Y', 2: 'Z'}
+
+        # Make sure neither x, y, z input is None
+        if None in [x, y, z]:
+            raise ValueError('Attempt to replicate None times. '
+                             'None is not an acceptable replication '
+                             'amount, 1 is the default.')
+
+        # Try to convert x, y, and z to int, raise a ValueError if fail
+        try:
+            x = int(x)
+            y = int(y)
+            z = int(z)
+        except (ValueError, TypeError):
+            raise ValueError('Cannot convert replication amounts into '
+                             'integers. x= {}, y= {}, z= {} needs to '
+                             'be an int.'.format(x, y, z))
+
+        for replication_amount, index in zip([x, y, z], range(3)):
+            if replication_amount < 1:
+                raise ValueError('Incorrect populate value: {} : {} is < 1. '
+                                 .format(error_dict[index],
+                                         replication_amount))
+
+        return x, y, z
+
     def populate(self, compound_dict=None, x=1, y=1, z=1):
         """Expand lattice and create compound from lattice.
 
@@ -484,29 +512,7 @@ class Lattice(object):
 
         """
 
-        error_dict = {0: 'X', 1: 'Y', 2: 'Z'}
-
-        # Make sure neither x, y, z input is None
-        if None in [x, y, z]:
-            raise ValueError('Attempt to replicate None times. '
-                             'None is not an acceptable replication '
-                             'amount, 1 is the default.')
-
-        # Try to convert x, y, and z to int, raise a ValueError if fail
-        try:
-            x = int(x)
-            y = int(y)
-            z = int(z)
-        except (ValueError, TypeError):
-            raise ValueError('Cannot convert replication amounts into '
-                             'integers. x= {}, y= {}, z= {} needs to '
-                             'be an int.'.format(x, y, z))
-
-        for replication_amount, index in zip([x, y, z], range(3)):
-            if replication_amount < 1:
-                raise ValueError('Incorrect populate value: {} : {} is < 1. '
-                                 .format(error_dict[index],
-                                         replication_amount))
+        x, y, z = self._sanitize_populate_args(x=x, y=y, z=z)
 
         if ((isinstance(compound_dict, dict)) or (compound_dict is None)):
             pass

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -613,9 +613,7 @@ class Lattice(object):
 
         [a, b, c] = self.lattice_spacing
 
-        if any(self.angles != [90, 90, 90]):
-            warn('Periodicity of non-rectangular lattices are not valid with '
-                 'default boxes. Only rectangular lattices are valid '
-                 'at this time.')
-
-        return mb.Box(lengths=np.asarray([a * x, b * y, c * z], dtype=np.float64))
+        return mb.Box(
+            lengths=np.asarray([a * x, b * y, c * z], dtype=np.float64),
+            angles=np.asarray(self.angles)
+        )

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -591,3 +591,31 @@ class Lattice(object):
 
         return ret_lattice
 
+    def get_populated_box(self, x=1, y=1, z=1):
+        """
+        Return a mbuild.Box representing the periodic boundaries of a
+        populated mbuild.Lattice. This is meant to be called in parallel
+        with, and using the same arguments of, a call to
+        mb.Lattice.populate().
+
+        Parameters
+        ----------
+        x : int, optional, default=1
+            How many iterations in the x direction.
+        y : int, optional, default=1
+            How many iterations in the y direction.
+        z : int, optional, default=1
+            How many iterations in the z direction.
+
+        """
+
+        x, y, z = self._sanitize_populate_args(x, y, z)
+
+        [a, b, c] = self.lattice_spacing
+
+        if any(self.angles != [90, 90, 90]):
+            warn('Periodicity of non-rectangular lattices are not valid with '
+                 'default boxes. Only rectangular lattices are valid '
+                 'at this time.')
+
+        return mb.Box(lengths=np.asarray([a * x, b * y, c * z], dtype=np.float64))

--- a/mbuild/tests/test_lattice.py
+++ b/mbuild/tests/test_lattice.py
@@ -230,3 +230,16 @@ class TestLattice(BaseTest):
         assert isinstance(mybox, mb.Box)
         np.testing.assert_allclose([90, 90, 90], mybox.angles)
         np.testing.assert_allclose(expected_lengths, mybox.lengths)
+
+    def test_get_box_non_rectangular(self):
+        lattice = mb.Lattice(lattice_spacing=[0.5, 0.5, 1], angles=[90, 90, 120],
+                             lattice_points={'A' : [[0, 0, 0]]})
+        replication=[2, 2, 1]
+
+        expected_lengths = [x*y for x,y in zip(replication, lattice.lattice_spacing)]
+
+        mybox = lattice.get_populated_box(x=2, y=2, z=1)
+
+        assert isinstance(mybox, mb.Box)
+        np.testing.assert_allclose([90, 90, 120], mybox.angles)
+        np.testing.assert_allclose(expected_lengths, mybox.lengths)

--- a/mbuild/tests/test_lattice.py
+++ b/mbuild/tests/test_lattice.py
@@ -217,3 +217,16 @@ class TestLattice(BaseTest):
         replication=[2, 5, 9]
         np.testing.assert_allclose(compound_test.periodicity,
                                    np.asarray([x*y for x,y in zip(replication, lattice.lattice_spacing)]))
+
+    def test_get_box(self):
+        lattice = mb.Lattice(lattice_spacing=[1, 1, 1], angles=[90, 90, 90],
+                             lattice_points={'A' : [[0, 0, 0]]})
+        replication=[5, 4, 3]
+
+        expected_lengths = [x*y for x,y in zip(replication, lattice.lattice_spacing)]
+
+        mybox = lattice.get_populated_box(x=5, y=4, z=3)
+
+        assert isinstance(mybox, mb.Box)
+        np.testing.assert_allclose([90, 90, 90], mybox.angles)
+        np.testing.assert_allclose(expected_lengths, mybox.lengths)


### PR DESCRIPTION
### PR Summary:
Addresses #465 with my proposed idea of a second function; would look something like this in practice:

```python3
mylattice = mb.Lattice(...)

mycompound = mylattice.populate(x=10, y=10, z=4)
mybox = mylattice.get_populated_box(x=10, y=10, z=4)
```

Things I suggest considering when reviewing
* Does this look okay from the user's perspective?
* What other tests should we consider? `_sanitize_populate_args ` is already tested in `populate` but I didn't consider edge cases
* How to handle non-rectangular boxes? Just punt?
### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
