### PR TITLE
Use numpy conversions

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -448,12 +448,11 @@ class Lattice(object):
         dataType = np.float64
         (alpha, beta, gamma) = angles
 
-        radianConversion = np.pi / 180.0
-        cosa = np.cos(alpha * radianConversion)
-        cosb = np.cos(beta * radianConversion)
-        sinb = np.sin(beta * radianConversion)
-        cosg = np.cos(gamma * radianConversion)
-        sing = np.sin(gamma * radianConversion)
+        cosa = np.cos(np.deg2rad(alpha))
+        cosb = np.cos(np.deg2rad(beta))
+        sinb = np.sin(np.deg2rad(beta))
+        cosg = np.cos(np.deg2rad(gamma))
+        sing = np.sin(np.deg2rad(gamma))
         matCoef_y = (cosa - cosb * cosg) / sing
         matCoef_z = np.power(sinb, 2, dtype=dataType) - \
             np.power(matCoef_y, 2, dtype=dataType)
@@ -479,7 +478,6 @@ class Lattice(object):
 
         """
 
-        degreeConversion = 180.0 / np.pi
         vector_magnitudes = np.linalg.norm(self.lattice_vectors, axis=1)
 
         a_dot_b = np.dot(self.lattice_vectors[0], self.lattice_vectors[1])
@@ -490,9 +488,9 @@ class Lattice(object):
         beta_raw = a_dot_c / (vector_magnitudes[0] * vector_magnitudes[2])
         gamma_raw = a_dot_b / (vector_magnitudes[0] * vector_magnitudes[1])
 
-        alpha = np.arccos(np.clip(alpha_raw, -1.0, 1.0)) * degreeConversion
-        beta = np.arccos(np.clip(beta_raw, -1.0, 1.0)) * degreeConversion
-        gamma = np.arccos(np.clip(gamma_raw, -1.0, 1.0)) * degreeConversion
+        alpha = np.rad2deg(np.arccos(np.clip(alpha_raw, -1.0, 1.0)))
+        beta = np.rad2deg(np.arccos(np.clip(beta_raw, -1.0, 1.0)))
+        gamma = np.rad2deg(np.arccos(np.clip(gamma_raw, -1.0, 1.0)))
 
         return np.asarray([alpha, beta, gamma], dtype=np.float64)
 

--- a/mbuild/tests/base_test.py
+++ b/mbuild/tests/base_test.py
@@ -120,10 +120,10 @@ class BaseTest:
         ch.name = 'CH'
         mb.translate(ch, -ch[0].pos)       
         ch.add(mb.Port(anchor=ch[0], separation=0.07), 'a')
-        mb.rotate_around_z(ch['a'], 120.0 * (np.pi/180.0))
+        mb.rotate_around_z(ch['a'], np.deg2rad(120.0))
 
         ch.add(mb.Port(anchor=ch[0], separation=0.07), 'b')
-        mb.rotate_around_z(ch['b'], -120.0 * (np.pi/180.0))
+        mb.rotate_around_z(ch['b'], np.deg2rad(-120.0))
         ch_copy = mb.clone(ch)
 
         benzene = mb.Compound(name='Benzene')
@@ -161,11 +161,11 @@ class BaseTest:
         mb.translate(ch, -ch[0].pos)    
         ch.add(mb.Port(anchor=ch[0]), 'a')
         mb.translate(ch['a'], [0, 0.07, 0]) 
-        mb.rotate_around_z(ch['a'], 120.0 * (np.pi/180.0))
+        mb.rotate_around_z(ch['a'], np.deg2rad(120.0))
 
         ch.add(mb.Port(anchor=ch[0]), 'b')
         mb.translate(ch['b'], [0, 0.07, 0]) 
-        mb.rotate_around_z(ch['b'], -120.0 * (np.pi/180.0))
+        mb.rotate_around_z(ch['b'], np.deg2rad(-120.0))
         return ch
 
     @pytest.fixture


### PR DESCRIPTION
### PR Summary:
Previously, when handling degrees and radians within mbuild, we defined
a conversion term (180 / pi) or (pi / 180) to convert radians to degrees or
degrees to radians, respectively.

Ryan (@rsdefever) mentioned in passing that numpy already has methods to
handle this conversion for us: `np.rad2deg` and `np.deg2rad`.
All instances where conversions between degrees and radians were needed
are now using these methods.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
