### PR TITLE
Deprecate Compound.periodicity and link to Compound.box

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -18,7 +18,7 @@ from parmed.periodic_table import AtomicNum, element_by_name, Mass, Element
 from mbuild.bond_graph import BondGraph
 from mbuild.box import Box
 from mbuild.exceptions import MBuildError
-from mbuild.utils.decorators import deprecated
+from mbuild.utils.decorators import deprecated, deprecated_property
 from mbuild.formats.xyz import read_xyz, write_xyz
 from mbuild.formats.json_formats import compound_to_json, compound_from_json
 from mbuild.formats.hoomdxml import write_hoomdxml
@@ -1099,13 +1099,13 @@ class Compound(object):
             raise MBuildError('Cannot set position on a Compound that has'
                               ' children.')
 
+    warning_message = (
+        "Compound.periodicity will be removed in version 0.11. "
+        "Please use Compound.box instead."
+    )
 
-    @property
+    @deprecated_property(warning_message)
     def periodicity(self):
-        warn(
-            "Compound.periodicity will be removed in version 0.11. "
-            "Please use Compound.box instead."
-        )
         if self.box is None:
             return np.array([0.,0.,0.])
         else:
@@ -1113,11 +1113,6 @@ class Compound(object):
 
     @periodicity.setter
     def periodicity(self, periods):
-        warn(
-            "Compound.periodicity will be removed in version 0.11. "  
-            "Please use Compound.box instead."
-        )
-
         if self.box is None:
             self.box = Box(lengths=periods)
         else:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -308,7 +308,6 @@ class Compound(object):
         else:
             self._pos = np.zeros(3)
 
-        self.box = box
         self.parent = None
         self.children = OrderedSet()
         self.labels = OrderedDict()
@@ -320,6 +319,8 @@ class Compound(object):
         self._rigid_id = None
         self._contains_rigid = False
         self._check_if_contains_rigid_bodies = False
+
+        self.box = box
 
         # self.add() must be called after labels and children are initialized.
         if subcompounds:
@@ -1106,6 +1107,8 @@ class Compound(object):
     def box(self, box):
         if box is not None and type(box) != Box:
             raise TypeError("box must be specified as an mbuild.Box")
+        if self.port_particle and box is not None:
+            raise ValueError("Ports cannot have a box")
         self._box = box
 
     @property
@@ -2943,6 +2946,7 @@ class Compound(object):
         newone.periodicity = deepcopy(self.periodicity)
         newone._pos = deepcopy(self._pos)
         newone.port_particle = deepcopy(self.port_particle)
+        newone.box = deepcopy(self.box)
         newone._check_if_contains_rigid_bodies = deepcopy(
             self._check_if_contains_rigid_bodies)
         newone._contains_rigid = deepcopy(self._contains_rigid)

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -579,12 +579,10 @@ class Lattice(object):
                                     'dictionary. For key {}, type: {} was '
                                     'provided, not mbuild.Compound.'
                                     .format(key_id, err_type))
-        # set periodicity
-        ret_lattice.periodicity = np.asarray([a * x, b * y, c * z], dtype=np.float64)
-        warn('Periodicity of non-rectangular lattices are not valid with '
-                    'default boxes. Only rectangular lattices are valid '
-                    'at this time.')
-
+        
+        # Create mbuild.box
+        ret_lattice.box = mb.Box(lengths=[a*x, b*y, c*z], angles=self.angles)
+        
         # if coordinates are below a certain threshold, set to 0
         tolerance = 1e-12
         ret_lattice.xyz_with_ports[ret_lattice.xyz_with_ports <= tolerance] = 0.
@@ -593,6 +591,8 @@ class Lattice(object):
 
     def get_populated_box(self, x=1, y=1, z=1):
         """
+        Deprecated. Will be removed in version 0.11. Use Compound.box instead.
+
         Return a mbuild.Box representing the periodic boundaries of a
         populated mbuild.Lattice. This is meant to be called in parallel
         with, and using the same arguments of, a call to

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -216,7 +216,7 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2,
         filled = Compound()
         filled = _create_topology(filled, compound, n_compounds)
         filled.update_coordinates(filled_xyz.name, update_port_locations=update_port_locations)
-        filled.periodicity = np.asarray(box.lengths, dtype=np.float32)
+        filled.box = box
 
     # ensure that the temporary files are removed from the machine after filling
     finally:

--- a/mbuild/periodic_kdtree.py
+++ b/mbuild/periodic_kdtree.py
@@ -93,7 +93,13 @@ class PeriodicCKDTree(KDTree):
 
     Parameters
     ----------
+    box : mbuild.Box
+        The box object containing the periodicity of the system.
+        A zero value for one of the box lengths mean that the
+        space is not periodic in that dimension.
     bounds : array_like, shape (k,)
+        Deprecated. Will be removed in version 0.11. Please use
+        the box argument instead.
         Size of the periodic box along each spatial dimension.  A
         negative or zero size for dimension k means that space is not
         periodic along k.
@@ -113,10 +119,23 @@ class PeriodicCKDTree(KDTree):
     query point and a data point to half the smallest box dimension.
     """
 
