### PR TITLE
Include support for the GSD 2.0 file io syntax

### DIFF
--- a/mbuild/formats/gsdwriter.py
+++ b/mbuild/formats/gsdwriter.py
@@ -80,9 +80,9 @@ def write_gsd(structure, filename, ref_distance=1.0, ref_mass=1.0,
         _write_angle_information(gsd_file, structure)
     if structure.rb_torsions:
         _write_dihedral_information(gsd_file, structure)
-
-
-    gsd.hoomd.create(filename, gsd_file)
+    
+    with gsd.hoomd.open(filename, mode='wb') as fp:
+        fp.append(gsd_file)
 
 def _write_particle_information(gsd_file, structure, xyz, ref_distance,
         ref_mass, ref_energy, rigid_bodies):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ oset
 parmed
 mdtraj
 foyer
-gsd
+gsd>=1.2
 openbabel
 networkx
 pytest >=3.0


### PR DESCRIPTION
### PR Summary:
With the update to GSD 2.X, the way we have been writing out the GSD
snapshot is no longer available.

The syntax has been updated to the non-deprecated and recommended way to
write out to GSD files. This feature was added in ver 1.2 of GSD, which
is why the version in requirements-dev.txt has been pinned to >=1.2

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
Addresses #680 