### PR TITLE
Add combine flag for some parmed saver

### DIFF
--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -744,17 +744,16 @@ def save(compound,
         and geometric combining rules respectively.
     foyer_kwargs : dict, optional, default=None
         Keyword arguments to provide to `foyer.Forcefield.apply`.
-    combine : 'all', None or list iterables, optional, default='all'
-        Specific for the parmed GRO and TOP writer. User can choose from
-        If None, system atom order may be changed to meet the
-        need for contiguously bonded groups of atoms to be part of a single
-        molecule type. All other values apart from 'all' will leave the atom
-        order unchanged.
     **kwargs
         Depending on the file extension these will be passed to either
         `write_gsd`, `write_hoomdxml`, `write_lammpsdata`,
         `write_mcf`, or `parmed.Structure.save`.
-        See https://parmed.github.io/ParmEd/html/structobj/parmed.structure.Structure.html#parmed.structure.Structure.save
+        For the case when saving out a `.gro` and `.top` file using parmed,
+        if the `combine` is not provided in **kwargs, we will default to
+        `combine='all'` to avoid unnecessary error when parmed tries to
+        change the atom order when saving out.
+        For more information, see
+        https://parmed.github.io/ParmEd/html/structobj/parmed.structure.Structure.html#parmed.structure.Structure.save
 
 
     Other Parameters
@@ -871,8 +870,13 @@ def save(compound,
         output_sdf.close()
 
     elif extension in ['.gro', '.top']:  # ParmEd supported saver.
-        structure.save(filename, overwrite=overwrite,
-                       combine=combine, **kwargs)
+        if 'combine' in kwargs:
+            # The case when `combine` is given as **kwarg, then pass as is
+            structure.save(filename, overwrite=overwrite, **kwargs)
+        else:
+            # else, default to `combine='all'`
+            structure.save(filename, overwrite=overwrite,
+                           combine='all', **kwargs)
     else:  # ParmEd supported saver.
         structure.save(filename, overwrite=overwrite, **kwargs)
 

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -702,6 +702,7 @@ def save(compound,
          residues=None,
          combining_rule='lorentz',
          foyer_kwargs=None,
+         combine='all',
          **kwargs):
     """Save the Compound to a file.
 
@@ -743,6 +744,12 @@ def save(compound,
         and geometric combining rules respectively.
     foyer_kwargs : dict, optional, default=None
         Keyword arguments to provide to `foyer.Forcefield.apply`.
+    combine : 'all', None or list iterables, optional, default='all'
+        Specific for parmed GRO writer. User can choose from
+        If None, system atom order may be changed to meet the
+        need for continguously bonded groups of atoms to be part
+        of a single molecule type. All other values leave the
+        atom order unchanged.
     **kwargs
         Depending on the file extension these will be passed to either
         `write_gsd`, `write_hoomdxml`, `write_lammpsdata`,
@@ -863,6 +870,9 @@ def save(compound,
         output_sdf.write(pybel_molecule)
         output_sdf.close()
 
+    elif extension in ['.gro', '.top']:  # ParmEd supported saver.
+        structure.save(filename, overwrite=overwrite,
+                       combine=combine, **kwargs)
     else:  # ParmEd supported saver.
         structure.save(filename, overwrite=overwrite, **kwargs)
 

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -745,11 +745,11 @@ def save(compound,
     foyer_kwargs : dict, optional, default=None
         Keyword arguments to provide to `foyer.Forcefield.apply`.
     combine : 'all', None or list iterables, optional, default='all'
-        Specific for parmed GRO writer. User can choose from
+        Specific for the parmed GRO and TOP writer. User can choose from
         If None, system atom order may be changed to meet the
-        need for continguously bonded groups of atoms to be part
-        of a single molecule type. All other values leave the
-        atom order unchanged.
+        need for contiguously bonded groups of atoms to be part of a single
+        molecule type. All other values apart from 'all' will leave the atom
+        order unchanged.
     **kwargs
         Depending on the file extension these will be passed to either
         `write_gsd`, `write_hoomdxml`, `write_lammpsdata`,


### PR DESCRIPTION
### PR Summary:

This PR relates to #525 and #768. Parmed saver use the `combine` flag to attempt to reorder the GROMACS gro and top files. However, this sometimes resulted in error, so this PR added the `combine` flag to mbuild `save()` function and default it to `all` which avoid the re-ordering step.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