-    def __init__(self, data, leafsize=10, bounds=None):
+    def __init__(self, data, leafsize=10, box=None, bounds=None):
+        if bounds is not None and box is not None:
+            raise ValueError(
+                "Only one of 'bounds' and 'box' may be specified. "
+                "Since 'bounds' is deprecated, please use 'box'."
+            )
         # Map all points to canonical periodic image.
-        if bounds is None:
-            bounds = np.array([0.0, 0.0, 0.0])
+        if box is None:
+            if bounds is None:
+                bounds = np.array([0.0, 0.0, 0.0])
+        elif np.allclose(box.angles, 90.0):
+            bounds = box.lengths
+        else:
+            raise NotImplementedError(
+                "Periodic KCDTree search only implemented"
+                "for orthorhombic periodic boundaries"
+            )
         self.bounds = np.array(bounds)
         self.real_data = np.asarray(data)
 

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -125,8 +125,6 @@ class TestBox(BaseTest):
                    [0.474, 0.0049, -0.7277],
                    [0.518, 0.0312, -0.8946],
                    [0.488, 0.1676, -0.7896]])
-        # Set periodicity
-        ethane.periodicity = np.array([0.767, 0.703, 0.710])
         # Convert compound to pmd.structure to set Box info
         # Conversion should happen without error
         ethane.to_parmed()

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1117,3 +1117,18 @@ class TestCompound(BaseTest):
         filled.save('methane.sdf')
         sdf_string = mb.load('methane.sdf')
         assert np.allclose(filled.xyz, sdf_string.xyz, atol=1e-5)
+
+    def test_box(self):
+        compound = mb.Compound()
+        assert compound.box == None
+        compound.box = mb.Box([3.,3.,3.])
+        assert np.allclose(compound.box.lengths, [3.,3.,3.])
+        assert np.allclose(compound.box.angles, [90.,90.,90])
+        with pytest.raises(TypeError, match=r"specified as an mbuild.Box"):
+            compound.box = "Hello, world"
+        with pytest.raises(TypeError, match=r"specified as an mbuild.Box"):
+            compound.box = [3.,3.,3.]
+        port = mb.Port()
+        assert port.box == None
+        with pytest.raises(ValueError, match=r"cannot have"):
+            port.box = mb.Box([3.,3.,3.])

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1132,3 +1132,26 @@ class TestCompound(BaseTest):
         assert port.box == None
         with pytest.raises(ValueError, match=r"cannot have"):
             port.box = mb.Box([3.,3.,3.])
+
+        compound = mb.Compound()
+        subcomp = mb.Compound(box=mb.Box([3.,3.,3.]))
+        compound.add(subcomp)
+        assert np.allclose(compound.box.lengths, [3.,3.,3.])
+        assert np.allclose(compound.box.angles, [90.,90.,90.])
+        compound = mb.Compound(box=mb.Box([3.,3.,3.]))
+        subcomp = mb.Compound(box=mb.Box(lengths=[6.,6.,6.], angles=[60.,60.,120.]))
+        with pytest.warns(UserWarning):
+            compound.add(subcomp)
+        assert np.allclose(compound.box.lengths, [3.,3.,3.])
+        assert np.allclose(compound.box.angles, [90.,90.,90.])
+        compound = mb.Compound(box=mb.Box([3.,3.,3.]))
+        subcomp = mb.Compound(box=mb.Box(lengths=[6.,6.,6.], angles=[60.,60.,120.]))
+        compound.add(subcomp, inherit_box=True)
+        assert np.allclose(compound.box.lengths, [6.,6.,6.])
+        assert np.allclose(compound.box.angles, [60.,60.,120.])
+        compound = mb.Compound(box=mb.Box([3.,3.,3.]))
+        subcomp = mb.Compound()
+        with pytest.warns(UserWarning):
+            compound.add(subcomp, inherit_box=True)
+        assert np.allclose(compound.box.lengths, [3.,3.,3.])
+        assert np.allclose(compound.box.angles, [90.,90.,90.])

--- a/mbuild/tests/test_lattice.py
+++ b/mbuild/tests/test_lattice.py
@@ -207,7 +207,7 @@ class TestLattice(BaseTest):
 
         assert len(is_true) == len(values_to_check)
 
-    def test_set_periodicity(self):
+    def test_box(self):
         lattice = mb.Lattice(lattice_spacing=[1, 1, 1], angles=[90, 90, 90],
                              lattice_points={'A' : [[0, 0, 0]]})
 
