### PR TITLE
Integrate element attribute with object conversions and writers

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -11,8 +11,9 @@ from collections.abc import Iterable
 from copy import deepcopy
 from warnings import warn
 from oset import oset as OrderedSet
+from ele.element import Element, element_from_symbol
+from ele.exceptions import ElementError
 
-from ele.element import Element
 
 from mbuild import conversion
 from mbuild.bond_graph import BondGraph
@@ -1727,15 +1728,18 @@ class Compound(object):
         """
 
         openbabel = import_('openbabel')
-        md = import_('mdtraj')
-        from mdtraj.core.element import get_by_symbol
         for particle in self.particles():
-            try:
-                get_by_symbol(particle.name)
-            except KeyError:
-                raise MBuildError("Element name {} not recognized. Cannot "
-                                  "perform minimization."
-                                  "".format(particle.name))
+            if particle.element is None:
+                try:
+                    element_from_symbol(particle.name[:2])
+                except ElementError:
+                    raise MBuildError(
+                        "No element assigned to {}; element could not be"
+                        "inferred from particle name {}. Cannot perform"
+                        "an energy minimization.".format(
+                            particle, particle.name
+                        )
+                    )
 
         obConversion = openbabel.OBConversion()
         obConversion.SetInAndOutFormats("mol2", "pdb")

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable
 from copy import deepcopy
 from warnings import warn
 from oset import oset as OrderedSet
-from ele.element import Element, element_from_symbol
+from ele.element import Element, element_from_symbol, element_from_name
 from ele.exceptions import ElementError
 
 
@@ -1733,13 +1733,16 @@ class Compound(object):
                 try:
                     element_from_symbol(particle.name)
                 except ElementError:
-                    raise MBuildError(
-                        "No element assigned to {}; element could not be"
-                        "inferred from particle name {}. Cannot perform"
-                        "an energy minimization.".format(
-                            particle, particle.name
+                    try:
+                        element_from_name(particle.name)
+                    except ElementError:
+                        raise MBuildError(
+                            "No element assigned to {}; element could not be"
+                            "inferred from particle name {}. Cannot perform"
+                            "an energy minimization.".format(
+                                particle, particle.name
+                            )
                         )
-                    )
 
         obConversion = openbabel.OBConversion()
         obConversion.SetInAndOutFormats("mol2", "pdb")

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1731,7 +1731,7 @@ class Compound(object):
         for particle in self.particles():
             if particle.element is None:
                 try:
-                    element_from_symbol(particle.name[:2])
+                    element_from_symbol(particle.name)
                 except ElementError:
                     raise MBuildError(
                         "No element assigned to {}; element could not be"

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1517,13 +1517,14 @@ def _add_intermol_molecule_type(intermol_system, parent):  # pragma: no cover
         intermol_bond = InterMolBond(atom1.index, atom2.index)
         molecule_type.bonds.add(intermol_bond)
 
+
 def _infer_element_from_compound(compound, guessed_elements):
     """Infer the element from the compound name
 
     Parameters
     ----------
     compound : mbuild.Compound
-        the compound to infer the element for 
+        the compound to infer the element for
     guessed_elements : list
         a list of the already-guessed-elements
 
