### PR TITLE
Fix bug in cloning compound with box

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -32,7 +32,7 @@ from mbuild.coordinate_transform import _translate, _rotate
 
 
 def load(filename_or_object, relative_to_module=None, compound=None, coords_only=False,
-         rigid=False, use_parmed=False, smiles=False, 
+         rigid=False, use_parmed=False, smiles=False,
          infer_hierarchy=True, **kwargs):
     """Load a file or an existing topology into an mbuild compound.
 
@@ -91,7 +91,7 @@ def load(filename_or_object, relative_to_module=None, compound=None, coords_only
         return filename_or_object
     for type in type_dict:
         if isinstance(filename_or_object, type):
-            type_dict[type](filename_or_object,coords_only=coords_only, 
+            type_dict[type](filename_or_object,coords_only=coords_only,
                     infer_hierarchy=infer_hierarchy, **kwargs)
             return compound
     if not isinstance(filename_or_object, str):
@@ -145,7 +145,7 @@ def load(filename_or_object, relative_to_module=None, compound=None, coords_only
             "use_parmed set to True.  Bonds may be inferred from inter-particle "
             "distances and standard residue templates!")
         structure = pmd.load_file(filename_or_object, structure=True, **kwargs)
-        compound.from_parmed(structure, coords_only=coords_only, 
+        compound.from_parmed(structure, coords_only=coords_only,
                 infer_hierarchy=infer_hierarchy)
 
     elif smiles:
@@ -2789,7 +2789,7 @@ class Compound(object):
             else:
                 temp_name = atom.type
             temp = Particle(name=temp_name, pos=xyz)
-            if infer_hierarchy and hasattr(atom, 'residue'): 
+            if infer_hierarchy and hasattr(atom, 'residue'):
                 # Is there a safer way to check for res?
                 if atom.residue.idx not in resindex_to_cmpd:
                     res_cmpd = Compound(name=atom.residue.name)
@@ -2965,7 +2965,6 @@ class Compound(object):
         newone.periodicity = deepcopy(self.periodicity)
         newone._pos = deepcopy(self._pos)
         newone.port_particle = deepcopy(self.port_particle)
-        newone.box = deepcopy(self.box)
         newone._check_if_contains_rigid_bodies = deepcopy(
             self._check_if_contains_rigid_bodies)
         newone._contains_rigid = deepcopy(self._contains_rigid)
@@ -3008,6 +3007,7 @@ class Compound(object):
                         # Referrers must have been handled already, or the will
                         # be handled
 
+        newone.box = deepcopy(self.box)
         return newone
 
     def _clone_bonds(self, clone_of=None):

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -9,7 +9,14 @@ import pytest
 import mbuild as mb
 from mbuild.exceptions import MBuildError
 from mbuild.utils.geometry import calc_dihedral
-from mbuild.utils.io import get_fn, import_, has_foyer, has_intermol, has_openbabel, has_networkx
+from mbuild.utils.io import (get_fn,
+                             import_,
+                             has_foyer,
+                             has_intermol,
+                             has_openbabel,
+                             has_networkx,
+                             has_py3Dmol,
+                             has_nglview)
 from mbuild.tests.base_test import BaseTest
 
 class TestCompound(BaseTest):
@@ -197,6 +204,10 @@ class TestCompound(BaseTest):
                         gmx_rule = int(line.split()[1])
                         assert gmx_rule == gmx_rules[combining_rule]
 
+    def test_clone_with_box(self, ethane):
+        ethane.box = ethane.boundingbox
+        ethane_clone = mb.clone(ethane)
+
     def test_batch_add(self, ethane, h2o):
         compound = mb.Compound()
         compound.add([ethane, h2o])
@@ -360,7 +371,7 @@ class TestCompound(BaseTest):
         assert ethane.n_bonds == 3
         assert len(ethane.children) == 1
         # Still contains a port
-        assert len(ethane.children[0].children) == 5  
+        assert len(ethane.children[0].children) == 5
 
         methyl = ethane.children[0]
         ethane.remove(methyl)
@@ -1166,3 +1177,15 @@ class TestCompound(BaseTest):
         compound.box = mb.Box([5.,4.,4.])
         with pytest.warns(UserWarning):
             compound.box = mb.Box([5.,4.,2.])
+
+    @pytest.mark.skipif(not has_py3Dmol, reason="Py3Dmol is not installed")
+    def test_visualize_py3dmol(self, ethane):
+        py3Dmol = import_("py3Dmol")
+        vis_object = ethane._visualize_py3dmol()
+        assert isinstance(vis_object, py3Dmol.view)
+
+    @pytest.mark.skipif(not has_nglview, reason="NGLView is not installed")
+    def test_visualize_nglview(self, ethane):
+        nglview = import_("nglview")
+        vis_object = ethane._visualize_nglview()
+        assert isinstance(vis_object.component_0, nglview.component.ComponentViewer)

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -207,6 +207,10 @@ class TestCompound(BaseTest):
     def test_clone_with_box(self, ethane):
         ethane.box = ethane.boundingbox
         ethane_clone = mb.clone(ethane)
+        assert np.all(ethane.xyz == ethane_clone.xyz)
+        assert np.all([p.name for p in ethane.particles()] ==
+                      [p.name for p in ethane_clone.particles()])
+        assert len(ethane.children) == len(ethane_clone.children)
 
     def test_batch_add(self, ethane, h2o):
         compound = mb.Compound()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,5 @@ codecov
 protobuf
 garnett >=0.7.1
 pycifrw
+py3Dmol
+nglview>=2.7


### PR DESCRIPTION
Fixes #752 
### PR Summary:
* Makes sure that the clone's children are set before setting it's box
* Adds tests for clone, and visualize

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