@@ -215,8 +215,29 @@ class TestLattice(BaseTest):
                                          x=2, y=5, z=9)
 
         replication=[2, 5, 9]
-        np.testing.assert_allclose(compound_test.periodicity,
-                                   np.asarray([x*y for x,y in zip(replication, lattice.lattice_spacing)]))
+        np.testing.assert_allclose(
+            compound_test.box.lengths,
+            np.asarray([x*y for x,y in zip(replication, lattice.lattice_spacing)])
+        )
+        np.testing.assert_allclose(
+            compound_test.box.angles,
+            np.asarray([90.,90.,90.])
+        )
+
+    def test_box_non_rectangular(self):
+        lattice = mb.Lattice(lattice_spacing=[0.5, 0.5, 1], angles=[90, 90, 120],
+                             lattice_points={'A' : [[0, 0, 0]]})
+        compound_test = lattice.populate(compound_dict={'A' : mb.Compound()},
+                                         x=2, y=2, z=1)
+        replication=[2, 2, 1]
+        np.testing.assert_allclose(
+            compound_test.box.lengths,
+            np.asarray([x*y for x,y in zip(replication, lattice.lattice_spacing)])
+        )
+        np.testing.assert_allclose(
+            compound_test.box.angles,
+            np.asarray([90.,90.,120.])
+        )
 
     def test_get_box(self):
         lattice = mb.Lattice(lattice_spacing=[1, 1, 1], angles=[90, 90, 90],

--- a/mbuild/utils/decorators.py
+++ b/mbuild/utils/decorators.py
@@ -2,6 +2,17 @@
 
 
 from warnings import warn
+from functools import wraps
+
+def make_callable(decorator):
+    """https://stackoverflow.com/questions/3888158/making-decorators-with-optional-arguments"""
+    @wraps(decorator)
+    def inner(*args, **kw):
+        if len(args) == 1 and not kw and callable(args[0]):
+            return decorator()(args[0])
+        else:
+            return decorator(*args, **kw)
+    return inner
 
 
 def deprecated(warning_string=''):
@@ -12,6 +23,74 @@ def deprecated(warning_string=''):
             fcn(*args, **kwargs)
         return wrapper
     return old_function
+
+
+@make_callable
+def deprecated_property(warning_msg='Property deprecated', always=False):
+    """A decorator to deprecate properties of an object.
+
+    Deprecation messages are shown only once per runtime by default
+
+    Parameters
+    ----------
+    warning_msg : str, Property deprecated
+        The deprecation warning to show
+    always: bool, default=False
+        If true, always show deprecation warning, default behavior shows
+        deprecation warning once per runtime
+    """
+
+    def old_func(fcn):
+        class Property(object):
+            def __init__(self, fget=None, fset=None, fdel=None, doc=None):
+                self.fget = fget
+                self.fset = fset
+                self.fdel = fdel
+                if doc is None and fget is not None:
+                    doc = fget.__doc__
+                self.__doc__ = doc
+                self.warning_msg = warning_msg
+                self.always_show = always
+
+            def __get__(self, obj, objtype=None):
+                self.show_warning_msg()
+                if obj is None:
+                    return self
+                if self.fget is None:
+                    raise AttributeError("unreadable attribute")
+                return self.fget(obj)
+
+            def __set__(self, obj, value):
+                self.show_warning_msg()
+                if self.fset is None:
+                    raise AttributeError("can't set attribute")
+                self.fset(obj, value)
+
+            def __delete__(self, obj):
+                self.show_warning_msg()
+                if self.fdel is None:
+                    raise AttributeError("can't delete attribute")
+                self.fdel(obj)
+
+            def getter(self, fget):
+                return type(self)(fget, self.fset, self.fdel, self.__doc__)
+
+            def setter(self, fset):
+                return type(self)(self.fget, fset, self.fdel, self.__doc__)
+
+            def deleter(self, fdel):
+                return type(self)(self.fget, self.fset, fdel, self.__doc__)
+
+            def show_warning_msg(self):
+                if self.warning_msg is not None:
+                    warn(f'Property {fcn.__name__} is deprecated. {self.warning_msg}', DeprecationWarning)
+                    if not self.always_show:
+                        self.warning_msg = None
+
+        prop = Property(fget=fcn)
+        return prop
+
+    return old_func
 
 
 def breaking_change(warning_string=''):


### PR DESCRIPTION
### PR Summary:
Marks the `Compound.periodicity` attribute as deprecated. Links the `Compound.periodicity` attribute to the `Compound.box` attribute and changes most of the behind-the-scenes to work with `Compound.box`. See #742 and #735. This PR builds on #735 and should be merged after that. Step 2/3 in closing #707.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
