### PR TITLE
Support entry_point plugins with conda

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -8,6 +8,7 @@ source:
 build:
   noarch: python
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)}}
+  preserve_egg_dir: True
   script_env:
     - CONDA_PY
   script: activate
@@ -16,6 +17,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
     - protobuf
 
   run:
@@ -27,6 +29,7 @@ requirements:
     - parmed
     - protobuf
     - mdtraj
+    - setuptools
 
 test:
   requires:


### PR DESCRIPTION
### PR Summary:

To ensure that we have our plugins supported properly when installed
from conda, it appears that a few options are necessary to ensure that
is the case.

For the case of setuptools entry_points, the conda-build documentation
recommends that we do include the build option: preserve_egg_dir

https://docs.conda.io/projects/conda-build/en/latest/user-guide/recipes/build-without-recipe.html#preserve-egg-directory

Setuptools are also now build and runtime dependencies.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