@@ -1531,7 +1532,7 @@ def _infer_element_from_compound(compound, guessed_elements):
     -------
     element : ele.Element or None
     """
-    
+
     try:
         element = element_from_symbol(compound.name)
     except ElementError:
@@ -1557,5 +1558,5 @@ def _infer_element_from_compound(compound, guessed_elements):
         if compound.name not in guessed_elements:
             warn(warn_msg)
             guessed_elements.add(compound.name)
-   
+
     return element

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -986,7 +986,7 @@ def to_parmed(compound,
             # Else we try to infer from the name
             else:
                 try:
-                    element = element_from_symbol(atom.name[:2])
+                    element = element_from_symbol(atom.name)
                     mass = element.mass
                     atomic_number = element.atomic_number
                     if atom.name not in guessed_elements:
@@ -1343,7 +1343,7 @@ def to_pybel(compound,
                 temp.SetAtomicNum(part.element.atomic_number)
             else:
                 try:
-                    element = element_from_symbol(part.name[:2])
+                    element = element_from_symbol(part.name)
                     temp.SetAtomicNum(element.atomic_number)
                 except ElementError:
                     warn(

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1549,7 +1549,7 @@ def _infer_element_from_compound(compound, guessed_elements):
             element = None
             warn_msg = (
                 "No element attribute associated with '{}'; "
-                "and no matching elements found based upon the"
+                "and no matching elements found based upon the "
                 "compound name. Setting atomic number to zero.".format(
                     compound,
                 )

--- a/mbuild/formats/compound.proto
+++ b/mbuild/formats/compound.proto
@@ -13,6 +13,13 @@ message Vec2 {
     int64 id2 = 2;
 }
 
+message Element {
+    string name = 1;
+    string symbol = 2;
+    int64 atomic_number = 3;
+    float mass = 4;
+}
+
 message Compound {
     string name = 1;
     repeated Compound children = 2;
@@ -21,6 +28,7 @@ message Compound {
     float charge = 5;
     int64 id = 6; // this is simply a unique number for this compound
     repeated Vec2 bonds = 7;  // a list of 2-tuples
+    Element element = 8;
 
     // Todo: Maybe need something for port particles
 }

--- a/mbuild/formats/json_formats.py
+++ b/mbuild/formats/json_formats.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 import mbuild as mb
 from mbuild.exceptions import MBuildError
+import ele
 
 
 def compound_from_json(json_file):
@@ -124,6 +125,7 @@ def _particle_info(cmpd, include_ports=False):
     particle_dict['pos'] = list(cmpd.pos)
     particle_dict['charge'] = cmpd.charge
     particle_dict['periodicity'] = list(cmpd.periodicity)
+    particle_dict['element'] = cmpd.element
 
     if include_ports:
         particle_dict['ports'] = list()
@@ -156,7 +158,19 @@ def _dict_to_mb(compound_dict):
     pos = compound_dict.get('pos', [0.0, 0.0, 0.0])
     charge = compound_dict.get('charge', 0.0)
     periodicity = compound_dict.get('periodicity', [0.0, 0.0, 0.0])
-    this_particle = mb.Compound(name=name, pos=pos, charge=charge, periodicity=periodicity)
+    element = compound_dict.get('element', None)
+    if isinstance(element, ele.element.Element):
+        pass
+    elif isinstance(element, list):
+        atom_num = element[0]
+        element = ele.element_from_atomic_number(atom_num)
+    elif isinstance(element, str):
+        pass
+    else:
+        pass
+
+    this_particle = mb.Compound(name=name, pos=pos, charge=charge,
+                                periodicity=periodicity, element=element)
     return this_particle
 
 

--- a/mbuild/formats/protobuf.py
+++ b/mbuild/formats/protobuf.py
@@ -1,4 +1,5 @@
 import mbuild as mb
+import ele
 from mbuild.formats import compound_pb2
 from google.protobuf.text_format import PrintMessage, Merge
 
@@ -93,6 +94,11 @@ def _mb_to_proto(cmpd, proto):
     proto.charge = cmpd.charge
     proto.id = id(cmpd)
     proto.periodicity.x, proto.periodicity.y, proto.periodicity.z = cmpd.periodicity
+    if cmpd.element:
+        proto.element.name = cmpd.element.name
+        proto.element.symbol = cmpd.element.symbol
+        proto.element.atomic_number = cmpd.element.atomic_number
+        proto.element.mass  = cmpd.element.mass
    
     return proto
 
@@ -141,11 +147,16 @@ def _proto_to_mb(proto):
     proto: compound_pb2.Compound()
     
     """
