### PR TITLE
Update element name and atom type name lengths

### DIFF
--- a/mbuild/formats/cassandramcf.py
+++ b/mbuild/formats/cassandramcf.py
@@ -280,31 +280,29 @@ def _write_atom_information(mcf_file, structure, in_ring, IG_CONSTANT_KCAL):
     sigmas = [atom.sigma for atom in structure.atoms]
 
     # Check constraints on atom type length and element name length
-    # TODO: Update these following Cassandra release
-    # to be more reasonable values
     n_unique_elements = len(set(elements))
     for element in elements:
-        if len(element) > 2:
+        if len(element) > 6:
             warnings.warn("Warning, element name {} will be shortened "
-                 "to two characters. Please confirm your final "
+                 "to six characters. Please confirm your final "
                  "MCF.".format(element))
 
-    elements = [ element[:2] for element in elements ]
+    elements = [ element[:6] for element in elements ]
     if len(set(elements)) < n_unique_elements:
         warnings.warn("Warning, the number of unique elements has been "
-              "reduced due to shortening the element name to two "
+              "reduced due to shortening the element name to six "
               "characters.")
 
     n_unique_types = len(set(types))
     for itype in types:
-        if len(itype) > 6:
-            warnings.warn("Warning, type name {} will be shortened to six "
+        if len(itype) > 20:
+            warnings.warn("Warning, type name {} will be shortened to twenty "
                       "characters as {}. Please confirm your final "
                       "MCF.".format(itype,itype[-6:]))
-        types = [ itype[-6:] for itype in types ]
+        types = [ itype[-20:] for itype in types ]
     if len(set(types)) < n_unique_types:
         warnings.warn("Warning, the number of unique atomtypes has been "
-              "reduced due to shortening the atomtype name to six "
+              "reduced due to shortening the atomtype name to twenty "
               "characters.")
 
     vdw_type = 'LJ'

--- a/mbuild/formats/cassandramcf.py
+++ b/mbuild/formats/cassandramcf.py
@@ -280,30 +280,35 @@ def _write_atom_information(mcf_file, structure, in_ring, IG_CONSTANT_KCAL):
     sigmas = [atom.sigma for atom in structure.atoms]
 
     # Check constraints on atom type length and element name length
+    max_element_length = 6
+    max_atomtype_length = 20
     n_unique_elements = len(set(elements))
     for element in elements:
-        if len(element) > 6:
+        if len(element) > max_element_length:
             warnings.warn("Warning, element name {} will be shortened "
-                 "to six characters. Please confirm your final "
-                 "MCF.".format(element))
+                 "to {} characters. Please confirm your final "
+                 "MCF.".format(element, max_element_length))
 
-    elements = [ element[:6] for element in elements ]
+    elements = [ element[:max_element_length] for element in elements ]
     if len(set(elements)) < n_unique_elements:
         warnings.warn("Warning, the number of unique elements has been "
-              "reduced due to shortening the element name to six "
-              "characters.")
+              "reduced due to shortening the element name to {} "
+              "characters.".format(max_element_length))
 
     n_unique_types = len(set(types))
     for itype in types:
