### PR TITLE
Allow single dimension setter for mb.Box class

### DIFF
--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -2,7 +2,7 @@ from warnings import warn
 
 import numpy as np
 
-__all__ = ['_BoxArray']
+__all__ = ['Box', '_BoxArray']
 
 class Box(object):
     """A box representing the bounds of the system.

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -24,9 +24,9 @@ class Box(object):
                     "You provided: "
                     "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
                 )
-            self._mins = np.array(mins, dtype=np.float)
-            self._maxs = np.array(maxs, dtype=np.float)
-            self._lengths = self.maxs - self.mins
+            self._mins = tuple(mins)
+            self._maxs = tuple(maxs)
+            self._lengths = tuple(self.maxs - self.mins)
         else:
             if mins is not None or maxs is not None:
                 warn(
@@ -34,31 +34,26 @@ class Box(object):
                     "is being used. You provided: "
                     "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
                 )
-            self._mins = np.array([0.0, 0.0, 0.0])
-            self._maxs = np.array(lengths, dtype=np.float)
-            self._lengths = np.array(lengths, dtype=np.float)
+            self._mins = (0.0, 0.0, 0.0)
+            self._maxs = tuple(lengths)
+            self._lengths = tuple(lengths)
         if angles is None:
             angles = np.array([90.0, 90.0, 90.0])
         elif isinstance(angles, (list, np.ndarray)):
             angles = np.array(angles, dtype=np.float)
         self._angles = angles
 
-        self._mins.setflags(write=False)
-        self._maxs.setflags(write=False)
-        self._lengths.setflags(write=False)
-
-
     @property
     def mins(self):
-        return self._mins
+        return np.array(self._mins, dtype=np.float)
 
     @property
     def maxs(self):
-        return self._maxs
+        return np.array(self._maxs, dtype=np.float)
 
     @property
     def lengths(self):
-        return self._lengths
+        return np.array(self._lengths, dtype=np.float)
 
     @property
     def angles(self):
@@ -69,38 +64,26 @@ class Box(object):
         if isinstance(mins, list):
             mins = np.array(mins, dtype=np.float)
         assert mins.shape == (3, )
-        self._mins = mins
-        self._lengths = self.maxs - self.mins
-
-        self._lengths.setflags(write=False)
-        self._mins.setflags(write=False)
+        self._mins = tuple(mins)
+        self._lengths = tuple(self.maxs - self.mins)
 
     @maxs.setter
     def maxs(self, maxes):
         if isinstance(maxes, list):
             maxes = np.array(maxes, dtype=np.float)
         assert maxes.shape == (3, )
-        self._maxs = maxes
-        self._lengths = self.maxs - self.mins
-
-        self._lengths.setflags(write=False)
-        self._maxs.setflags(write=False)
+        self._maxs = tuple(maxes)
+        self._lengths = tuple(self.maxs - self.mins)
 
     @lengths.setter
     def lengths(self, lengths):
         if isinstance(lengths, list):
-            lengths = np.array(lengths, dtype=np.float)
+            lengths = np.array(lengths, dtype=float)
         assert lengths.shape == (3, )
-        self._maxs.setflags(write=True)
-        self._mins.setflags(write=True)
         
-        self._maxs += 0.5*lengths - 0.5*self.lengths
-        self._mins -= 0.5*lengths - 0.5*self.lengths
+        self._maxs = tuple(self.maxs + 0.5*lengths - 0.5*self.lengths)
+        self._mins = tuple(self.mins - (0.5*lengths - 0.5*self.lengths))
         self._lengths = lengths
-
-        self._maxs.setflags(write=False)
-        self._mins.setflags(write=False)
-        self._lengths.setflags(write=False)
 
     @angles.setter
     def angles(self, angles):

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -40,6 +40,8 @@ class Box(object):
                 )
             if isinstance(lengths, int) or isinstance(lengths, float):
                 lengths = np.array(lengths*np.ones(3), dtype=np.float)
+            else:
+                lengths = np.array(lengths, dtype=np.float)
             assert lengths.shape == (3, )
             self._mins = BoxArray(array=(0,0,0), var="mins", box=self)
             self._maxs = BoxArray(array=lengths, var="maxs", box=self)

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -77,8 +77,7 @@ class Box(object):
     def lengths(self, lengths):
         lengths = np.array(lengths, dtype=np.float)
         assert lengths.shape == (3, )
-        print(type(lengths), lengths) 
-        self._maxs = boxArray(array=(self.maxs + 0.5*lengths - 0.5*self.lengths), var="maxs", box=self)
+        self._maxs = boxArray(array=(self.maxs + (0.5*lengths - 0.5*self.lengths)), var="maxs", box=self)
         self._mins = boxArray(array=(self.mins - (0.5*lengths - 0.5*self.lengths)), var="mins", box=self)
         self._lengths = boxArray(array=lengths, var="lengths", box=self, dtype=np.float)
 
@@ -109,6 +108,6 @@ class boxArray(np.ndarray):
         elif self.var == "mins":
             self.box.mins = array
         elif self.var == "lengths":
-            self.lengths = array
+            self.box.lengths = array
         else:
             self.angles = array

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -43,8 +43,14 @@ class Box(object):
             angles = np.array(angles, dtype=np.float)
         self._angles = angles
 
+        self._mins.setflags(write=False)
+        self._maxs.setflags(write=False)
+        self._lengths.setflags(write=False)
+
+
     @property
     def mins(self):
+        print(self._mins)
         return self._mins
 
     @property

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -2,7 +2,7 @@ from warnings import warn
 
 import numpy as np
 
-__all__ = ['__BoxArray']
+__all__ = ['_BoxArray']
 
 class Box(object):
     """A box representing the bounds of the system.
