### PR TITLE
Fix unnecessary warnings when load from SMILES

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -174,7 +174,7 @@ def load(filename_or_object, relative_to_module=None, compound=None, coords_only
         temp_file = os.path.join(tmp_dir, 'smiles_to_mol2_intermediate.mol2')
         mymol.make3D()
         compound = Compound()
-        compound.from_pybel(mymol, infer_hierarchy=infer_hierarchy)
+        compound.from_pybel(mymol, infer_hierarchy=infer_hierarchy, ignore_box_warn=True)
 
     else:
         traj = md.load(filename_or_object, **kwargs)
@@ -2673,7 +2673,7 @@ class Compound(object):
         return pybelmol
 
     def from_pybel(self, pybel_mol, use_element=True, coords_only=False,
-            infer_hierarchy=True):
+            infer_hierarchy=True, ignore_box_warn=False):
         """Create a Compound from a Pybel.Molecule
 
         Parameters
@@ -2688,7 +2688,8 @@ class Compound(object):
             with other conversion functions
         infer_hierarchy : bool, optional, default=True
             If True, infer hierarchy from residues
-
+        ignore_box_warn : bool, optional, default=False
+            If True, ignore warning if no box is present.
         """
         openbabel = import_("openbabel")
         self.name = pybel_mol.title.split('.')[0]
@@ -2743,7 +2744,8 @@ class Compound(object):
                                 pybel_mol.unitcell.GetGamma()])
             self.periodicity = box.lengths
         else:
-            warn("No unitcell detected for pybel.Molecule {}".format(pybel_mol))
+            if not ignore_box_warn:
+                warn("No unitcell detected for pybel.Molecule {}".format(pybel_mol))
 #       TODO: Decide how to gather PBC information from openbabel. Options may
 #             include storing it in .periodicity or writing a separate function
 #             that returns the box.

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -142,6 +142,19 @@ def import_(module):
             return pybel
         except ModuleNotFoundError:
             pass
+    if module == 'openbabel':
+        try:
+            return importlib.import_module('openbabel.openbabel')
+        except ModuleNotFoundError:
+            pass
+        try:
+            openbabel = importlib.import_module('openbabel')
+            msg = ('openbabel 2.0 detected and will be dropped in a future '
+                   'release. Consider upgrading to 3.x.')
+            warnings.warn(msg, DeprecationWarning)
+            return pybel
+        except ModuleNotFoundError:
+            pass
     try:
         return importlib.import_module(module)
     except ImportError as e:
@@ -181,7 +194,7 @@ except ImportError:
     has_gsd = False
 
 try:
-    import openbabel
+    from openbabel import openbabel
     has_openbabel = True
     del openbabel
 except ImportError:


### PR DESCRIPTION
### PR Summary:

Closes #706.

* Update openbabel import to avoid import deprecation warning
* Add ignore_box_warn flag to from_pybel so that the
      no box present warning can be ignored when creating
      an mbuild.Compound from a SMILES string

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
