### PR TITLE
Updates to parmed mass handling

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -13,7 +13,7 @@ from mdtraj.core.element import get_by_symbol
 import numpy as np
 from oset import oset as OrderedSet
 import parmed as pmd
-from parmed.periodic_table import AtomicNum, element_by_name, Mass, Element
+from parmed.periodic_table import AtomicNum, Mass, Element
 
 from mbuild.bond_graph import BondGraph
 from mbuild.box import Box

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2436,11 +2436,13 @@ class Compound(object):
                 try:
                     atomic_number = AtomicNum[atom.name.capitalize()]
                 except KeyError:
-                    element = element_by_name(atom.name.capitalize())
                     if name not in guessed_elements:
                         warn(
-                            'Guessing that "{}" is element: "{}"'.format(
-                                atom, element))
+                            'Cannot infer mass of "{}" since its name does '
+                            'not match the two-letter code of any known '
+                            'elements. Setting mass to 0.0'.format(atom)
+                        )
+                        element = "EP"
                         guessed_elements.add(name)
                 else:
                     element = atom.name.capitalize()

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1117,3 +1117,8 @@ class TestCompound(BaseTest):
         filled.save('methane.sdf')
         sdf_string = mb.load('methane.sdf')
         assert np.allclose(filled.xyz, sdf_string.xyz, atol=1e-5)
+
+    def test_parmed_mass(self):
+        compound = mb.Compound()
+        pmd = compound.to_parmed()
+        assert pmd.atoms[0].mass == 0.0

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -223,3 +223,51 @@ class TestPacking(BaseTest):
         butane = Alkane(n=4)
         butane.remove(butane[-1])
         box = mb.fill_box(butane, n_compounds=10, density=1)
+
+    def test_validate_inputs(self, h2o):
+        with pytest.raises(TypeError, match=r"must be an mbuild.Compound"):
+            filled = mb.fill_box('h2o', n_compounds = 10, box=[1,1,1])
+        with pytest.raises(TypeError, match=r"must be an int or"):
+            filled = mb.fill_box(h2o, n_compounds = 10.2, box=[1,1,1])
+        with pytest.raises(TypeError, match=r"must be a bool or"):
+            filled = mb.fill_box(h2o, n_compounds = 10, box=[1,1,1], fix_orientation=2)
+        with pytest.raises(TypeError, match=r"must be a list with"):
+            filled = mb.fill_box([h2o, h2o], n_compounds = [10,2], box=[1,1,1], compound_ratio=1)
+        with pytest.raises(TypeError, match=r"must be a float or"):
+            filled = mb.fill_box(h2o, n_compounds = 10, box=[1,1,1], compound_mass='5')
+        with pytest.raises(ValueError, match=r"must be of equal"):
+            filled = mb.fill_box([h2o, h2o], n_compounds = 10, box=[1,1,1])
+        with pytest.raises(ValueError, match=r"must be of equal"):
+            filled = mb.fill_box([h2o, h2o], n_compounds = [10,10], box=[1,1,1], fix_orientation=[True])
+        with pytest.raises(ValueError, match=r"must be of equal"):
+            filled = mb.fill_box([h2o, h2o], n_compounds = [10,10], box=[1,1,1], compound_mass=1)
+
+    def test_specify_mass(self):
+        compound1 = mb.Compound(name="A")
+        compound2 = mb.Compound(name="B")
+        filled = mb.fill_box(compound1, box=[1,1,1], density=1000, compound_mass=18)
+        assert filled.n_particles == 33
+        filled = mb.fill_box([compound1,compound2], box=[1,1,1],
+                density=1000, compound_mass=[18,18], compound_ratio=[1,1])
+        assert filled.n_particles == 32
+
+    def test_no_mass(self):
+        compound = mb.Compound(name="A")
+        with pytest.raises(MBuildError, match=r"Total mass of compound"):
+            filled = mb.fill_box(compound, box=[1,1,1], density=1000)
+        with pytest.raises(MBuildError, match=r"Total mass of compound"):
+            filled = mb.fill_box(compound, n_compounds=100, density=1000)
+        with pytest.raises(MBuildError, match=r"Total mass of compound"):
+            filled = mb.fill_box([compound, compound], box=[1,1,1],
+                    density=1000, compound_ratio=[1,2])
+        with pytest.raises(MBuildError, match=r"Total mass of compound"):
+            filled = mb.fill_sphere(compound, sphere=[3, 3, 3, 1.5],
+                    density=50)
+        with pytest.raises(MBuildError, match=r"Total mass of compound"):
+            filled = mb.fill_sphere([compound, compound], sphere=[3, 3, 3, 1.5],
+                    density=50, compound_ratio=[1,2])
+
+
+        filled = mb.fill_box(compound, box=[1,1,1], n_compounds=10)
+        filled = mb.fill_sphere(compound, sphere=[3, 3, 3, 1.5], n_compounds=10)
+ 


### PR DESCRIPTION
### PR Summary:
Two major changes in PR:

(1) Changes `to_parmed()` behavior so that the mass is set to zero *unless* the Compound name matches the two-character element code of a valid element in the periodic table. This behavior is somewhat stricter, and prevents a particle with name `Compound` from being treated as a `Carbon` element by `parmed`
(2) The `fill_box` and `fill_sphere` capabilities use the `to_parmed` feature to estimate the mass of the Compounds. I have added a `compound_mass` argument to `fill_box` and `fill_sphere` that allows the user to specify the mass of non-atomistic compounds.
(3) A bit of clean-up. Move the validation of the `fill_box`, `fill_region`, `fill_sphere` functions to a separate helper function. 

Addresses #726. 

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
