### PR TITLE
Properly test and import the correct CIF modules

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -20,8 +20,8 @@ def load_cif(file_or_path=None, wrap_coords=False):
         Wrap the lattice points back into the 0-1 acceptable coordinates.
     """
 
-    garnett = import_('Garnett')
-    pycifrw = import_('pycifrw')
+    garnett = import_('garnett')
+    pycifrw = import_('CifFile')
 
     assert isinstance(file_or_path, (str, pathlib.Path))
     cif_location = pathlib.Path(file_or_path)

--- a/mbuild/tests/test_cif.py
+++ b/mbuild/tests/test_cif.py
@@ -11,19 +11,19 @@ class TestCif(BaseTest):
     """
     Unit tests for CIF file loading and Lattice generation.
     """
-    @pytest.mark.skipif(not has_garnett, reason="Garnett package not installed")
+    @pytest.mark.skipif(not has_garnett, reason="garnett package not installed")
     @pytest.mark.skipif(not has_pycifrw, reason="pycifrw package not installed")
     def test_malformed_cif(self):
         with pytest.raises(Exception):
             load_cif(file_or_path=get_fn("extra_blank_field.cif"))
 
-    @pytest.mark.skipif(not has_garnett, reason="Garnett package not installed")
+    @pytest.mark.skipif(not has_garnett, reason="garnett package not installed")
     @pytest.mark.skipif(not has_pycifrw, reason="pycifrw package not installed")
     def test_wrap_false(self):
         with pytest.raises(ValueError):
             load_cif(file_or_path=get_fn("needs_to_be_wrapped.cif"), wrap_coords=False)
 
-    @pytest.mark.skipif(not has_garnett, reason="Garnett package not installed")
+    @pytest.mark.skipif(not has_garnett, reason="garnett package not installed")
     @pytest.mark.skipif(not has_pycifrw, reason="pycifrw package not installed")
     def test_wrap_true(self):
         assert load_cif(file_or_path=get_fn("needs_to_be_wrapped.cif"), wrap_coords=True)

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -267,9 +267,9 @@ except ImportError:
     has_garnett = False
 
 try:
-    import pycifrw
+    import CifFile
     has_pycifrw = True
-    del pycifrw
+    del CifFile
 except ImportError:
     has_pycifrw = False
 


### PR DESCRIPTION
### PR Summary:

Thanks to a catch by @uppittu11, the `pycifrw` package was not being
properly tested for an import error, this has now been fixed.

Previously, the `pycifrw` package was conditionally imported using
`import_('pycifrw')`, this is not the module name for `pycifrw`, it is
actually `CifFile`. This change has been made in both the cif reading
logic as well as the tests.

Also, two tests were being skipped always in `test_cif.py`, this was due
to a capitalization error in the `has_garnett` module in
`mbuild.utils.io`.

This has also been fixed.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?

### Note

I recommend a release of mBuild once merged.