-        if len(itype) > 20:
-            warnings.warn("Warning, type name {} will be shortened to twenty "
+        if len(itype) > max_atomtype_length:
+            warnings.warn("Warning, type name {} will be shortened to {} "
                       "characters as {}. Please confirm your final "
-                      "MCF.".format(itype,itype[-6:]))
-        types = [ itype[-20:] for itype in types ]
+                      "MCF.".format(
+                          itype,
+                          max_atomtype_length,
+                          itype[-max_atomtype_length:]))
+        types = [ itype[-max_atomtype_length:] for itype in types ]
     if len(set(types)) < n_unique_types:
         warnings.warn("Warning, the number of unique atomtypes has been "
-              "reduced due to shortening the atomtype name to twenty "
-              "characters.")
+              "reduced due to shortening the atomtype name to {} "
+              "characters.".format(max_atomtype_length))
 
     vdw_type = 'LJ'
     header = ('!Atom Format\n'

--- a/mbuild/tests/test_cassandramcf.py
+++ b/mbuild/tests/test_cassandramcf.py
@@ -157,7 +157,7 @@ class TestCassandraMCF(BaseTest):
 
         # Check a some atom info
         assert mcf_data[atom_section_start+1][0] == '8'
-        assert mcf_data[atom_section_start+2][1] == 'ls_135'
+        assert mcf_data[atom_section_start+2][1] == 'opls_135'
         assert mcf_data[atom_section_start+2][3] == '12.011'
         assert mcf_data[atom_section_start+2][4] == '-0.180'
         assert mcf_data[atom_section_start+2][5] == 'LJ'
@@ -246,7 +246,7 @@ class TestCassandraMCF(BaseTest):
 
         # Check a some atom info
         assert mcf_data[atom_section_start+1][0] == '12'
-        assert mcf_data[atom_section_start+2][1] == 'ls_145'
+        assert mcf_data[atom_section_start+2][1] == 'opls_145'
         assert mcf_data[atom_section_start+2][3] == '12.011'
         assert mcf_data[atom_section_start+2][4] == '-0.115'
         assert mcf_data[atom_section_start+2][5] == 'LJ'

--- a/mbuild/tests/test_cassandramcf.py
+++ b/mbuild/tests/test_cassandramcf.py
@@ -304,3 +304,25 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[fragment_conn_start+1][0] == '0'
 
 
+    def test_shorten_atomname(self, ethane):
+        from mbuild.formats.cassandramcf import write_mcf
+        import foyer
+
+        typed_ethane = foyer.forcefields.load_OPLSAA().apply(ethane)
+        typed_ethane[0].type == "C_very_very_very_extended"
+        with pytest.raises(UserWarning,
+                match=r'Warning, type name C_very_very_very_extended will be shortened'):
+            write_mcf(typed_ethane, 'ethane-opls.mcf', angle_style='harmonic',
+                    dihedral_style='opls')
+
+        mcf_data = []
+        with open('ethane-opls.mcf') as f:
+            for line in f:
+                mcf_data.append(line.strip().split())
+
+        for idx,line in enumerate(mcf_data):
+            if len(line) > 1:
+                if line[1] == 'Atom_Info':
+                    atom_section_start = idx
+
+        assert mcf_data[atom_section_start+2][1] == "C_very_very_very_ex"

--- a/mbuild/tests/test_cassandramcf.py
+++ b/mbuild/tests/test_cassandramcf.py
@@ -309,11 +309,9 @@ class TestCassandraMCF(BaseTest):
         import foyer
 
         typed_ethane = foyer.forcefields.load_OPLSAA().apply(ethane)
-        typed_ethane[0].type == "C_very_very_very_extended"
-        with pytest.raises(UserWarning,
-                match=r'Warning, type name C_very_very_very_extended will be shortened'):
-            write_mcf(typed_ethane, 'ethane-opls.mcf', angle_style='harmonic',
-                    dihedral_style='opls')
+        typed_ethane[0].type = "C_very_very_very_extended"
+        write_mcf(typed_ethane, 'ethane-opls.mcf', angle_style='harmonic',
+                dihedral_style='opls')
 
         mcf_data = []
         with open('ethane-opls.mcf') as f:
@@ -325,4 +323,4 @@ class TestCassandraMCF(BaseTest):
                 if line[1] == 'Atom_Info':
                     atom_section_start = idx
 
-        assert mcf_data[atom_section_start+2][1] == "C_very_very_very_ex"
+        assert mcf_data[atom_section_start+2][1] == "y_very_very_extended"


### PR DESCRIPTION
Changes concurrent with release of Cassandra-1.2.2
which supports up to six characters for element
names and twenty characters for atom names.