### PR TITLE
Update `create_hoomd_simulation` to support new HOOMD v3 API

### DIFF
--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -377,8 +377,9 @@ def save_forcefield(forcefield, nl, filename="forcefield.json", overwrite=False)
     """ Serialize hoomd objects to file
 
      Save hoomd objects to a json file that can be used to
-     run a simulation. Useful for restarting a simulation
-     and double checking forfcefield paramters.
+     run a simulation. Useful for restarting a simulation,
+     double checking forfcefield parameters, and to separate
+     forcefield generation from simulation.
 
      Parameters
      ----------

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -55,7 +55,7 @@ def create_hoomd_simulation(structure, ref_distance=1.0, ref_mass=1.0,
         Kwargs to pass to hoomd's pppm function
 
     Returns
-    ------
+    -------
     hoomd_snapshot : snapshot
         HOOMD snapshot object to initialize the simulation
     hoomd_forcefield : list

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -58,6 +58,8 @@ def create_hoomd_simulation(structure, ref_distance=1.0, ref_mass=1.0,
         HOOMD snapshot object to initialize the simulation
     hoomd_forcefield : list
         List of hoomd force computes created during conversion
+    nl : hoomd.md.nlst.Cell
+        Neighborlist used for md.pair and md.special_pair forces
     ReferenceValues : namedtuple
         Values used in scaling
 
@@ -146,7 +148,7 @@ def create_hoomd_simulation(structure, ref_distance=1.0, ref_mass=1.0,
         hoomd_objects.append(rb_torsions)
     print("HOOMD SimulationContext updated from ParmEd Structure")
 
-    return hoomd_snapshot, hoomd_objects, ref_values
+    return hoomd_snapshot, hoomd_objects, nl, ref_values
 
 def _init_hoomd_lj(structure, nl, r_cut=1.2,
         ref_distance=1.0, ref_energy=1.0):
@@ -365,7 +367,7 @@ def _check_hoomd_version():
     return version_numbers
 
 
-def save_forcefield(forcefield, filename="forcefield.json", overwrite=False):
+def save_forcefield(forcefield, nl, filename="forcefield.json", overwrite=False):
     """ Serialize hoomd objects to file
 
      Save hoomd objects to a json file that can be used to
@@ -377,6 +379,9 @@ def save_forcefield(forcefield, filename="forcefield.json", overwrite=False):
      hoomd_forcefield : list
         List of hoomd force computes to be serialized
 
+    nl : hoomd.md.nlist.Cell
+        neighborlist used in hoomd_forcefield
+
      filename : str, optional, default=forcefield.json
             Filesystem path in which to save the file
 
