### PR TITLE
Add Support for Periodic Impropers in LAMMPS datafile

### DIFF
--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -189,9 +189,10 @@ def write_lammpsdata(structure, filename, atom_style='full',
             use_rb_torsions = True
         else:
             use_rb_torsions = False
+
+        charmm_proper = TrackedList()
+        charmm_improper = TrackedList()
         if len(structure.dihedrals) > 0:
-            charmm_proper = TrackedList()
-            charmm_improper = TrackedList()
             for dihedral in structure.dihedrals:
                 if dihedral.improper:
                     charmm_improper.append(dihedral)

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -479,7 +479,7 @@ def write_lammpsdata(structure, filename, atom_style='full',
                     data.write('\nImproper Coeffs # cvff\n')
                     data.write('#k, d, n\n')
                     for params,idx in sorted_improper_types.items():
-                        data.write('{}\t{:.5f}\t{:.5f}\t{:.5f}\t# {}\t{}\t{}\t{}\n'.format(idx, params[0],
+                        data.write('{}\t{:.5f}\t{}\t{}\t# {}\t{}\t{}\t{}\n'.format(idx, params[0],
                                                                                     params[1], params[2],
                                                                                     params[3], params[4],
                                                                                     params[5], params[6]))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 numpy
 scipy
+hypothesis
 packmol>=1!18.013
 oset
 parmed

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 numpy
 scipy
-hypothesis
 packmol>=1!18.013
 oset
 parmed


### PR DESCRIPTION
### PR Summary:
This PR aims to add support for periodic improper dihedrals in the LAMMPS datafile writer.  I ran into this issue trying to write out a system using ionic liquid parameters using the CL&P force field (https://link.springer.com/article/10.1007/s00214-012-1129-7) which uses RB torsions for proper dihedrals and periodic torsions for improper dihedrals.  Since periodic improper dihedrals are stored in `structure.dihedrals`, this was causing an error because I had both RB and periodic torsions.  Here, I attempt to fix this by looping through `structure.dihedrals` and separating out the proper and improper dihedrals.  If any of the dihedrals in `structure.dihedrals` are propers and RB torsions also exist, this will error out as previously.  However, if all of the `structure.dihedrals` are impropers then these will get written out.  Now, the writer checks if the parmed structure contains both `structure.improper` and `structure.dihedrals` that are impropers.  If this is the case, an error will get raised.

Need to test on some systems, clean up, and add unit tests before a proper review.
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
