### PR TITLE
Typecast float to int to prevent NaNs in np.arange

### DIFF
--- a/mbuild/pattern.py
+++ b/mbuild/pattern.py
@@ -277,7 +277,7 @@ class SpherePattern(Pattern):
         phi = (1 + np.sqrt(5)) / 2   # the golden ratio
         long_incr = 2*np.pi / phi    # how much to increment the longitude
         dz = 2.0 / float(n)          # a unit sphere has diameter 2
-        bands = np.arange(n)         # each band will have one point placed on it
+        bands = np.arange(int(n))         # each band will have one point placed on it
         z = bands * dz - 1.0 + (dz/2.0)  # the height z of each band/point
         r = np.sqrt(1.0 - z*z)         # project onto xy-plane
         az = bands * long_incr       # azimuthal angle of point modulo 2 pi

--- a/mbuild/tests/test_pattern.py
+++ b/mbuild/tests/test_pattern.py
@@ -57,6 +57,11 @@ class TestPattern(BaseTest):
         pattern = mb.SpherePattern(100)
         assert len(pattern) == 100
 
+    def test_sphere_float(self):
+        pattern = mb.SpherePattern(n=100.2)
+        assert len(pattern) == 100
+        assert not np.any(np.isnan(pattern.points))
+
     def test_disk(self):
         pattern = mb.DiskPattern(100)
         assert len(pattern) == 100


### PR DESCRIPTION
### PR Summary:

In the `SpherePattern` class, `n` is assumed to be an integer value for
the number of points on a sphere. However that was not enforced. This
could lead to floating point math issues with the numpy `arange`
function. See issue
[467](https://github.com/mosdef-hub/mbuild/issues/467) for a more
detailed disucssion.

This patch typecasts `n` to an integer when passing to `numpy.arange`.
This appears to prevent floating point overflow, preventing NaNs for the
generated points on the SpherePattern.


### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?

Closes #467 
