### PR TITLE
Fix Box related bug in to_parmed

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2476,10 +2476,7 @@ class Compound(object):
                 if not val:
                     box_vec_max[dim] += 0.25
                     box_vec_min[dim] -= 0.25
-            # In rare cases `AssertionError` will be raised if `mins` is set before `maxs`
-            # As a result, set `maxs` before `mins`
-            box.maxs = np.asarray(box_vec_max)
-            box.mins = np.asarray(box_vec_min)
+            box = Box(mins=box_vec_min, maxs=box_vec_max)
 
         box_vector = np.empty(6)
         if box.angles is not None:

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -667,6 +667,18 @@ class TestCompound(BaseTest):
 
         assert np.allclose(compound2.xyz, compound3.xyz)
 
+    def test_fillbox_then_parmed(self):
+        # This test would fail with the old to_parmed code (pre PR #699)
+
+        bead = mb.Compound(name="Bead")
+        box = mb.Box(mins=(2,2,2), maxs=(3,3,3))
+        bead_box = mb.fill_box(bead, 100, box)
+        bead_box_in_pmd = bead_box.to_parmed()
+
+        assert isinstance(bead_box_in_pmd, pmd.Structure)
+        assert len(bead_box_in_pmd.atoms) == 100
+        assert (bead_box_in_pmd.box == np.array([10., 10.,10. ,90., 90., 90.])).all()
+
     def test_resnames_parmed(self, h2o, ethane):
         system = mb.Compound([h2o, mb.clone(h2o), ethane])
         struct = system.to_parmed(residues=['Ethane', 'H2O'])


### PR DESCRIPTION
### PR Summary:
This PR is to fix a bug in `to_parmed` which relates to the new `mb.Box` class. 
This bug (found by @rmatsum836) happens when we trying to convert a mb.Compound to a pmd.Structure. During one step, we create a box based of Compound `self.boundingbox`, and try to re-set it maxs and mins. If the new maxs (or mins) is smaller (or greater) than the one already in that box, we have an error raised by one of our sanity check.
  
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
