### PR TITLE
Data structure update

### DIFF
--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -114,7 +114,7 @@ class _BoxArray(np.ndarray):
     """Subclass of np.ndarry specifically for mb.Box
 
     This subclass is meant to be used internally to store Box attribute array.
-    This subclass is modified so that its __setitem__ method is reroute to the
+    This subclass is modified so that its __setitem__ method is rerouted to the
     corresponding setter method.
 
     Parameters

--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -15,6 +15,8 @@ class Box(object):
         Maximum x, y, z coordinates.
     lengths : np.ndarray, shape(3,), dtype=float
         Box length in x, y and z directions.
+    angles : np.ndarray, shape(3,), dtype=float, default=[90,90,90]
+        Angles defining the tilt of the box
 
     """
     def __init__(self, lengths=None, mins=None, maxs=None, angles=None):

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -67,13 +67,13 @@ class Lattice(object):
     >>> cholesterol_lattice = mb.Lattice(spacing,
     ...                                  angles=angle_values,
     ...                                  lattice_points=basis)
-
+    >>>
     >>> # The lattice based on the bravais lattice parameters of crystalline
     >>> # cholesterol was generated.
-
+    >>>
     >>> # Replicating the triclinic unit cell out 3 replications
     >>> # in x,y,z directions.
-
+    >>>
     >>> cholesterol_unit = mb.Compound()
     >>> cholesterol_unit = mb.load(get_fn('cholesterol.pdb'))
     >>> # associate basis vector with id 'cholesterol' to cholesterol Compound
@@ -96,9 +96,9 @@ class Lattice(object):
     >>> spacing = [.4123, .4123, .4123]
     >>> basis = {'Cl' : [[0., 0., 0.]], 'Cs' : [[.5, .5, .5]]}
     >>> cscl_lattice = mb.Lattice(spacing, lattice_points=basis)
-
+    >>>
     >>> # Now associate id with Compounds for lattice points and replicate 3x
-
+    >>>
     >>> cscl_dict = {'Cl' : chlorine, 'Cs' : cesium}
     >>> cscl_compound = cscl_lattice.populate(x=3, y=3, z=3,
     ...                                       compound_dict=cscl_dict)


### PR DESCRIPTION
### PR Summary:
The examples in the Lattice docstring were not properly formatted, new
lines were separated into multiple example blocks, when they should have
been a single box.

This has been updated by including newlines using the example numpydoc
syntax.

The Box class was also missing a definition for the angles
parameter/attribute, this has been updated.

A spelling mistake in the `BoxArray` class was also fixed.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