@@ -89,7 +89,10 @@ class Box(object):
 
     @lengths.setter
     def lengths(self, lengths):
-        lengths = np.array(lengths, dtype=np.float)
+        if isinstance(lengths, int) or isinstance(lengths, float):
+            lengths = np.array(lengths*np.ones(3), dtype=np.float)
+        else:
+            lengths = np.array(lengths, dtype=np.float)
         assert lengths.shape == (3, )
         assert all(lengths >= 0), "Given lengths are negative" 
         self._maxs = _BoxArray(array=(self.maxs + (0.5*lengths - 0.5*self.lengths)), var="maxs", box=self)

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -24,6 +24,10 @@ class Box(object):
                     "You provided: "
                     "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
                 )
+            mins = np.array(mins, dtype=np.float)
+            maxs = np.array(maxs, dtype=np.float)
+            assert mins.shape == (3, ), "Given mins have wrong dimensions"
+            assert maxs.shape == (3, ), "Given maxs have wrong dimensions"
             self._mins = BoxArray(array=mins, var="mins", box=self)
             self._maxs = BoxArray(array=maxs, var="maxs", box=self)
             self._lengths = BoxArray(array=(self.maxs - self.mins), var="lengths", box=self)
@@ -34,6 +38,9 @@ class Box(object):
                     "is being used. You provided: "
                     "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
                 )
+            if isinstance(lengths, int) or isinstance(lengths, float):
+                lengths = np.array(lengths*np.ones(3), dtype=np.float)
+            assert lengths.shape == (3, )
             self._mins = BoxArray(array=(0,0,0), var="mins", box=self)
             self._maxs = BoxArray(array=lengths, var="maxs", box=self)
             self._lengths = BoxArray(array=lengths, var="lenghts", box=self)

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -72,6 +72,9 @@ class Box(object):
         self._mins = mins
         self._lengths = self.maxs - self.mins
 
+        self._lengths.setflags(write=False)
+        self._mins.setflags(write=False)
+
     @maxs.setter
     def maxs(self, maxes):
         if isinstance(maxes, list):
@@ -80,14 +83,24 @@ class Box(object):
         self._maxs = maxes
         self._lengths = self.maxs - self.mins
 
+        self._lengths.setflags(write=False)
+        self._maxs.setflags(write=False)
+
     @lengths.setter
     def lengths(self, lengths):
         if isinstance(lengths, list):
             lengths = np.array(lengths, dtype=np.float)
         assert lengths.shape == (3, )
+        self._maxs.setflags(write=True)
+        self._mins.setflags(write=True)
+        
         self._maxs += 0.5*lengths - 0.5*self.lengths
         self._mins -= 0.5*lengths - 0.5*self.lengths
         self._lengths = lengths
+
+        self._maxs.setflags(write=False)
+        self._mins.setflags(write=False)
+        self._lengths.setflags(write=False)
 
     @angles.setter
     def angles(self, angles):

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -50,7 +50,6 @@ class Box(object):
 
     @property
     def mins(self):
