### PR TITLE
Add has_protobuff variable

### DIFF
--- a/mbuild/tests/test_protobuf.py
+++ b/mbuild/tests/test_protobuf.py
@@ -1,8 +1,11 @@
+import pytest
 from mbuild.tests.base_test import BaseTest
 from mbuild.formats.protobuf import write_pb2, read_pb2
+from mbuild.utils.io import has_protobuf
 
 class TestPB2(BaseTest):
 
+    @pytest.mark.skipif(not has_protobuf, reason="Protobuf package not installed")
     def test_loop(self, ethane):
         write_pb2(ethane, 'ethane.pb2')
         proto = read_pb2('ethane.pb2')

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -222,6 +222,14 @@ try:
 except ImportError:
     has_py3Dmol = False
 
+try:
+    from google import protobuf
+    has_protobuf = True
+    del protobuf
+except ImportError:
+    has_protobuf = False
+
+
 def get_fn(name):
     """Get the full path to one of the reference files shipped for utils.
 


### PR DESCRIPTION
### PR Summary:

Relate to #697. Basically, this PR will add the `has_protobuf` variable, which will allow us to skip the `protobuf` unit test if the package is not installed. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
