### PR TITLE
Include missing transpose of cif box_matrix

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -48,7 +48,7 @@ def load_cif(file_or_path=None, wrap_coords=False):
                     else:
                         pass
             position_dict[frame.types[elem_id]].append(list(coords))
-        box_vectors = frame.box.get_box_matrix()
+        box_vectors = np.asarray(frame.box.get_box_matrix()).T
         return Lattice(lattice_spacing=lattice_spacing,
                        lattice_vectors=box_vectors,
                        lattice_points=position_dict)


### PR DESCRIPTION
### PR Summary:

Currently, when creating a `Lattice` from a CIF file, the information
that is used to construct the lattice is the `box_matrix` from the
Garnett CIF reader.

The box_matrix has the a,b,c vectors of the lattice arranged in a
columnar format:

| ax | bx | cx |
| --- | --- | --- |
| ay | by |cy|
| az | bz |cz|

The a vector is the first column, b the next, etc.

mBuild constructs its Lattice's with a box matrix in row-ordered
formatting, which is the transpose of the above matrix.

The transpose was never completed before constructing a lattice, which
led to numerous issues regarding the lattice dimensions.

This fix transposes the matrix before being passed to the `Lattice`
constructor.

This PR closes #766 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?