+    if proto.element.symbol is '':
+        elem = None
+    else:
+        elem = ele.element_from_symbol(proto.element.symbol)
     return  mb.Compound(name=proto.name,
                 pos=[proto.pos.x, proto.pos.y, proto.pos.z],
                 charge=proto.charge,
                 periodicity=[proto.periodicity.x, proto.periodicity.y, 
-                            proto.periodicity.z])
+                            proto.periodicity.z],
+                element=elem)
 
 def _add_mb_bonds(proto, cmpd, proto_to_cmpd):
     """ Parse the compound_pb2.Compound bonds, add to mb.Compound

--- a/mbuild/formats/xyz.py
+++ b/mbuild/formats/xyz.py
@@ -2,6 +2,9 @@ import numpy as np
 
 import mbuild as mb
 from mbuild.exceptions import MBuildError
+from ele import element_from_symbol
+from ele.exceptions import ElementError
+from warnings import warn
 
 __all__ = ['read_xyz', 'write_xyz']
 
@@ -36,6 +39,8 @@ def read_xyz(filename, compound=None):
     if compound is None:
         compound = mb.Compound()
 
+    guessed_elements = set()
+
     with open(filename, 'r') as xyz_file:
         n_atoms = int(xyz_file.readline())
         xyz_file.readline()
@@ -49,7 +54,20 @@ def read_xyz(filename, compound=None):
                 raise MBuildError(msg.format(n_atoms))
             coords[row] = line[1:4]
             coords[row] *= 0.1
-            particle = mb.Compound(pos=coords[row], name=line[0])
+            name = line[0]
+            try:
+                element = name.capitalize()
+                element = element_from_symbol(element)
+            except ElementError:
+                if name not in guessed_elements:
+                    warn(
+                        "No matching element found for {}; the particle will "
+                        "be added to the compound without an element "
+                        "attribute.".format(name)
+                    )
+                    guessed_elements.add(name)
+
+            particle = mb.Compound(pos=coords[row], name=name, element=element)
             compound.add(particle)
 
         # Verify we have read the last line by ensuring the next line in blank

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -889,7 +889,12 @@ class TestCompound(BaseTest):
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel package not installed")
     def test_energy_minimize_non_element(self, octane):
         for particle in octane.particles():
+            particle.element = None
+        # Pass with element inference from names
+        octane.energy_minimization()
+        for particle in octane.particles():
             particle.name = 'Q'
+        # Fail once names don't match elements
         with pytest.raises(MBuildError):
             octane.energy_minimize()
 
@@ -1294,3 +1299,7 @@ class TestCompound(BaseTest):
                 c.element for c in container.particles_by_element("sod")
             ]
 
+    def test_elements_from_smiles(self):
+        mol = mb.load("COC", smiles=True)
+        for particle in mol.particles():
+            assert particle.element is not None

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -722,7 +722,7 @@ class TestCompound(BaseTest):
     def test_fillbox_then_parmed(self):
         # This test would fail with the old to_parmed code (pre PR #699)
 
-        bead = mb.Compound(name="Bead")
+        bead = mb.Compound(name="Ar")
         box = mb.Box(mins=(2,2,2), maxs=(3,3,3))
         bead_box = mb.fill_box(bead, 100, box)
         bead_box_in_pmd = bead_box.to_parmed()
@@ -891,7 +891,7 @@ class TestCompound(BaseTest):
         for particle in octane.particles():
             particle.element = None
         # Pass with element inference from names
-        octane.energy_minimization()
+        octane.energy_minimize()
         for particle in octane.particles():
             particle.name = 'Q'
         # Fail once names don't match elements

--- a/mbuild/tests/test_json_formats.py
+++ b/mbuild/tests/test_json_formats.py
@@ -6,8 +6,12 @@ import mbuild as mb
 class TestJSONFormats(BaseTest):
 
     def test_loop(self, ethane):
+        for part in ethane:
+            part.element = part.name
         compound_to_json(ethane, 'ethane.json')
         ethane_copy = compound_from_json('ethane.json')
+        for part_orig, part_copy in zip(ethane, ethane_copy):
+            assert part_orig.element.symbol == part_copy.element.symbol
         assert ethane.n_particles == ethane_copy.n_particles
         assert ethane.n_bonds == ethane_copy.n_bonds
         assert len(ethane.children) == len(ethane_copy.children)
@@ -72,5 +76,3 @@ class TestJSONFormats(BaseTest):
         for child, child_copy in zip(parent.successors(), parent_copy.successors()):
             assert child.labels.keys() == child_copy.labels.keys()
         assert parent_copy.available_ports() == parent.available_ports()
-
-

--- a/mbuild/tests/test_xyz.py
+++ b/mbuild/tests/test_xyz.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import ele
 
 import mbuild as mb
 from mbuild.formats.xyz import write_xyz
@@ -15,6 +16,10 @@ class TestXYZ(BaseTest):
         assert len(ethane_in.children) == 8
         assert ethane_in.n_bonds == 0
         assert set([child.name for child in ethane_in.children]) == {'C', 'H'}
+        assert set([child.element for child in ethane_in.children]) == {
+            ele.Elements.C,
+            ele.Elements.H
+        }
 
     def test_wrong_n_atoms(self):
         with pytest.raises(MBuildError):


### PR DESCRIPTION
### PR Summary:

Initial integration of element attribute into conversions. This includes to/from conversions for:
* pybel
* parmed
* mdtraj

Removes reliance on `parmed` and `mdtraj` periodic table except when converting to/from those data structures.

How do we handle inference?
* Check if `Compound.name` is an exact match to the two-character element code
* Check if `Compound.name` is an exact match to a full element name (e.g., calcium)
* Otherwise default to no element (atomic number, mass = 0, parmed="EP")

**Examples**: see [here](https://gist.github.com/rsdefever/8d57910f6a00101c953889fcc3ad3e16) for a notebook with some examples to test out the functionality!

Tests passing locally at the moment. Need to add more tests and consider integration with writers.


### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
