### PR TITLE
lammpsdata writer is now passed min and max box info

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1966,6 +1966,13 @@ class Compound(object):
             if extension in ['.gsd', '.hoomdxml']:
                 kwargs['rigid_bodies'] = [
                         p.rigid_id for p in self.particles()]
+            # lammps does not require the box to be centered at any a specific origin
+            # min and max dimensions are therefore needed to write the file in a consistent way
+            # the parmed structure only stores the box length
+            if extension in ['.lammps', '.lmp']:
+                if box:
+                    kwargs['mins'] = [m for m in box.mins]
+                    kwargs['maxs'] = [m for m in box.maxs]
             saver(filename=filename, structure=structure, **kwargs)
 
         elif extension == '.sdf':

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1968,7 +1968,7 @@ class Compound(object):
                         p.rigid_id for p in self.particles()]
             # lammps does not require the box to be centered at any a specific origin
             # min and max dimensions are therefore needed to write the file in a consistent way
-            # the parmed structure only stores the box length
+            # the parmed structure only has the box length
             if extension in ['.lammps', '.lmp']:
                 if box:
                     kwargs['mins'] = [m for m in box.mins]

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -20,8 +20,7 @@ def _check_minsmaxs(mins, maxs):
             if len(mins) == 3 & len(maxs) == 3:
                 return True
             else:
-                warn('mins and maxs passed to write_lammpsdata, but list size is incorrect.',
-                     'mins and maxs will be ignored.')
+                warn('mins and maxs passed to write_lammpsdata, but list size is incorrect. mins and maxs will be ignored.')
                 return False
         else:
             return False

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -15,14 +15,11 @@ __all__ = ['write_lammpsdata']
 # returns True if both mins and maxs have been defined, and each have length 3
 # otherwise returns False
 def _check_minsmaxs(mins, maxs):
-    if mins:
-        if maxs:
-            if len(mins) == 3 & len(maxs) == 3:
-                return True
-            else:
-                warn('mins and maxs passed to write_lammpsdata, but list size is incorrect. mins and maxs will be ignored.')
-                return False
+    if mins and maxs:
+        if len(mins) == 3 and len(maxs) == 3:
+            return True
         else:
+            warn('mins and maxs passed to write_lammpsdata, but list size is incorrect. mins and maxs will be ignored.')
             return False
     else:
         return False

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -124,6 +124,68 @@ class TestLammpsData(BaseTest):
 
         assert set(res_list) == set(['1', '0'])
 
+    def test_box_bounds(self, ethane):
+        from foyer import Forcefield
+        
+        OPLSAA = Forcefield(name='oplsaa')
+        structure = OPLSAA.apply(ethane)
+        box = mb.Box(mins=np.array([-1.0, -2.0, -3.0]), maxs=np.array([3.0, 2.0, 1.0]))
+
+        write_lammpsdata(filename='box.lammps', structure=structure,
+                         unit_style='real', mins=[m for m in box.mins],
+                         maxs=[m for m in box.maxs])
+                         
+        checked_section = False
+        with open('box.lammps', 'r') as fi:
+            while not checked_section:
+                line = fi.readline()
+                if 'xlo' in line:
+                    xlo = float(line.split()[0])
+                    xhi = float(line.split()[1])
+                    assert np.isclose(xlo, -10.0)
+                    assert np.isclose(xhi, 30.0)
+                    
+                    line = fi.readline()
+                    ylo = float(line.split()[0])
+                    yhi = float(line.split()[1])
+                    assert np.isclose(ylo, -20.0)
+                    assert np.isclose(yhi, 20.0)
+                    
+                    line = fi.readline()
+                    zlo = float(line.split()[0])
+                    zhi = float(line.split()[1])
+                    assert np.isclose(zlo, -30.0)
+                    assert np.isclose(zhi, 10.0)
+                    
+                    checked_section = True
+
+        write_lammpsdata(filename='box.lammps', structure=structure,
+                         unit_style='real')
+                         
+        checked_section = False
+        with open('box.lammps', 'r') as fi:
+            while not checked_section:
+                line = fi.readline()
+                if 'xlo' in line:
+                    xlo = float(line.split()[0])
+                    xhi = float(line.split()[1])
+                    assert np.isclose(xlo, 0.0)
+                    assert np.isclose(xhi, 7.13999987)
+                    
+                    line = fi.readline()
+                    ylo = float(line.split()[0])
+                    yhi = float(line.split()[1])
+                    assert np.isclose(ylo, 0.0)
+                    assert np.isclose(yhi, 7.93800011)
+                    
+                    line = fi.readline()
+                    zlo = float(line.split()[0])
+                    zhi = float(line.split()[1])
+                    assert np.isclose(zlo, 0.0)
+                    assert np.isclose(zhi, 6.646)
+                    
+                    checked_section = True
+
     def test_lj_box(self, ethane):
         from foyer import Forcefield
 


### PR DESCRIPTION
### PR Summary:
LAMMPS boxes do not need to be centered at the origin or run [0,0,0] to [Lx,Ly,Lz]; min and max values for each dimensions are explicitly set in the data file (xlo xhi, ylo yhi, zlo zhi). 

The way the writer was written, an mbuild Box was defined with the function based on  the total length in each dimension, extracted from the parmed structure object. Since this parmed object doesn't not contain min and max info, only total length,  box dimensions were written out as [0,0,0] to [Lx,Ly,Lz]. The system coordinates were not shifted such that the system COM is placed at [ Lx/2, Ly/2 Lz/2]).  While this is just a minor inconsistency in terms of spatial location for periodic systems (although annoying when trying to convert between formats), this can fundamentally break a non-periodic system (since LAMMPS will try to wrap the structure back into the box).

This PR implements a simple fix; if an mBuild Box is explicitly passed to the save function, min and max vales are extracted and passed as kwargs to the lammpsdata writer; these values used to initialize the box information, rather than the parmed structure.  If a box is not passed, the code performs as before (extracting from the parmed structure), although a print statement was added to alert the user box dimensions were being set to be 0 to L. 

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
