### PR TITLE
Move MDTraj to an optional dependency and remove others not used in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pip install -e .
 
 script:
-  - python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report= --pyargs mbuild
+  - python -m pytest -v --cov=mbuild --cov-report= --pyargs mbuild
 
 after_success:
   - if [[ $PYTHON_VERSION == 3.7 ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then source devtools/travis-ci/update_gh_pages.sh; fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
       - bash: |
           source activate test-environment
           pip install pytest-azurepipelines
-          python -m pytest -v --nbval --nbval-lax --pyargs mbuild --cov=mbuild --no-coverage-upload
+          python -m pytest -v --pyargs mbuild --cov=mbuild --no-coverage-upload
         displayName: Run Tests
         
       - bash: |
@@ -125,7 +125,7 @@ jobs:
       - script: |
           call activate test-environment
           python -m pip install pytest-azurepipelines
-          python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report=html --pyargs mbuild --no-coverage-upload
+          python -m pytest -v --cov=mbuild --cov-report=html --pyargs mbuild --no-coverage-upload
         displayName: Run Tests
 
   - job: LinuxBleedingFoyer
@@ -166,5 +166,5 @@ jobs:
       - bash: |
           source activate bleeding-test-environment
           pip install pytest-azurepipelines
-          python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report= --pyargs mbuild --no-coverage-upload
+          python -m pytest -v --cov=mbuild --cov-report= --pyargs mbuild --no-coverage-upload
         displayName: Run Tests

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -23,26 +23,21 @@ requirements:
     - numpy
     - scipy
     - packmol >=1!18.013
-    - nglview >=2.7
     - oset
     - parmed
     - protobuf
-    - mdtraj
 
 test:
   requires:
     - pytest >=3.0
-    - jupyter
-    - nbformat
-    - ipykernel
     - foyer
     - networkx
-    - nbval
+    - mdtraj
 
   commands:
     - set LNAME=mosdef
     - activate
-    - pytest -v --pyargs mbuild --nbval --nbval-lax
+    - pytest -v --pyargs mbuild
 
 about:
   home: http://mosdef-hub.github.io/mbuild

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -3,13 +3,13 @@ import time
 
 import numpy as np
 import parmed as pmd
-import mdtraj
 import pytest
 
 import mbuild as mb
 from mbuild.exceptions import MBuildError
 from mbuild.utils.geometry import calc_dihedral
-from mbuild.utils.io import get_fn, import_, has_foyer, has_intermol, has_openbabel, has_networkx
+from mbuild.utils.io import (import_, get_fn, has_mdtraj, has_foyer,
+                             has_intermol, has_openbabel, has_networkx)
 from mbuild.tests.base_test import BaseTest
 
 class TestCompound(BaseTest):
@@ -526,6 +526,8 @@ class TestCompound(BaseTest):
         assert traj.n_chains == 1
         assert traj.n_residues == 1
 
+    
+    @pytest.mark.skipif(not has_mdtraj, reason="MDTraj is not installed")
     def test_box_mdtraj(self, ethane):
         assert np.allclose(ethane.periodicity, np.zeros(3))
         traj_boundingbox = ethane.to_trajectory()
@@ -549,6 +551,7 @@ class TestCompound(BaseTest):
             box.lengths
         )
 
+    @pytest.mark.skipif(not has_mdtraj, reason="MDTraj is not installed")
     def test_resnames_mdtraj(self, h2o, ethane):
         system = mb.Compound([h2o, mb.clone(h2o), ethane])
         traj = system.to_trajectory(residues=['Ethane', 'H2O'])
@@ -575,6 +578,7 @@ class TestCompound(BaseTest):
         assert traj.n_residues == 1
         assert residues[0].name == 'RES'
 
+    @pytest.mark.skipif(not has_mdtraj, reason="MDTraj is not installed")
     def test_chainnames_mdtraj(self, h2o, ethane):
         system = mb.Compound([h2o, mb.clone(h2o), ethane])
         traj = system.to_trajectory(chains=['Ethane', 'H2O'])
@@ -589,6 +593,7 @@ class TestCompound(BaseTest):
         traj = system.to_trajectory()
         assert traj.n_chains == 1
 
+    @pytest.mark.skipif(not has_mdtraj, reason="MDTraj is not installed")
     def test_mdtraj_box(self, h2o):
         compound = mb.Compound()
         compound.add(h2o)
@@ -857,6 +862,7 @@ class TestCompound(BaseTest):
         with pytest.raises(MBuildError):
             ch3_clone = mb.clone(ch3)
 
+    @pytest.mark.skipif(not has_mdtraj, reason="MDTraj is not installed")
     def test_load_mol2_mdtraj(self):
         with pytest.raises(KeyError):
             mb.load(get_fn('benzene-nonelement.mol2'))
@@ -973,6 +979,7 @@ class TestCompound(BaseTest):
 
         assert all([isinstance(n, str) for n in graph.nodes()])
 
+    @pytest.mark.skipif(not has_mdtraj, reason="MDTraj is not installed")
     def test_from_trajectory(self):
         comp = mb.Compound()
         traj = mdtraj.load(get_fn('spc.pdb'))
@@ -985,6 +992,7 @@ class TestCompound(BaseTest):
         comp.from_parmed(struc)
         assert comp.children[0].name == 'SPC'
 
+    @pytest.mark.skipif(not has_mdtraj, reason="MDTraj is not installed")
     def test_complex_from_trajectory(self):
         comp = mb.Compound()
         traj = mdtraj.load(get_fn('pro_but.pdb'))

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -88,6 +88,19 @@ or
 # pip install protobuf
 '''
 
+MESSAGES['mdtraj'] = '''
+The code at {filename}:{line_number} requires the "mdtraj" package
+
+protobuf can be installed using:
+
+# conda install -c conda-forge mdtraj
+
+or 
+
+# pip install mdtraj
+'''
+
+
 def import_(module):
     """Import a module, and issue a nice message to stderr if the module isn't installed.
 
@@ -195,6 +208,13 @@ try:
     del hoomd
 except ImportError:
     has_hoomd  = False
+
+try:
+    import mdtraj
+    has_mdtraj = True
+    del mdtraj 
+except ImportError:
+    has_mdtraj = False
 
 def get_fn(name):
     """Get the full path to one of the reference files shipped for utils.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 numpy
 scipy
 packmol>=1!18.013
-nglview>=2.7
 oset
 parmed
 mdtraj
@@ -10,11 +9,7 @@ gsd
 openbabel
 networkx
 pytest >=3.0
-jupyter
-nbformat
 pytest-cov
 pytest-faulthandler
 codecov
 protobuf
-nbval
-py3Dmol


### PR DESCRIPTION
### PR Summary:

This PR does two main things

1. Moves MDTraj to an optional requirement, which also means using ParmEd loaders by default
2. Removes from `requirements-dev.txt` some packages not used in tests. I am willing to be convinced this is a bad change, since some of those packages are likely to be used by developers, but I do not like that CI installs some non-trivial software like Jupyter and makes absolutely zero use of them. If this change is not popular I would offer an an alternative a setup I've seen in signac, in which there's `requirements.txt` for base use, `requirements-test.txt` for testing (a.k.a. tailored to CI), and `requirements-dev.txt` that includes other things a dev may use but a CI bot would not.

Directly addresses #679 and touches on https://github.com/mosdef-hub/mbuild/issues/677

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
