### PR TITLE
Include Box and Lattice in Data Structure docs

### DIFF
--- a/docs/data_structures.rst
+++ b/docs/data_structures.rst
@@ -34,7 +34,7 @@ Port
     :members:
 
 Box
-----
+---
 
 .. autoclass:: mbuild.box.Box
     :members:

--- a/docs/data_structures.rst
+++ b/docs/data_structures.rst
@@ -40,7 +40,7 @@ Box
     :members:
 
 Lattice
-----
+-------
 
 .. autoclass:: mbuild.lattice.Lattice
     :members:

--- a/docs/data_structures.rst
+++ b/docs/data_structures.rst
@@ -33,3 +33,14 @@ Port
 .. autoclass:: mbuild.port.Port
     :members:
 
+Box
+----
+
+.. autoclass:: mbuild.box.Box
+    :members:
+
+Lattice
+----
+
+.. autoclass:: mbuild.lattice.Lattice
+    :members:

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -25,13 +25,6 @@ Silica Interface
 .. autoclass:: mbuild.lib.recipes.silica_interface.SilicaInterface
     :members:
 
-Lattice
--------
-
-.. autoclass:: mbuild.lattice.Lattice
-    :members:
-
-
 Packing
 -------
 .. automodule:: mbuild.packing


### PR DESCRIPTION
### PR Summary:

In the `Data Structure` section of our documentation, we did not have
the `mbuild.Box` class represented.

The docstrings were there, but the rst files did not include them.
The Lattice class was also in the `Recipes` section of the docs, but
better fits in the Data Structure section.


### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
#700 