### PR TITLE
Add Compound.box attribute

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -308,7 +308,6 @@ class Compound(object):
         else:
             self._pos = np.zeros(3)
 
-        self.box = box
         self.parent = None
         self.children = OrderedSet()
         self.labels = OrderedDict()
@@ -320,6 +319,8 @@ class Compound(object):
         self._rigid_id = None
         self._contains_rigid = False
         self._check_if_contains_rigid_bodies = False
+
+        self.box = box
 
         # self.add() must be called after labels and children are initialized.
         if subcompounds:
@@ -1106,6 +1107,8 @@ class Compound(object):
     def box(self, box):
         if box is not None and type(box) != Box:
             raise TypeError("box must be specified as an mbuild.Box")
+        if self.port_particle and box is not None:
+            raise ValueError("Ports cannot have a box")
         self._box = box
 
     @property
@@ -2943,6 +2946,7 @@ class Compound(object):
         newone.periodicity = deepcopy(self.periodicity)
         newone._pos = deepcopy(self._pos)
         newone.port_particle = deepcopy(self.port_particle)
+        newone.box = deepcopy(self.box)
         newone._check_if_contains_rigid_bodies = deepcopy(
             self._check_if_contains_rigid_bodies)
         newone._contains_rigid = deepcopy(self._contains_rigid)

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -786,6 +786,7 @@ class Compound(object):
         # If parent has box --> keep unless inherit_box == True
         # If inherit_box == True, parent box != None, child_box == None,
         # keep parent box anyway and warn
+        # If inherit_box == False, child.box != None, warn
         if self.box is None:
             if new_child.box is not None:
                 self.box = new_child.box
@@ -807,6 +808,15 @@ class Compound(object):
                         "inherit_box = True if you wish to replace the parent "
                         "compound box with that of Compound being added."
                     )
+
+        # Check that bounding box is within box after adding compound
+        if self.box:
+            if (self.box.lengths < self.boundingbox.lengths).any():
+                warn(
+                    "After adding new Compound, Compound.box.lengths < "
+                    "Compound.boundingbox.lengths. There may be particles "
+                    "outside of the defined simulation box"
+                )
 
 
     def remove(self, objs_to_remove):
@@ -1109,6 +1119,15 @@ class Compound(object):
             raise TypeError("box must be specified as an mbuild.Box")
         if self.port_particle and box is not None:
             raise ValueError("Ports cannot have a box")
+        # TODO: Fix this for non-orthogonal boxes
+        # Make sure the box is bigger than the bounding box
+        if box is not None:
+            if (box.lengths < self.boundingbox.lengths).any():
+                warn(
+                    "Compound.box.lengths < Compound.boundingbox.lengths. "
+                    "There may be particles outside of the defined "
+                    "simulation box."
+                )
         self._box = box
 
     @property

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1117,3 +1117,18 @@ class TestCompound(BaseTest):
         filled.save('methane.sdf')
         sdf_string = mb.load('methane.sdf')
         assert np.allclose(filled.xyz, sdf_string.xyz, atol=1e-5)
+
+    def test_box(self):
+        compound = mb.Compound()
+        assert compound.box == None
+        compound.box = mb.Box([3.,3.,3.])
+        assert np.allclose(compound.box.lengths, [3.,3.,3.])
+        assert np.allclose(compound.box.angles, [90.,90.,90])
+        with pytest.raises(TypeError, match=r"specified as an mbuild.Box"):
+            compound.box = "Hello, world"
+        with pytest.raises(TypeError, match=r"specified as an mbuild.Box"):
+            compound.box = [3.,3.,3.]
+        port = mb.Port()
+        assert port.box == None
+        with pytest.raises(ValueError, match=r"cannot have"):
+            port.box = mb.Box([3.,3.,3.])

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1132,3 +1132,26 @@ class TestCompound(BaseTest):
         assert port.box == None
         with pytest.raises(ValueError, match=r"cannot have"):
             port.box = mb.Box([3.,3.,3.])
+
+        compound = mb.Compound()
+        subcomp = mb.Compound(box=mb.Box([3.,3.,3.]))
+        compound.add(subcomp)
+        assert np.allclose(compound.box.lengths, [3.,3.,3.])
+        assert np.allclose(compound.box.angles, [90.,90.,90.])
+        compound = mb.Compound(box=mb.Box([3.,3.,3.]))
+        subcomp = mb.Compound(box=mb.Box(lengths=[6.,6.,6.], angles=[60.,60.,120.]))
+        with pytest.warns(UserWarning):
+            compound.add(subcomp)
+        assert np.allclose(compound.box.lengths, [3.,3.,3.])
+        assert np.allclose(compound.box.angles, [90.,90.,90.])
+        compound = mb.Compound(box=mb.Box([3.,3.,3.]))
+        subcomp = mb.Compound(box=mb.Box(lengths=[6.,6.,6.], angles=[60.,60.,120.]))
+        compound.add(subcomp, inherit_box=True)
+        assert np.allclose(compound.box.lengths, [6.,6.,6.])
+        assert np.allclose(compound.box.angles, [60.,60.,120.])
+        compound = mb.Compound(box=mb.Box([3.,3.,3.]))
+        subcomp = mb.Compound()
+        with pytest.warns(UserWarning):
+            compound.add(subcomp, inherit_box=True)
+        assert np.allclose(compound.box.lengths, [3.,3.,3.])
+        assert np.allclose(compound.box.angles, [90.,90.,90.])

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1155,3 +1155,14 @@ class TestCompound(BaseTest):
             compound.add(subcomp, inherit_box=True)
         assert np.allclose(compound.box.lengths, [3.,3.,3.])
         assert np.allclose(compound.box.angles, [90.,90.,90.])
+
+        compound = mb.Compound()
+        carbon = mb.Compound(name="C")
+        compound.add(carbon)
+        compound.box = mb.Box([3.,3.,3.])
+        nitrogen = mb.Compound(name="N", pos=[4,3,3,])
+        with pytest.warns(UserWarning):
+            compound.add(nitrogen)
+        compound.box = mb.Box([5.,4.,4.])
+        with pytest.warns(UserWarning):
+            compound.box = mb.Box([5.,4.,2.])


### PR DESCRIPTION
### PR Summary:

Adds a `Compound.box` attribute (see #707 and #735). This PR only adds the attribute and basic unit tests. `Compound.periodicity` is still fully independent and functional. 

Port particles are explicitly prevented from having a `Compound.box` attribute.

A follow-up PR will map `Compound.periodicity` -> `Compound.box.lengths` and replace core `Compound.periodicity` usage with `Compound.box`. 


### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
