### PR TITLE
Add Compound.box, remove Compound.periodicity

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -216,7 +216,7 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2,
         filled = Compound()
         filled = _create_topology(filled, compound, n_compounds)
         filled.update_coordinates(filled_xyz.name, update_port_locations=update_port_locations)
-        filled.periodicity = np.asarray(box.lengths, dtype=np.float32)
+        filled.box = box
 
     # ensure that the temporary files are removed from the machine after filling
     finally:

--- a/mbuild/periodic_kdtree.py
+++ b/mbuild/periodic_kdtree.py
@@ -93,10 +93,10 @@ class PeriodicCKDTree(KDTree):
 
     Parameters
     ----------
-    bounds : array_like, shape (k,)
-        Size of the periodic box along each spatial dimension.  A
-        negative or zero size for dimension k means that space is not
-        periodic along k.
+    box : mbuild.Box
+        The box object containing the periodicity of the system.
+        A zero or negative value for one of the box lengths
+        means that the space is not periodic in that dimension.
     data : array-like, shape (n,m)
         The n data points of dimension mto be indexed. This array is
         not copied unless this is necessary to produce a contiguous
@@ -113,10 +113,17 @@ class PeriodicCKDTree(KDTree):
     query point and a data point to half the smallest box dimension.
     """
 
-    def __init__(self, data, leafsize=10, bounds=None):
+    def __init__(self, data, leafsize=10, box=None):
         # Map all points to canonical periodic image.
-        if bounds is None:
+        if box is None:
             bounds = np.array([0.0, 0.0, 0.0])
+        elif np.allclose(box.angles, 90.0):
+            bounds = box.lengths
+        else:
+            raise NotImplementedError(
+                "Periodic KCDTree search only implemented"
+                "for orthorhombic periodic boundaries"
+            )
         self.bounds = np.array(bounds)
         self.real_data = np.asarray(data)
 

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -125,8 +125,6 @@ class TestBox(BaseTest):
                    [0.474, 0.0049, -0.7277],
                    [0.518, 0.0312, -0.8946],
                    [0.488, 0.1676, -0.7896]])
-        # Set periodicity
-        ethane.periodicity = np.array([0.767, 0.703, 0.710])
         # Convert compound to pmd.structure to set Box info
         # Conversion should happen without error
         ethane.to_parmed()


### PR DESCRIPTION
### PR Summary:

Opening this as a draft PR to get feedback. This is a first attempt at the long-discussed `Compound.box` attribute (#707), that represents a simulation box (*not* a bounding box). I remove the `Compound.periodicity` attribute since that seems duplicative of the periodicity of a system is presumably normally defined by its simulation box. 

One of my biggest motivations for this PR is to be able to support non-orthorhombic simulation boxes. Right now that information is lossy if converting to/from parmed/mdtraj or reading from file.

The new `Compound.box` attribute is a `mbuild.Box`. Therefore, we can store `box.lengths` and `box.angles`. This will enable non-orthorhombic PBC in the future. For now I throw an error if that functionality is used with `box.angles != 90`. When using `Compound.add(child)`, the default behavior is to keep the `Compound.box`, unless `Compound.box is None` and `child.box is not None`. There is also a flag to override that and use `child.box` no matter what.

Tests are currently *not* passing; both failing tests come from the JSON writer. I was a bit intimidated and decided to hold off until everyone agreed on the approach. 

LMK what you all think!

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