-        print(self._mins)
         return self._mins
 
     @property

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -61,24 +61,21 @@ class Box(object):
 
     @mins.setter
     def mins(self, mins):
-        if isinstance(mins, list):
-            mins = np.array(mins, dtype=np.float)
+        mins = np.array(mins, dtype=np.float)
         assert mins.shape == (3, )
         self._mins = tuple(mins)
         self._lengths = tuple(self.maxs - self.mins)
 
     @maxs.setter
     def maxs(self, maxes):
-        if isinstance(maxes, list):
-            maxes = np.array(maxes, dtype=np.float)
+        maxes = np.array(maxes, dtype=np.float)
         assert maxes.shape == (3, )
         self._maxs = tuple(maxes)
         self._lengths = tuple(self.maxs - self.mins)
 
     @lengths.setter
     def lengths(self, lengths):
-        if isinstance(lengths, list):
-            lengths = np.array(lengths, dtype=np.float)
+        lengths = np.array(lengths, dtype=np.float)
         assert lengths.shape == (3, )
         
         self._maxs = tuple(self.maxs + 0.5*lengths - 0.5*self.lengths)
@@ -87,8 +84,7 @@ class Box(object):
 
     @angles.setter
     def angles(self, angles):
-        if isinstance(angles, list):
-            angles = np.array(angles, dtype=np.float)
+        angles = np.array(angles, dtype=np.float)
         assert angles.shape == (3, )
         self._angles = angles
 

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -78,7 +78,7 @@ class Box(object):
     @lengths.setter
     def lengths(self, lengths):
         if isinstance(lengths, list):
-            lengths = np.array(lengths, dtype=float)
+            lengths = np.array(lengths, dtype=np.float)
         assert lengths.shape == (3, )
         
         self._maxs = tuple(self.maxs + 0.5*lengths - 0.5*self.lengths)

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -93,6 +93,19 @@ class Box(object):
 class BoxArray(np.ndarray):
     """Subclass of np.ndarry specifically for mb.Box
 
+    This subclass is meant to be used internally to store Box attribute array.
+    This subclass is modified so that its __setitem__ method is reroute to the
+    corresponding setter method.
+
+    Parameters
+    ----------
+    array : array-like object
+        This can be tuple, list, or any array-like object that can be usually
+        passed to np.array
+    var : str
+        Corresponding Box's attributes like "maxs", "mins", "lengths", "angles"
+    box : mb.Box
+        This is the Box contains this attribute (one level up of this array)
     """
     def __new__(cls, array, var=None, box=None, dtype=np.float):
         _array = np.asarray(array, dtype).view(cls)

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -2,7 +2,7 @@ from warnings import warn
 
 import numpy as np
 
