### PR TITLE
Fix MCF fragment identification for more complex ring systems

### DIFF
--- a/mbuild/formats/cassandramcf.py
+++ b/mbuild/formats/cassandramcf.py
@@ -203,21 +203,24 @@ def _id_rings_fragments(structure):
     # First create a neighbor list for each atom
     neigh_dict = {i:list(bond_graph.neighbors(i))
                   for i in range(bond_graph.number_of_nodes())}
-    # First ID fused rings
-    fused_rings = []
-    rings_to_remove = []
-    for i in range(len(all_rings)):
-        ring1 = all_rings[i]
-        for j in range(i+1, len(all_rings)):
-            ring2 = all_rings[j]
-            shared_atoms = list(set(ring1) & set(ring2))
-            if len(shared_atoms) == 2:
-                fused_rings.append(list(set(ring1+ring2)))
-                rings_to_remove.append(ring1)
-                rings_to_remove.append(ring2)
-    for ring in rings_to_remove:
-        all_rings.remove(ring)
-    all_rings = all_rings + fused_rings
+
+    # Handle fused/adjoining rings
+    rings_changed = True
+    while rings_changed:
+        rings_changed = False
+        for ring1 in all_rings:
+            if rings_changed:
+                break
+            for ring2 in all_rings:
+                if ring1 == ring2:
+                    continue
+                if len(set(ring1) & set(ring2)) > 0:
+                    all_rings.remove(ring1)
+                    all_rings.remove(ring2)
+                    all_rings.append(list(set(ring1+ring2)))
+                    rings_changed=True
+                    break
+
     # ID fragments which contain a ring
     for ring in all_rings:
         adjacentatoms = []

--- a/mbuild/tests/test_cassandramcf.py
+++ b/mbuild/tests/test_cassandramcf.py
@@ -325,3 +325,49 @@ class TestCassandraMCF(BaseTest):
                     atom_section_start = idx
 
         assert mcf_data[atom_section_start+2][1] == "y_very_very_extended"
+
+    def test_fused_rings(self):
+        import mbuild
+        import foyer
+        from mbuild.formats.cassandramcf import write_mcf
+
+        naph = mbuild.load("C1=CC=C2C=CC=CC2=C1", smiles=True)
+        # Note the atomtyping is wrong -- doesn't matter for test though
+        naph_ff = foyer.forcefields.load_OPLSAA().apply(naph)
+        write_mcf(naph_ff, 'naph.mcf', angle_style='harmonic',
+                dihedral_style='opls')
+
+        mcf_data = []
+        with open('naph.mcf') as f:
+            for line in f:
+                mcf_data.append(line.strip().split())
+
+        for idx,line in enumerate(mcf_data):
+            if len(line) > 1:
+                if line[1] == 'Fragment_Info':
+                    frag_section_start = idx
+
+        assert int(mcf_data[frag_section_start+1][0]) == 1
+        assert int(mcf_data[frag_section_start+2][1]) == 18
+
+        tmada = mbuild.load("C[C](C)(C)C12CC3CC(C1)CC(C3)C2", smiles=True)
+        tmada_ff = foyer.forcefields.load_OPLSAA().apply(tmada)
+        write_mcf(tmada_ff, 'tmada.mcf', angle_style='harmonic',
+                dihedral_style='opls')
+
+        mcf_data = []
+        with open('tmada.mcf') as f:
+            for line in f:
+                mcf_data.append(line.strip().split())
+
+        for idx,line in enumerate(mcf_data):
+            if len(line) > 1:
+                if line[1] == 'Fragment_Info':
+                    frag_section_start = idx
+
+        assert int(mcf_data[frag_section_start+1][0]) == 5
+        assert int(mcf_data[frag_section_start+2][1]) == 26
+        assert int(mcf_data[frag_section_start+3][1]) == 5
+        assert int(mcf_data[frag_section_start+4][1]) == 5
+        assert int(mcf_data[frag_section_start+5][1]) == 5
+        assert int(mcf_data[frag_section_start+6][1]) == 5


### PR DESCRIPTION
### PR Summary:
It was brought to my attention that the fragment identification did not work properly in the cases of more complex ring systems: e.g., this cage molecule here:

![example](https://user-images.githubusercontent.com/4744720/84401749-a0a67700-abd1-11ea-81aa-d5e21b8c26b8.png)

This PR updates how fragments are identified for fused/merged rings and adds unit test for two cases, naphthalene, and then one of these cage-type structures.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
