### PR TITLE
Fix syntax error in conversion.py

### DIFF
--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -422,7 +422,9 @@ def from_parmed(structure,
         if len(structure.atoms) != compound.n_particles:
             raise ValueError(
                 'Number of atoms in {structure} does not '
-                '{compound}'.formats(**locals())
+                'match {compound}'.format(**locals())
+                'Structure: {} atoms'.format(len(structure.atoms))
+                'Compound: {} atoms'.format(compound.n_particles)
             )
         atoms_particles = zip(
             structure.atoms,

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -421,10 +421,11 @@ def from_parmed(structure,
     if compound and coords_only:
         if len(structure.atoms) != compound.n_particles:
             raise ValueError(
-                'Number of atoms in {structure} does not '
-                'match {compound}'.format(**locals())
-                'Structure: {} atoms'.format(len(structure.atoms))
-                'Compound: {} atoms'.format(compound.n_particles)
+                'Number of atoms in {} does not '
+                'match {}'
+                'Structure: {} atoms'
+                'Compound: {} atoms'
+                .format(structure, compound, len(structure.atoms), compound.n_particles)
             )
         atoms_particles = zip(
             structure.atoms,


### PR DESCRIPTION
### PR Summary:

Currently, after the overhaul of the load functionality, there was a
small syntax error introduced during a condition where a ValueError was
raised.

This has now been fixed, as well as providing a slightly more
descriptive error message.


### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
