### PR TITLE
Build and Publish Docker Image (latest) to dockerhub (Closes #727)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,20 +19,19 @@ RUN conda update conda -yq && \
 	conda config --add channels omnia && \
 	conda config --add channels conda-forge && \
 	conda config --add channels mosdef && \
-	conda create -n mbuild-docker python=$PY_VERSION && \
 	. /opt/conda/etc/profile.d/conda.sh && \
+	conda create -n mbuild-docker python=$PY_VERSION nomkl --file requirements-dev.txt && \
 	conda activate mbuild-docker && \
-	conda install python=$PY_VERSION nomkl --file requirements-dev.txt && \
         python setup.py install && \
 	echo "source activate mbuild-docker" >> \
 	/home/anaconda/.profile && \
 	conda clean -afy && \
+	mkdir /home/anaconda/mbuild-notebooks && \
 	chown -R anaconda:anaconda /mbuild && \
 	chown -R anaconda:anaconda /opt && \
 	chown -R anaconda:anaconda /home/anaconda
 
-USER anaconda
 
 WORKDIR /home/anaconda
 
-CMD /bin/sh --login -i
+CMD /bin/su anaconda -s /bin/sh -l

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,38 @@
 ARG PY_VERSION=3.7
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:4.8.2-alpine AS builder
 
 EXPOSE 8888
 
 LABEL maintainer.name="mosdef-hub"\
       maintainer.url="https://mosdef.org"
 
-SHELL ["/bin/bash", "-c"]
+ENV PATH /opt/conda/bin:$PATH
+
+USER root
 
 ADD . /mbuild
 
 WORKDIR /mbuild
 
-RUN conda update conda -yq
+RUN conda update conda -yq && \
+	conda config --set always_yes yes --set changeps1 no && \
+	conda config --add channels omnia && \
+	conda config --add channels conda-forge && \
+	conda config --add channels mosdef && \
+	conda create -n mbuild-docker python=$PY_VERSION && \
+	. /opt/conda/etc/profile.d/conda.sh && \
+	conda activate mbuild-docker && \
+	conda install python=$PY_VERSION nomkl --file requirements-dev.txt && \
+        python setup.py install && \
+	echo "conda activate mbuild-docker" >> \
+	/home/anaconda/.profile && \
+	conda clean -afy && \
+	chown -R anaconda:anaconda /mbuild && \
+	chown -R anaconda:anaconda /opt && \
+	chown -R anaconda:anaconda /home/anaconda
 
-RUN conda config --set always_yes yes --set changeps1 no
-
-RUN conda config --add channels omnia
-
-RUN conda config --add channels janschulz
-
-RUN conda config --add channels conda-forge
-
-RUN conda config --add channels mosdef
-
-RUN conda create -n mbuild-docker python=$PY_VERSION --file requirements-dev.txt
-
-RUN source activate mbuild-docker && python setup.py install
-
-RUN echo "source activate mbuild-docker" >> ~/.bashrc
-
-ENV PATH "/opt/conda/envs/mbuild-docker/bin:$PATH"
+USER anaconda
 
 WORKDIR /scratch
+
+CMD [ "/bin/sh", "--login -i" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+ARG PY_VERSION=3.7
+FROM continuumio/miniconda3
+
+EXPOSE 8888
+
+LABEL maintainer.name="mosdef-hub"\
+      maintainer.url="https://mosdef.org"
+
+SHELL ["/bin/bash", "-c"]
+
+ADD . /mbuild
+
+WORKDIR /mbuild
+
+RUN conda update conda -yq
+
+RUN conda config --set always_yes yes --set changeps1 no
+
+RUN conda config --add channels omnia
+
+RUN conda config --add channels janschulz
+
+RUN conda config --add channels conda-forge
+
+RUN conda config --add channels mosdef
+
+RUN conda create -n mbuild-docker python=$PY_VERSION --file requirements-dev.txt
+
+RUN source activate mbuild-docker && python setup.py install
+
+RUN echo "source activate mbuild-docker" >> ~/.bashrc
+
+ENV PATH "/opt/conda/envs/mbuild-docker/bin:$PATH"
+
+WORKDIR /scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN conda update conda -yq && \
 	conda activate mbuild-docker && \
 	conda install python=$PY_VERSION nomkl --file requirements-dev.txt && \
         python setup.py install && \
-	echo "conda activate mbuild-docker" >> \
+	echo "source activate mbuild-docker" >> \
 	/home/anaconda/.profile && \
 	conda clean -afy && \
 	chown -R anaconda:anaconda /mbuild && \
@@ -33,6 +33,6 @@ RUN conda update conda -yq && \
 
 USER anaconda
 
-WORKDIR /scratch
+WORKDIR /home/anaconda
 
-CMD [ "/bin/sh", "--login -i" ]
+CMD /bin/sh --login -i

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Alternatively, you can also start a Bourne shell directly:
 $ docker run -it --name mbuild mosdef/mbuild:latest
 ```
 
-To learn more about using `mBuild` with docker, please refer to the documentation [here](https://mbuild.mosdef.org/en/stable/docker.html).
+To learn more about using `mBuild` with docker, please refer to the documentation [here](https://mbuild.mosdef.org/en/latest/docker.html).
 
 #### Tutorials
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,18 @@ If you use this package, please cite [our paper](http://dx.doi.org/10.1007/978-9
 #### Quick Start with Docker
 To use `mbuild` in a jupyter-notebook that runs from a docker container with all the dependencies installed use the following command:
 
-```bash
+```sh
 $ docker pull mosdef/mbuild:latest
-$ docker run -it --name mbuild -p 8888:8888  mosdef/mbuild:latest jupyter notebook --ip="*" --allow-root
+$ docker run -it --name mbuild -p 8888:8888 mosdef/mbuild:latest\
+  /opt/conda/envs/mbuild-docker/bin/jupyter notebook --ip="*"
 ```
 
-Alternatively, you can also start a bash shell directly:
-```bash
+Alternatively, you can also start a Bourne shell directly:
+```sh
 $ docker run -it --name mbuild mosdef/mbuild:latest
 ```
 
-Note: Instead of using `latest`, you can use the image `mosdef/mbuild:stable` for stable released version of `mbuild`.
+Note: Instead of using `latest`, you can use the image `mosdef/mbuild:stable` for most recent stable release of `mbuild`.
 
 #### Tutorials
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ If you use this package, please cite [our paper](http://dx.doi.org/10.1007/978-9
 }
 ```
 
+#### Quick Start with Docker
+To use `mbuild` in a jupyter-notebook that runs from a docker container with all the dependencies installed use the following command:
+
+```bash
+$ docker pull mosdef/mbuild:latest
+$ docker run -it --name mbuild -p 8888:8888  mosdef/mbuild:latest jupyter notebook --ip="*" --allow-root
+```
+
+Alternatively, you can also start a bash shell directly:
+```bash
+$ docker run -it --name mbuild mosdef/mbuild:latest
+```
+
+Note: Instead of using `latest`, you can use the image `mosdef/mbuild:stable` for stable released version of `mbuild`.
+
 #### Tutorials
 
 *Interactive tutorials can be found here:* 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ To use `mbuild` in a jupyter-notebook that runs from a docker container with all
 
 ```sh
 $ docker pull mosdef/mbuild:latest
-$ docker run -it --name mbuild -p 8888:8888 mosdef/mbuild:latest\
-  /opt/conda/envs/mbuild-docker/bin/jupyter notebook --no-browser --ip="0.0.0.0"
+$ docker run -it --name mbuild -p 8888:8888 mosdef/mbuild:latest su anaconda -s\
+      /bin/sh -l -c "jupyter-notebook --no-browser --ip="0.0.0.0" --notebook-dir\
+      /home/anaconda/mbuild-notebooks
 ```
 
 Alternatively, you can also start a Bourne shell directly:
@@ -46,7 +47,7 @@ Alternatively, you can also start a Bourne shell directly:
 $ docker run -it --name mbuild mosdef/mbuild:latest
 ```
 
-Note: Instead of using `latest`, you can use the image `mosdef/mbuild:stable` for most recent stable release of `mbuild`.
+To learn more about using `mBuild` with docker, please refer to the documentation [here](https://mbuild.mosdef.org/en/stable/docker.html).
 
 #### Tutorials
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To use `mbuild` in a jupyter-notebook that runs from a docker container with all
 ```sh
 $ docker pull mosdef/mbuild:latest
 $ docker run -it --name mbuild -p 8888:8888 mosdef/mbuild:latest\
-  /opt/conda/envs/mbuild-docker/bin/jupyter notebook --ip="*"
+  /opt/conda/envs/mbuild-docker/bin/jupyter notebook --no-browser --ip="0.0.0.0"
 ```
 
 Alternatively, you can also start a Bourne shell directly:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,6 +187,8 @@ stages:
 
           - task: Docker@2
             displayName: Build and Push
-            repository: tumesh/mbuild
-            tags: demo
+            inputs:
+              command: buildAndPush
+              repository: tumesh/mbuild
+              tags: demo
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/727-docker-build-action'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,5 @@
 trigger:
   - master
-  - 727-docker-build-action
 
 pr:
   autoCancel: true
@@ -174,7 +173,7 @@ stages:
 
   - stage: Docker
     dependsOn: Test
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/727-docker-build-action'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'Schedule'))
     pool:
       vmImage: 'ubuntu-latest'
     jobs:
@@ -191,7 +190,7 @@ stages:
             inputs:
               command: buildAndPush
               repository: mosdef/mbuild
-              tags: latest-demo
+              tags: latest
 
           - task: Docker@2
             displayName: Logout

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
   - master
+  - 727-docker-build-action
 
 pr:
   autoCancel: true
@@ -15,156 +16,177 @@ schedules:
     - master
   always: true
 
-jobs:
-  - job: NoBleeding
-    strategy:
-      matrix:
-        Python36Ubuntu:
-          imageName: 'ubuntu-latest'
-          python.version: 3.6
-        Python37Ubuntu:
-          imageName: 'ubuntu-latest'
-          python.version: 3.7
-        Python36macOS:
-          imageName: 'macOS-latest'
-          python.version: 3.6
-        Python37macOS:
-          imageName: 'macOS-latest'
-          python.version: 3.7
+stages:
+  - stage: Test
+    jobs:
+      - job: NoBleeding
+        strategy:
+          matrix:
+            Python36Ubuntu:
+              imageName: 'ubuntu-latest'
+              python.version: 3.6
+            Python37Ubuntu:
+              imageName: 'ubuntu-latest'
+              python.version: 3.7
+            Python36macOS:
+              imageName: 'macOS-latest'
+              python.version: 3.6
+            Python37macOS:
+              imageName: 'macOS-latest'
+              python.version: 3.7
 
-    pool:
-      vmImage: $(imageName)
+        pool:
+          vmImage: $(imageName)
 
-    steps:
-      - bash: echo "##vso[task.prependpath]$CONDA/bin"
-        displayName: Add Conda to path
+        steps:
+          - bash: echo "##vso[task.prependpath]$CONDA/bin"
+            displayName: Add Conda to path
 
-      - bash: sudo chown -R $USER $CONDA
-        condition: eq( variables['Agent.OS'], 'Darwin' )
-        displayName: Take ownership of conda installation
+          - bash: sudo chown -R $USER $CONDA
+            condition: eq( variables['Agent.OS'], 'Darwin' )
+            displayName: Take ownership of conda installation
 
-      - bash: |
-          conda config --set always_yes yes --set changeps1 no
-          conda config --add channels omnia
-          conda config --add channels janschulz
-          conda config --add channels conda-forge
-          conda config --add channels mosdef
-        displayName: Add relavent Channels
+          - bash: |
+              conda config --set always_yes yes --set changeps1 no
+              conda config --add channels omnia
+              conda config --add channels janschulz
+              conda config --add channels conda-forge
+              conda config --add channels mosdef
+            displayName: Add relavent Channels
 
-      - bash: |
-          conda update -c defaults conda
-          conda update --all
-          conda create -n test-environment
-          source activate test-environment
-          conda install --yes python=$(python.version) --file requirements-dev.txt
-          conda install --yes python=$(python.version) --file requirements-dev.txt
-          pip install -e .
-        displayName: Create Conda env, Activate, Install dependencies, Install Branch
+          - bash: |
+              conda update -c defaults conda
+              conda update --all
+              conda create -n test-environment
+              source activate test-environment
+              conda install --yes python=$(python.version) --file requirements-dev.txt
+              conda install --yes python=$(python.version) --file requirements-dev.txt
+              pip install -e .
+            displayName: Create Conda env, Activate, Install dependencies, Install Branch
 
-      - bash: |
-          source activate test-environment
-          pip install pytest-azurepipelines
-          python -m pytest -v --nbval --nbval-lax --pyargs mbuild --cov=mbuild --no-coverage-upload
-        displayName: Run Tests
-        
-      - bash: |
-          source activate test-environment
-          coverage xml
-          codecov --file ./coverage.xml --token 2b64a140-cfdd-4d0f-b1ba-33d34b8bf522
-          coverage html
-        condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.7' ) )
-        displayName: Upload Coverage Report
-      
-      - task: PublishCodeCoverageResults@1
-        inputs: 
-          codeCoverageTool: Cobertura
-          summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-          reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
-        condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.7' ) )
-        displayName: Publish Coverage Report
+          - bash: |
+              source activate test-environment
+              pip install pytest-azurepipelines
+              python -m pytest -v --nbval --nbval-lax --pyargs mbuild --cov=mbuild --no-coverage-upload
+            displayName: Run Tests
 
-          
+          - bash: |
+              source activate test-environment
+              coverage xml
+              codecov --file ./coverage.xml --token 2b64a140-cfdd-4d0f-b1ba-33d34b8bf522
+              coverage html
+            condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.7' ) )
+            displayName: Upload Coverage Report
 
-  - job: Windows_no_bleeding
-    pool:
-      vmImage: 'windows-latest'
-    strategy:
-      matrix:
-        Python36:
-          python.version: 3.6
-        Python37:
-          python.version: 3.7
+          - task: PublishCodeCoverageResults@1
+            inputs:
+              codeCoverageTool: Cobertura
+              summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+              reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+            condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.7' ) )
+            displayName: Publish Coverage Report
 
-    steps:
-      - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-        displayName: Add Conda to path
 
-      - script: |
-          conda config --set always_yes yes --set changeps1 no
-          conda config --add channels omnia
-          conda config --add channels janschulz
-          conda config --add channels conda-forge
-          conda config --add channels mosdef
-        displayName: Add relavent channels
 
-      - script: |
-          conda update -c defaults conda
-          conda update --all
-          conda create -n test-environment
-          call activate test-environment
-          conda install --yes python=$(python.version) --file requirements-dev.txt
-          conda install --yes python=$(python.version) --file requirements-dev.txt
-        displayName: Create Conda env, Activate, Install dependencies
-        
-      - script: |
-          call activate test-environment
-          python -m pip --version
-          python -m pip --verbose install -e .
-        displayName: Install mBuild
+      - job: Windows_no_bleeding
+        pool:
+          vmImage: 'windows-latest'
+        strategy:
+          matrix:
+            Python36:
+              python.version: 3.6
+            Python37:
+              python.version: 3.7
 
-      - script: |
-          call activate test-environment
-          python -m pip install pytest-azurepipelines
-          python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report=html --pyargs mbuild --no-coverage-upload
-        displayName: Run Tests
+        steps:
+          - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+            displayName: Add Conda to path
 
-  - job: LinuxBleedingFoyer
+          - script: |
+              conda config --set always_yes yes --set changeps1 no
+              conda config --add channels omnia
+              conda config --add channels janschulz
+              conda config --add channels conda-forge
+              conda config --add channels mosdef
+            displayName: Add relavent channels
 
+          - script: |
+              conda update -c defaults conda
+              conda update --all
+              conda create -n test-environment
+              call activate test-environment
+              conda install --yes python=$(python.version) --file requirements-dev.txt
+              conda install --yes python=$(python.version) --file requirements-dev.txt
+            displayName: Create Conda env, Activate, Install dependencies
+
+          - script: |
+              call activate test-environment
+              python -m pip --version
+              python -m pip --verbose install -e .
+            displayName: Install mBuild
+
+          - script: |
+              call activate test-environment
+              python -m pip install pytest-azurepipelines
+              python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report=html --pyargs mbuild --no-coverage-upload
+            displayName: Run Tests
+
+      - job: LinuxBleedingFoyer
+
+        pool:
+          vmImage: 'ubuntu-latest'
+
+        steps:
+          - bash: echo "##vso[task.prependpath]$CONDA/bin"
+            displayName: Add Conda to path
+
+          - bash: |
+              conda config --set always_yes yes --set changeps1 no
+              conda config --add channels omnia
+              conda config --add channels janschulz
+              conda config --add channels conda-forge
+              conda config --add channels mosdef
+              conda update -c defaults conda
+              conda update --all
+              conda create -n  bleeding-test-environment
+              source activate bleeding-test-environment
+              conda install --yes python=3.7 --file requirements-dev.txt
+              conda install --yes python=3.7 --file requirements-dev.txt
+            displayName: Create a new bleeding test environment
+
+          - bash: |
+              source activate bleeding-test-environment
+              git clone https://github.com/mosdef-hub/foyer.git
+              cd foyer
+              conda install --yes --file requirements-dev.txt
+              conda install --yes --file requirements-dev.txt
+              pip install -e .
+              pip uninstall mbuild -y
+              cd ..
+              pip install -e .
+            displayName: clone foyer, install foyer, install mbuild
+
+          - bash: |
+              source activate bleeding-test-environment
+              pip install pytest-azurepipelines
+              python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report= --pyargs mbuild --no-coverage-upload
+            displayName: Run Tests
+
+  - stage: Docker
+    dependsOn: Test
     pool:
       vmImage: 'ubuntu-latest'
+    jobs:
+      - job: publishDocker
+        steps:
+          - task: Docker@2
+            displayName: Login to docker hub
+            inputs:
+              command: login
+              containerRegistry: testdockerhubconnection
 
-    steps:
-      - bash: echo "##vso[task.prependpath]$CONDA/bin"
-        displayName: Add Conda to path
-
-      - bash: |
-          conda config --set always_yes yes --set changeps1 no
-          conda config --add channels omnia
-          conda config --add channels janschulz
-          conda config --add channels conda-forge
-          conda config --add channels mosdef
-          conda update -c defaults conda
-          conda update --all
-          conda create -n  bleeding-test-environment
-          source activate bleeding-test-environment
-          conda install --yes python=3.7 --file requirements-dev.txt
-          conda install --yes python=3.7 --file requirements-dev.txt
-        displayName: Create a new bleeding test environment
-
-      - bash: |
-          source activate bleeding-test-environment
-          git clone https://github.com/mosdef-hub/foyer.git
-          cd foyer
-          conda install --yes --file requirements-dev.txt
-          conda install --yes --file requirements-dev.txt
-          pip install -e .
-          pip uninstall mbuild -y
-          cd ..
-          pip install -e .
-        displayName: clone foyer, install foyer, install mbuild
-
-      - bash: |
-          source activate bleeding-test-environment
-          pip install pytest-azurepipelines
-          python -m pytest -v --nbval --nbval-lax --cov=mbuild --cov-report= --pyargs mbuild --no-coverage-upload
-        displayName: Run Tests
+          - task: Docker@2
+            displayName: Build and Push
+            repository: tumesh/mbuild
+            tags: demo
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/727-docker-build-action'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
   - master
+  - 727-docker-build-action
 
 pr:
   autoCancel: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
   - master
+  - 727-docker-build-action
 
 pr:
   autoCancel: true
@@ -190,7 +191,7 @@ stages:
             inputs:
               command: buildAndPush
               repository: mosdef/mbuild
-              tags: latest
+              tags: latest-demo
 
           - task: Docker@2
             displayName: Logout

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,5 @@
 trigger:
   - master
-  - 727-docker-build-action
 
 pr:
   autoCancel: true
@@ -174,7 +173,7 @@ stages:
 
   - stage: Docker
     dependsOn: Test
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/727-docker-build-action'))
     pool:
       vmImage: 'ubuntu-latest'
     jobs:

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,0 +1,74 @@
+Using mBuild with Docker
+========================
+
+As much of scientific software development happens in unix platforms, to avoid the quirks of development dependent on system you use, a recommended way is to use docker or other containerization technologies. This section is a how to guide on using mBuild with docker.
+
+Prerequisites
+-------------
+A docker installation in your machine. Follow this `link <https://docs.docker.com/get-docker/>`_ to get a docker installation working on your machine.
+
+Quick Start
+-----------
+After you have a working docker installation, please use the following command to use run a jupyter-notebook with all the dependencies for `mBuild` installed:
+
+.. code-block:: bash
+
+    $ docker pull mosdef/mbuild:latest
+    $ docker run -it --name mbuild -p 8888:8888 mosdef/mbuild:latest su anaconda -s\
+      /bin/sh -l -c "jupyter-notebook --no-browser --ip="0.0.0.0" --notebook-dir\
+      /home/anaconda/mbuild-notebooks"
+
+
+If every thing happens correctly, you should a be able to start a `jupyter-notebook` server running in a python environment with all the dependencies for `mBuild` installed.
+
+Alternatively, you can also start a Bourne shell to use python from the container's terminal:
+
+.. code-block:: bash
+
+    $ docker run -it --name mbuild mosdef/mbuild:latest
+
+.. important::
+
+    The instructions above will start a docker container but containers by nature are ephemeral, so any filesystem changes (like adding a new notebook) you make will only persist till the end of the container's lifecycle. If the container is removed, any changes or code additions will not persist.
+
+Persisting User Volumes
+-----------------------
+If you will be using `mBuild` from a docker container, a recommended way is to mount what are called user volumes in the container. User volumes will provide a way to persist all filesystem/code additions made to a container regardless of the container lifecycle. For example, you might want to create a directory called `mbuild-notebooks` in your local system, which will store all your `mBuild` notebooks/code. In order to make that accessible to the container(where the notebooks will be created/edited), use the following steps:
+
+
+1. Create a directory in your filesystem
+
+.. code-block:: bash
+
+    $ mkdir -p /path/to/mbuild-notebooks
+    $ cd /path/to/mbuild-notebooks
+
+2. Define an entry-point script. Inside `mbuild-notebooks` in your local file system create a file called :code:`dir_entrypoint.sh` and paste the following content.
+
+.. code-block:: bash
+
+    #!/bin/sh
+
+    chown -R anaconda:anaconda /home/anaconda/mbuild-notebooks
+
+    su anaconda -s /bin/sh -l -c "jupyter-notebook --no-browser --ip="0.0.0.0" --notebook-dir /home/anaconda/mbuild-notebooks"
+
+3. Run docker image for `mbuild`
+
+.. code-block:: bash
+
+    $ docker run -it --name mbuild -p 8888:8888 --entrypoint /home/anaconda/mbuild-notebooks/dir_entrypoint.sh -v /home/umesh/mbuild-notebooks:/home/anaconda/mbuild-notebooks mosdef/mbuild:latest
+
+
+Cleaning Up
+-----------
+You can remove the created container by using the following command:
+
+.. code-block:: bash
+
+    $ docker container rm mbuild
+
+.. note::
+
+    Instead of using `latest`, you can use the image :code:`mosdef/mbuild:stable` for most recent stable release of `mBuild` and run the tutorials.
+

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -5,7 +5,7 @@ As much of scientific software development happens in unix platforms, to avoid t
 
 Prerequisites
 -------------
-A docker installation in your machine. Follow this `link <https://docs.docker.com/get-docker/>`_ to get a docker installation working on your machine.
+A docker installation in your machine. Follow this `link <https://docs.docker.com/get-docker/>`_ to get a docker installation working on your machine. If you are not familiar with docker and want to get started with docker, the Internet is full of good tutorials like the ones `here <https://docker-curriculum.com/>`_ and `here <https://www.youtube.com/watch?v=zJ6WbK9zFpI&feature=youtu.be>`_.
 
 Quick Start
 -----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ different licenses. See those files for their specific terms.
 
 .. toctree::
     installation
+    docker
     tutorials/tutorials
     data_structures
     coordinate_transforms


### PR DESCRIPTION
This PR addresses #727, By adding dividing azure-pipeline into two stages:
1. Test: Runs all the tests as is
2. Docker: Does the docker build and publish image (`mosdef/mbuild:latest`)(If the tests pass and the branch is `master`). 

To Dos:
1. Add docker service connection for logging into `mosdef` docker account. This should be done in azure pipeline settings.

Also, the current Image size is around 2.79 GB in my machine. That should be reduced to a sustainable size.