### PR TITLE
fix factor of 2 error in rmin/2

### DIFF
--- a/mbuild/formats/par_writer.py
+++ b/mbuild/formats/par_writer.py
@@ -119,8 +119,8 @@ def write_par(structure, filename):
         for atype in unique_atypes:
             # atype, 0.0, epsilon, rmin/2, 0.0, epsilon(1-4), rmin/2 (1-4)
             f.write('{:8s} {:8.3f} {:8.3f} {:8.3f} {:8.3f} {:8.3f} {:8.3f}\n'.
-                    format(atype.name, 0.0, -1 * atype.epsilon, atype.rmin / 2,
-                           0.0, -1 * sc_nb * atype.epsilon, atype.rmin / 2))
+                    format(atype.name, 0.0, -1 * atype.epsilon, atype.rmin,
+                           0.0, -1 * sc_nb * atype.epsilon, atype.rmin ))
 
         if structure.has_NBFIX():
             warnings.warn("NBFixes detected but unsupported in par writer")

--- a/mbuild/formats/par_writer.py
+++ b/mbuild/formats/par_writer.py
@@ -13,6 +13,8 @@ def write_par(structure, filename):
     node25.html)
     Furthermore, ParmEd should support writing CHARMM par, rtf, str files
     by converting the parmed.Structure into parmed.CharmmParameterSet
+
+    Parmed stores rmin/2 in "rmin"
     """
 
     # ATOMS


### PR DESCRIPTION
### PR Summary:
Fixes the problem of par_writer.py outputing rmin/4 instead of rmin/2.  Parmed stores rmin/2 in "rmin", so no additional division by 2 is needed when writing values to the CHARMM-style parameter file.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
