### PR TITLE
Pin Openbabel to 0.3.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ parmed
 mdtraj
 foyer
 gsd>=1.2
-openbabel
+openbabel>=3.0.0
 networkx
 pytest >=3.0
 pytest-cov


### PR DESCRIPTION
### PR Summary:
If people installing all the requirements from `requirements-dev.txt` and not have their conda channel in the correct order, an old version of `openbabel` (2.4) will be (more than likely) be pulled from `ominia` and break mbuild. This PR will pin the `openbabel` to the more recent working version (>=3.0.0), so the user can still pull the working version even if the conda channel is in wrong order. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
