### PR TITLE
changed _forced to _FORCED within the os.system command for the packmol…

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -687,7 +687,7 @@ def _run_packmol(input_text, filled_xyz, temp_file):
                "the .xyz_FORCED file instead. This may not be a "
                "sufficient packing result.")
         warnings.warn(msg)
-        os.system('cp {0}_forced {0}'.format(filled_xyz.name))
+        os.system('cp {0}_FORCED {0}'.format(filled_xyz.name))
 
     if 'ERROR' in out or proc.returncode != 0:
         _packmol_error(out, err)


### PR DESCRIPTION
… outputs

### PR Summary:
Fixed typo bug within the _run_packmol function.  Capitalized FORCED in the os.system command used to replace the unforced .xyz with the forced .xyz.

Addresses issue #755 

### PR Checklist
------------
 - [N/A ] Includes appropriate unit test(s)
 - [ N/A] Appropriate docstring(s) are added/updated
 - [ X] Code is (approximately) PEP8 compliant
 - [ X] Issue(s) raised/addressed?
