### PR TITLE
Switch order that box mins and maxs are set

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2476,6 +2476,8 @@ class Compound(object):
                 if not val:
                     box_vec_max[dim] += 0.25
                     box_vec_min[dim] -= 0.25
+            # In rare cases `AssertionError` will be raised if `mins` is set before `maxs`
+            # As a result, set `maxs` before `mins`
             box.maxs = np.asarray(box_vec_max)
             box.mins = np.asarray(box_vec_min)
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2476,8 +2476,8 @@ class Compound(object):
                 if not val:
                     box_vec_max[dim] += 0.25
                     box_vec_min[dim] -= 0.25
-            box.mins = np.asarray(box_vec_min)
             box.maxs = np.asarray(box_vec_max)
+            box.mins = np.asarray(box_vec_min)
 
         box_vector = np.empty(6)
         if box.angles is not None:

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -113,3 +113,20 @@ class TestBox(BaseTest):
             box.maxs[1] = box.mins[1] - 1
         with pytest.raises(AssertionError):
             box.lengths = -1
+
+    def test_compound_without_box(self, ethane):
+        # Set coordinates to trigger the case where `box.mins`
+        # coordinates can be less than [0, 0, 0]
+        ethane.xyz = np.array([[0.31079999, 0.0653, -0.85259998],
+                   [0.459, 0.0674, -0.8132],
+                   [0.281, -0.0349, -0.8761],
+                   [0.251, 0.1015, -0.7710],
+                   [0.295, 0.1278, -0.9380],
+                   [0.474, 0.0049, -0.7277],
+                   [0.518, 0.0312, -0.8946],
+                   [0.488, 0.1676, -0.7896]])
+        # Set periodicity
+        ethane.periodicity = np.array([0.767, 0.703, 0.710])
+        # Convert compound to pmd.structure to set Box info
+        # Conversion should happen without error
+        ethane.to_parmed()


### PR DESCRIPTION
### PR Summary:
The bleeding mbuild tests were failing on a foyer PR due the the assertion error that the `mins` of the mb.Box were greater than the `maxs`.  

The source of this was due to the way we currently handle mBuild compounds with no Box information.  In this case, we first initialize a box by calling `boundingbox`, which simply returns a box based on the minimum and maximum coordinates of the compound.  The issue is that after this, we set `box.mins` to `[0, 0, 0]`.  In the case of the failing test, `box.maxs` had negative coordinates due to calling `self.boundingbox`.

I think we can avoid this assertion error if we first set `box.maxs` first and then `box.mins`.  That way, we can ensure that the max coordinates are greater than the min values.
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
