### PR TITLE
Add sidemax as argument for various packing functions

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -20,6 +20,7 @@ tolerance {0:.16f}
 filetype xyz
 output {1}
 seed {2}
+sidemax {3}
 
 """
 PACKMOL_SOLUTE = """
@@ -52,7 +53,7 @@ constrain_rotation z 0. 0.
 
 
 def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2,
-             seed=12345, edge=0.2, compound_ratio=None,
+             seed=12345, sidemax=100.0, edge=0.2, compound_ratio=None,
              aspect_ratio=None, fix_orientation=False, temp_file=None,
              update_port_locations=False):
     """Fill a box with a `mbuild.compound` or `Compound`s using PACKMOL.
@@ -93,6 +94,10 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2,
         Minimum separation between atoms of different molecules.
     seed : int, default=12345
         Random seed to be passed to PACKMOL.
+    sidemax : float, optional, default=100.0
+        Needed to build an initial approximation of the molecule distribution in PACKMOL.
+        All system coordinates must fit with in +/- sidemax,
+        so increase sidemax accordingly to your final box size.
     edge : float, units nm, default=0.2
         Buffer at the edge of the box to not place molecules. This is necessary
         in some systems because PACKMOL does not account for periodic boundary
@@ -197,7 +202,7 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2,
     # create a list to contain the file handles for the compound temp files
     compound_xyz_list = list()
     try:
-        input_text = PACKMOL_HEADER.format(overlap, filled_xyz.name, seed)
+        input_text = PACKMOL_HEADER.format(overlap, filled_xyz.name, seed, sidemax*10)
         for comp, m_compounds, rotate in zip(compound, n_compounds, fix_orientation):
             m_compounds = int(m_compounds)
 
@@ -210,7 +215,6 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2,
                                              box_mins[2], box_maxs[0],
                                              box_maxs[1], box_maxs[2],
                                              PACKMOL_CONSTRAIN if rotate else "")
-
         _run_packmol(input_text, filled_xyz, temp_file)
         # Create the topology and update the coordinates.
         filled = Compound()
@@ -229,7 +233,7 @@ def fill_box(compound, n_compounds=None, box=None, density=None, overlap=0.2,
 
 
 def fill_region(compound, n_compounds, region, overlap=0.2,
-                seed=12345, edge=0.2, fix_orientation=False, temp_file=None,
+                seed=12345, sidemax=100.0, edge=0.2, fix_orientation=False, temp_file=None,
                 update_port_locations=False):
     """Fill a region of a box with `mbuild.Compound`(s) using PACKMOL.
 
