### PR TITLE
Add openbabel to default install

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - protobuf
     - mdtraj
     - setuptools
+    - openbabel
 
 test:
   requires:


### PR DESCRIPTION
Tired of always having to install `openbabel` Is there a compelling reason why we don't just have it get installed by default? Since using the `conda-forge` version I haven't had issues installing or using it.

### PR Summary:

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