@@ -384,6 +389,7 @@ def save_forcefield(forcefield, filename="forcefield.json", overwrite=False):
             Overwrite if the filename already exists
     """
     logger = hoomd.logging.Logger(flags=["state"])
+    logger += nl
     logger += forcefield
 
     with open(filename, 'w') as f:

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -25,7 +25,6 @@ hoomd.md.charge = import_("hoomd.md.charge")
 hoomd.md.bond = import_("hoomd.md.bond")
 hoomd.md.angle = import_("hoomd.md.angle")
 hoomd.md.dihedral = import_("hoomd.md.dihedral")
-hoomd.group = import_("hoomd.group")
 
 
 def create_hoomd_simulation(structure, ref_distance=1.0, ref_mass=1.0,

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -3,6 +3,7 @@ import itertools
 import numpy as np
 import operator
 from collections import namedtuple
+import json
 
 import parmed as pmd
 import mbuild as mb
@@ -363,3 +364,27 @@ def _check_hoomd_version():
     version_numbers = version.split('.')
     return version_numbers
 
+
+def save_forcefield(forcefield, filename="forcefield.json", overwrite=False):
+    """ Serialize hoomd objects to file
+
+     Save hoomd objects to a json file that can be used to
+     run a simulation. Useful for restarting a simulation
+     and double checking forfcefield paramters.
+
+     Parameters
+     ----------
+     hoomd_forcefield : list
+        List of hoomd force computes to be serialized
+
+     filename : str, optional, default=forcefield.json
+            Filesystem path in which to save the file
+
+     overwrite : bool, optional, default=False
+            Overwrite if the filename already exists
+    """
+    logger = hoomd.logging.Logger(flags=["state"])
+    logger += forcefield
+
+    with open(filename, 'w') as f:
+        json.dump(logger.log(), f, indent=2)

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -215,7 +215,7 @@ def _init_hoomd_14_pairs(structure, nl, snapshot, r_cut=1.2, ref_distance=1.0, r
 
     # Update neighborlist to exclude 1-4 interactions,
     # but impose a special_pair force to handle these pairs
-    nl.exclusions = nl.exclusions + ('1-4', )
+    nl.exclusions = nl.exclusions + ['1-4', ]
 
     if snapshot.pairs.N == 0:
         print("No 1,4 pairs found in hoomd snapshot")

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -445,7 +445,7 @@ def load_forcefield(filename="forcefield.json"):
     nlist_dict = ff["md"].pop("nlist", None)
     if nlist_dict:
         if len(nlist_dict) > 1:
-            raise Exception("More than one neighborlist is not supported")
+            raise MBuildError("More than one neighborlist is not supported")
 
         nl = _get_nlist(nlist_dict)
     else:
@@ -464,7 +464,7 @@ def load_forcefield(filename="forcefield.json"):
                         cls = Obj.from_state(state, nlist=nl)
                         forcefield.append(cls)
                     else:
-                        raise Exception(
+                        raise MBuildError(
                             f"no md.nlist in {filename}, cannot initialize {Obj}"
                         )
                 else:

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -370,6 +370,8 @@ def _check_hoomd_version():
 
 
 def save_forcefield(forcefield, nl, filename="forcefield.json", overwrite=False):
+    #TODO need to think about how/if scaling values should be saved here, or
+    # if that is on the user to figure out/solve/keep track of
     """ Serialize hoomd objects to file
 
      Save hoomd objects to a json file that can be used to

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import warnings
 import itertools
 import numpy as np
@@ -10,6 +11,7 @@ import mbuild as mb
 from mbuild.utils.sorting import natural_sort
 from mbuild.utils.io import import_
 from mbuild.utils.conversion import RB_to_OPLS
+from mbuild.exceptions import MBuildError
 
 from .hoomd_snapshot import to_hoomdsnapshot
 
@@ -388,6 +390,10 @@ def save_forcefield(forcefield, nl, filename="forcefield.json", overwrite=False)
      overwrite : bool, optional, default=False
             Overwrite if the filename already exists
     """
+
+    if Path(filename).is_file() and not overwrite:
+        raise MBuildError(f"{filename} exists")
+
     logger = hoomd.logging.Logger(flags=["state"])
     logger += nl
     logger += forcefield


### PR DESCRIPTION
### PR Summary:

Change `create_hoomd_simulation` to work with the new HOOMD v3 API. It now returns a snapshot and a forcefield (which is a list of HOOMD force compute objects). `create_hoomd_simulation` no longer needs to initialize a HOOMD `Device` or `Simulation` context.

Users can inspect and modify the returned objects as needed before constructing a simulation using them. 

### Example:

Here is an example snippet which is an adaptation of https://github.com/cmelab/CG-Tutorial

Call `create_hoomd_simulation`:
```python
from mbuild.formats.hoomd_simulation import create_hoomd_simulation
import hoomd

snapshot, forcefield, values = create_hoomd_simulation(struc, 
                                                       r_cut=1.2,
                                                       auto_scale=True)
```
Construct the integrator and GSD output:
```python
langevin = hoomd.md.methods.Langevin(filter=hoomd.filters.All(),
                                     kT=1.0,
                                     seed=1)
integrator = hoomd.md.Integrator(dt=0.0001,
                                 methods=[langevin],
                                 forces=forcefield)

gsd = hoomd.dump.GSD(filename='traj.gsd',
                     trigger=hoomd.triggers.PeriodicTrigger(int(1e5)),
                     overwrite=True)
```

Modify an object in the force field:
```python
for force in forcefield:
    if isinstance(force, hoomd.md.pair.LJ):
        force.r_cut.default = 1.2
```

Assemble and run the simulation:
```python
sim = hoomd.Simulation(hoomd.device.GPU())
sim.create_state_from_snapshot(snapshot)
sim.operations.integrator = integrator
sim.operations.add(gsd)
sim.operations.schedule()

sim.run(3e5)
```
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