@@ -245,6 +249,10 @@ def fill_region(compound, n_compounds, region, overlap=0.2,
         Minimum separation between atoms of different molecules.
     seed : int, default=12345
         Random seed to be passed to PACKMOL.
+    sidemax : float, optional, default=100.0
+        Needed to build an initial approximation of the molecule distribution in PACKMOL.
+        All system coordinates must fit with in +/- sidemax,
+        so increase sidemax accordingly to your final box size.
     edge : float, units nm, default=0.2
         Buffer at the edge of the region to not place molecules. This is
         necessary in some systems because PACKMOL does not account for
@@ -302,7 +310,7 @@ def fill_region(compound, n_compounds, region, overlap=0.2,
     # List to hold file handles for the temporary compounds
     compound_xyz_list = list()
     try:
-        input_text = PACKMOL_HEADER.format(overlap, filled_xyz.name, seed)
+        input_text = PACKMOL_HEADER.format(overlap, filled_xyz.name, seed, sidemax*10)
 
         for comp, m_compounds, reg, rotate in zip(compound, n_compounds, region, fix_orientation):
             m_compounds = int(m_compounds)
@@ -336,7 +344,7 @@ def fill_region(compound, n_compounds, region, overlap=0.2,
 
 
 def fill_sphere(compound, sphere, n_compounds=None, density=None, overlap=0.2,
-                seed=12345, edge=0.2, compound_ratio=None,
+                seed=12345, sidemax=100.0, edge=0.2, compound_ratio=None,
                 fix_orientation=False, temp_file=None, update_port_locations=False):
     """Fill a sphere with a compound using packmol.
 
@@ -362,6 +370,10 @@ def fill_sphere(compound, sphere, n_compounds=None, density=None, overlap=0.2,
         Minimum separation between atoms of different molecules.
     seed : int, default=12345
         Random seed to be passed to PACKMOL.
+    sidemax : float, optional, default=100.0
+        Needed to build an initial approximation of the molecule distribution in PACKMOL.
+        All system coordinates must fit with in +/- sidemax,
+        so increase sidemax accordingly to your final box size
     edge : float, units nm, default=0.2
         Buffer at the edge of the sphere to not place molecules. This is necessary
         in some systems because PACKMOL does not account for periodic boundary
@@ -460,7 +472,7 @@ def fill_sphere(compound, sphere, n_compounds=None, density=None, overlap=0.2,
     # List to hold file handles for the temporary compounds
     compound_xyz_list = list()
     try:
-        input_text = PACKMOL_HEADER.format(overlap, filled_xyz.name, seed)
+        input_text = PACKMOL_HEADER.format(overlap, filled_xyz.name, seed, sidemax*10)
         for comp, m_compounds, rotate in zip(compound, n_compounds, fix_orientation):
             m_compounds = int(m_compounds)
 
@@ -472,7 +484,6 @@ def fill_sphere(compound, sphere, n_compounds=None, density=None, overlap=0.2,
                                                 sphere[0], sphere[1],
                                                 sphere[2], radius,
                                                 PACKMOL_CONSTRAIN if rotate else "")
-        print(input_text)
         _run_packmol(input_text, filled_xyz, temp_file)
 
         # Create the topology and update the coordinates.
@@ -489,7 +500,7 @@ def fill_sphere(compound, sphere, n_compounds=None, density=None, overlap=0.2,
 
 
 def solvate(solute, solvent, n_solvent, box, overlap=0.2,
-            seed=12345, edge=0.2, fix_orientation=False, temp_file=None,
+            seed=12345, sidemax=100.0, edge=0.2, fix_orientation=False, temp_file=None,
             update_port_locations=False):
     """Solvate a compound in a box of solvent using packmol.
 
@@ -507,6 +518,10 @@ def solvate(solute, solvent, n_solvent, box, overlap=0.2,
         Minimum separation between atoms of different molecules.
     seed : int, default=12345
         Random seed to be passed to PACKMOL.
+    sidemax : float, optional, default=100.0
+        Needed to build an initial approximation of the molecule distribution in PACKMOL.
+        All system coordinates must fit with in +/- sidemax,
+        so increase sidemax accordingly to your final box size
     edge : float, units nm, default=0.2
         Buffer at the edge of the box to not place molecules. This is necessary
         in some systems because PACKMOL does not account for periodic boundary
@@ -557,7 +572,7 @@ def solvate(solute, solvent, n_solvent, box, overlap=0.2,
     solvent_xyz_list = list()
     try:
         solute.save(solute_xyz.name, overwrite=True)
-        input_text = (PACKMOL_HEADER.format(overlap, solvated_xyz.name, seed) +
+        input_text = (PACKMOL_HEADER.format(overlap, solvated_xyz.name, seed, sidemax*10) +
                       PACKMOL_SOLUTE.format(solute_xyz.name, *center_solute))
 
         for solv, m_solvent, rotate in zip(solvent, n_solvent, fix_orientation):

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -246,5 +246,5 @@ class TestPacking(BaseTest):
                     sphere=[1000, 1000, 1000, 1000],
                     n_compounds=500,
                     sidemax=2000.0)
-        assert all(big_box_of_methane.boundingbox.lengths > [990, 990, 990])
-        assert all(big_sphere_of_methane.boundingbox.lengths > [1900, 1900, 1900])
+        assert all(big_box_of_methane.boundingbox.lengths > [900, 900, 900])
+        assert all(big_sphere_of_methane.boundingbox.lengths > [1800, 1800, 1800])

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -223,3 +223,28 @@ class TestPacking(BaseTest):
         butane = Alkane(n=4)
         butane.remove(butane[-1])
         box = mb.fill_box(butane, n_compounds=10, density=1)
+
+    def test_sidemax(self):
+        from mbuild.lib.molecules import Methane
+        ch4 = Methane()
+        #With default sidemax
+        box_of_methane = mb.fill_box(ch4,
+                    box=[1000, 1000, 1000],
+                    n_compounds=500)
+        sphere_of_methane = mb.fill_sphere(ch4,
+                    sphere=[1000, 1000, 1000, 1000],
+                    n_compounds=500)
+        assert all(box_of_methane.boundingbox.lengths < [110, 110, 110])
+        assert all(sphere_of_methane.boundingbox.lengths < [210, 210, 210])
+
+        #With adjusted sidemax
+        big_box_of_methane = mb.fill_box(ch4,
+                    box=[1000, 1000, 1000],
+                    n_compounds=500,
+                    sidemax=1000.0)
+        big_sphere_of_methane = mb.fill_sphere(ch4,
+                    sphere=[1000, 1000, 1000, 1000],
+                    n_compounds=500,
+                    sidemax=2000.0)
+        assert all(big_box_of_methane.boundingbox.lengths > [990, 990, 990])
+        assert all(big_sphere_of_methane.boundingbox.lengths > [1900, 1900, 1900])


### PR DESCRIPTION
### PR Summary:
Relate to this #762 and #446. Add `sidemax` as an argument for various packing functions so user can build larger box/sphere. 

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
