### PR TITLE
Remove `nglview` as a hard dependency

### DIFF
--- a/mbuild/tests/test_utils.py
+++ b/mbuild/tests/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 import mbuild as mb
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import get_fn, import_
+from mbuild.utils.io import get_fn, import_, run_from_ipython
 from mbuild.utils.validation import assert_port_exists
 from mbuild.utils.jsutils import overwrite_nglview_default
 from mbuild.utils.geometry import wrap_coords
@@ -134,3 +134,8 @@ class TestUtils(BaseTest):
 
         assert (new_xyz[0,:] == np.array([-1,-1,1])).all()
         assert (new_xyz[1,:] == xyz[1,:]).all()
+
+    def test_has_ipython(self):
+        __IPYTHON__ = None
+        assert run_from_ipython() is False
+

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -93,7 +93,7 @@ The code at {filename}:{line_number} requires the "protobuf" package
 
 protobuf can be installed using:
 
-# conda install -c anaconda protobuf
+# conda install -c conda-forge protobuf
 
 or
 

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -206,7 +206,7 @@ try:
     has_hoomd = True
     del hoomd
 except ImportError:
-    has_hoomd  = False
+    has_hoomd = False
 
 try:
     import nglview

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -50,6 +50,18 @@ or
 # pip install nglview
 '''
 
+MESSAGES['py3Dmol'] = '''
+The code at {filename}:{line_number} requires the "py3Dmol" package
+
+py3Dmol can be installed using:
+
+# conda install -c conda-forge py3Dmol
+
+or
+
+# pip install py3Dmol
+'''
+
 MESSAGES['openbabel'] = '''
 The code at {filename}:{line_number} requires the "openbabel" package
 
@@ -76,14 +88,14 @@ or
 # pip install foyer
 '''
 
-MESSAGES['protobuf'] = ''' 
+MESSAGES['protobuf'] = '''
 The code at {filename}:{line_number} requires the "protobuf" package
 
 protobuf can be installed using:
 
 # conda install -c anaconda protobuf
 
-or 
+or
 
 # pip install protobuf
 '''
@@ -195,6 +207,20 @@ try:
     del hoomd
 except ImportError:
     has_hoomd  = False
+
+try:
+    import nglview
+    has_nglview = True
+    del nglview
+except ImportError:
+    has_nglview  = False
+
+try:
+    import py3Dmol
+    has_py3Dmol = True
+    del py3Dmol
+except ImportError:
+    has_py3Dmol  = False
 
 def get_fn(name):
     """Get the full path to one of the reference files shipped for utils.

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -220,7 +220,7 @@ try:
     has_py3Dmol = True
     del py3Dmol
 except ImportError:
-    has_py3Dmol  = False
+    has_py3Dmol = False
 
 def get_fn(name):
     """Get the full path to one of the reference files shipped for utils.

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -213,7 +213,7 @@ try:
     has_nglview = True
     del nglview
 except ImportError:
-    has_nglview  = False
+    has_nglview = False
 
 try:
     import py3Dmol

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 scipy
 packmol>=1!18.013
-nglview>=2.7
 oset
 parmed
 mdtraj


### PR DESCRIPTION
# PR Summary:

Currently we hard require `nglview` for all `mBuild` installs, which
brings along a lot of `ipython` and other `jupyter` dependencies.

These are only ever used when running `ipython` instances and wanting to
visualize a `Compound`. It seems reasonable to migrate this to a soft
dependency, and inform the user if they try to `visualize` that they
need to install `nglview` or `py3Dmol`.

We have not tested if our `run_from_ipython` method returns what we
expect, although I have never ran into an issue where it has even
behaved in an unintended manner. A test has been added to at least check
if an environment is not an ipython env.

This should also minimize the dependencies of `mBuild` for a regular
installation.


### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