-__all__ = ['Box', '_BoxArray']
+__all__ = ['Box']
 
 class Box(object):
     """A box representing the bounds of the system.
@@ -103,7 +103,7 @@ class Box(object):
     def angles(self, angles):
         angles = np.array(angles, dtype=np.float)
         assert angles.shape == (3, )
-        self._angles = angles
+        self._angles = _BoxArray(array=angles, var="angles", box=self, dtype=np.float)
 
     def __repr__(self):
         return "Box(mins={}, maxs={}, angles={})".format(self.mins, self.maxs, self.angles)

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -24,9 +24,9 @@ class Box(object):
                     "You provided: "
                     "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
                 )
-            self._mins = boxArray(array=mins, var="mins", box=self)
-            self._maxs = boxArray(array=maxs, var="maxs", box=self)
-            self._lengths = boxArray(array=(self.maxs - self.mins), var="lengths", box=self)
+            self._mins = BoxArray(array=mins, var="mins", box=self)
+            self._maxs = BoxArray(array=maxs, var="maxs", box=self)
+            self._lengths = BoxArray(array=(self.maxs - self.mins), var="lengths", box=self)
         else:
             if mins is not None or maxs is not None:
                 warn(
@@ -34,17 +34,17 @@ class Box(object):
                     "is being used. You provided: "
                     "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
                 )
-            self._mins = boxArray(array=(0,0,0), var="mins", box=self)
-            self._maxs = boxArray(array=lengths, var="maxs", box=self)
-            self._lengths = boxArray(array=lengths, var="lenghts", box=self)
+            self._mins = BoxArray(array=(0,0,0), var="mins", box=self)
+            self._maxs = BoxArray(array=lengths, var="maxs", box=self)
+            self._lengths = BoxArray(array=lengths, var="lenghts", box=self)
         if angles is None:
-            angles = boxArray(array=(90.0, 90.0, 90.0), var="angles", box=self)
+            angles = BoxArray(array=(90.0, 90.0, 90.0), var="angles", box=self)
         elif isinstance(angles, (list, np.ndarray)):
-            angles = boxArray(array=angles, var="anglese", box=self)
+            angles = BoxArray(array=angles, var="anglese", box=self)
         self._angles = angles
 
     @property
-    def mins(self): 
+    def mins(self):
         return self._mins
 
     @property
@@ -63,23 +63,23 @@ class Box(object):
     def mins(self, mins):
         mins = np.array(mins, dtype=np.float)
         assert mins.shape == (3, )
-        self._mins = boxArray(array=mins, var="mins", box=self)
-        self._lengths = boxArray(array=(self.maxs - self.mins), var="lengths", box=self)
+        self._mins = BoxArray(array=mins, var="mins", box=self)
+        self._lengths = BoxArray(array=(self.maxs - self.mins), var="lengths", box=self)
 
     @maxs.setter
     def maxs(self, maxs):
         maxs = np.array(maxs, dtype=np.float)
         assert maxs.shape == (3, )
-        self._maxs = boxArray(array=maxs, var="maxs", box=self)
-        self._lengths = boxArray(array= (self.maxs - self.mins), var="lengths", box=self)
+        self._maxs = BoxArray(array=maxs, var="maxs", box=self)
+        self._lengths = BoxArray(array= (self.maxs - self.mins), var="lengths", box=self)
 
     @lengths.setter
     def lengths(self, lengths):
         lengths = np.array(lengths, dtype=np.float)
         assert lengths.shape == (3, )
-        self._maxs = boxArray(array=(self.maxs + (0.5*lengths - 0.5*self.lengths)), var="maxs", box=self)
-        self._mins = boxArray(array=(self.mins - (0.5*lengths - 0.5*self.lengths)), var="mins", box=self)
-        self._lengths = boxArray(array=lengths, var="lengths", box=self, dtype=np.float)
+        self._maxs = BoxArray(array=(self.maxs + (0.5*lengths - 0.5*self.lengths)), var="maxs", box=self)
+        self._mins = BoxArray(array=(self.mins - (0.5*lengths - 0.5*self.lengths)), var="mins", box=self)
+        self._lengths = BoxArray(array=lengths, var="lengths", box=self, dtype=np.float)
 
     @angles.setter
     def angles(self, angles):
@@ -90,7 +90,7 @@ class Box(object):
     def __repr__(self):
         return "Box(mins={}, maxs={}, angles={})".format(self.mins, self.maxs, self.angles)
 
-class boxArray(np.ndarray):
+class BoxArray(np.ndarray):
     """Subclass of np.ndarry specifically for mb.Box
 
     """

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -142,8 +142,8 @@ def write_lammpsdata(structure, filename, atom_style='full',
     box = Box(lengths=np.array([0.1 * val for val in structure.box[0:3]]),
               angles=structure.box[3:6])
     # Divide by conversion factor
-    box.lengths /= sigma_conversion_factor
-    box.maxs /= sigma_conversion_factor
+    box.lengths = box.lengths/sigma_conversion_factor
+    box.maxs = box.maxs/sigma_conversion_factor
     
     # Lammps syntax depends on the functional form
     # Infer functional form based on the properties of the structure

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -142,8 +142,8 @@ def write_lammpsdata(structure, filename, atom_style='full',
     box = Box(lengths=np.array([0.1 * val for val in structure.box[0:3]]),
               angles=structure.box[3:6])
     # Divide by conversion factor
-    box.lengths = box.lengths/sigma_conversion_factor
-    box.maxs = box.maxs/sigma_conversion_factor
+    box.lengths /= sigma_conversion_factor
+    box.maxs /= sigma_conversion_factor
     
     # Lammps syntax depends on the functional form
     # Infer functional form based on the properties of the structure

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -142,7 +142,6 @@ def write_lammpsdata(structure, filename, atom_style='full',
     box = Box(lengths=np.array([0.1 * val for val in structure.box[0:3]]),
               angles=structure.box[3:6])
     # Divide by conversion factor
-    box.lengths /= sigma_conversion_factor
     box.maxs /= sigma_conversion_factor
     
     # Lammps syntax depends on the functional form

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -72,3 +72,18 @@ class TestBox(BaseTest):
         assert (box.maxs - box.mins == 4 * np.ones(3)).all()
         box.angles = [90, 90, 120]
         assert (box.angles == np.array([90, 90, 120])).all()
+
+    def test_single_dimension_setter(self):
+        box = mb.Box(mins=np.zeros(3), maxs=4*np.ones(3))
+        assert (box.lengths == 4*np.ones(3)).all()
+        
+        box.maxs[0] = 5
+        box.mins[2] = 1
+        assert (box.mins == np.array([0, 0, 1], dtype=np.float)).all()
+        assert (box.maxs == np.array([5, 4, 4], dtype=np.float)).all()
+        assert (box.lengths == np.array([5, 4, 3], dtype=np.float)).all()
+
+        box.lengths[1] = 6
+        assert (box.mins == np.array([0, -1, 1], dtype=np.float)).all()
+        assert (box.maxs == np.array([5, 5, 4], dtype=np.float)).all()
+        assert (box.lengths == np.array([5, 6, 3], dtype=np.float)).all()

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -87,3 +87,29 @@ class TestBox(BaseTest):
         assert np.allclose(box.mins, np.array([0, -1, 1], dtype=np.float))
         assert np.allclose(box.maxs, np.array([5, 5, 4], dtype=np.float))
         assert np.allclose(box.lengths, np.array([5, 6, 3], dtype=np.float))
+
+        new_box = mb.Box(5)
+        assert np.allclose(new_box.lengths, np.array([5, 5, 5], dtype=np.float))
+        assert np.allclose(new_box.mins, np.array([0, 0, 0], dtype=np.float))
+        assert np.allclose(new_box.maxs, np.array([5, 5, 5], dtype=np.float))
+
+        new_box.lengths = 4
+        assert np.allclose(new_box.lengths, np.array([4, 4, 4], dtype=np.float))
+        assert np.allclose(new_box.mins, np.array([0.5, 0.5, 0.5], dtype=np.float))
+        assert np.allclose(new_box.maxs, np.array([4.5, 4.5, 4.5], dtype=np.float))
+
+    def test_sanity_checks(self):
+        # Initialization step
+        with pytest.raises(AssertionError):
+            box = mb.Box(mins=[3,3,3], maxs=[1,1,1])
+        with pytest.raises(AssertionError):
+            box = mb.Box(lengths=-1)
+        
+        # Modifying step
+        box = mb.Box(mins=[2,2,2], maxs=[4,4,4])
+        with pytest.raises(AssertionError):
+            box.mins[1] = box.maxs[1] + 1
+        with pytest.raises(AssertionError): 
+            box.maxs[1] = box.mins[1] - 1
+        with pytest.raises(AssertionError):
+            box.lengths = -1

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -79,11 +79,11 @@ class TestBox(BaseTest):
         
         box.maxs[0] = 5
         box.mins[2] = 1
-        assert (box.mins == np.array([0, 0, 1], dtype=np.float)).all()
-        assert (box.maxs == np.array([5, 4, 4], dtype=np.float)).all()
-        assert (box.lengths == np.array([5, 4, 3], dtype=np.float)).all()
+        assert np.allclose(box.mins, np.array([0, 0, 1], dtype=np.float))
+        assert np.allclose(box.maxs, np.array([5, 4, 4], dtype=np.float))
+        assert np.allclose(box.lengths, np.array([5, 4, 3], dtype=np.float))
 
         box.lengths[1] = 6
-        assert (box.mins == np.array([0, -1, 1], dtype=np.float)).all()
-        assert (box.maxs == np.array([5, 5, 4], dtype=np.float)).all()
-        assert (box.lengths == np.array([5, 6, 3], dtype=np.float)).all()
+        assert np.allclose(box.mins, np.array([0, -1, 1], dtype=np.float))
+        assert np.allclose(box.maxs, np.array([5, 5, 4], dtype=np.float))
+        assert np.allclose(box.lengths, np.array([5, 6, 3], dtype=np.float))


### PR DESCRIPTION
### PR Summary:
Patches for #365. Makes `box._lengths`, `box._maxs` and `box._mins` to be "immutable". You still can change mins, maxs, and lengths by `box.mins = [1, 1, 1]` (which go through the `settter` method), but `box.mins[0] = 1` will return a `ValueError`.
 
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
