### PR TITLE
Use correct lattice spacing when reading from cif

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -34,7 +34,7 @@ def load_cif(file_or_path=None, wrap_coords=False):
         frame = my_cif[0]
 
         # convert angstroms to nanometers
-        lattice_spacing = [frame.box.Lx/10, frame.box.Ly/10, frame.box.Lz/10]
+        lattice_spacing = np.linalg.norm(np.asarray(frame.box.get_box_matrix()).T, axis=1) / 10
 
         # create lattice_points dictionary
         position_dict = defaultdict(list)

--- a/mbuild/tests/test_cif.py
+++ b/mbuild/tests/test_cif.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+from operator import itemgetter
+from collections import OrderedDict
 
 import mbuild as mb
 from mbuild.tests.base_test import BaseTest
@@ -27,3 +29,41 @@ class TestCif(BaseTest):
     @pytest.mark.skipif(not has_pycifrw, reason="pycifrw package not installed")
     def test_wrap_true(self):
         assert load_cif(file_or_path=get_fn("needs_to_be_wrapped.cif"), wrap_coords=True)
+
+    @pytest.mark.skipif(not has_garnett, reason="garnett package not installed")
+    @pytest.mark.skipif(not has_pycifrw, reason="pycifrw package not installed")
+    def test_cif_vs_manual(self):
+        spacing = [0.760296570, 0.760296570, 0.437540800]
+        points_dict = {"La": [[1/3, 2/3, 1/4],
+                             [2/3, 1/3, 3/4]],
+                       "Cl": [[0.69490400, 0.08690400, 1/4],
+                              [0.60800000, 0.69490400, 3/4],
+                              [0.30509600, 0.91309600, 3/4],
+                              [0.39200000, 0.30509600, 1/4],
+                              [0.91309600, 0.60800000, 1/4],
+                              [0.08690400, 0.39200000, 3/4]]}
+
+        lattice_manual = mb.Lattice(lattice_spacing=spacing, lattice_points=points_dict, angles=[90, 90, 120])
+        lattice_cif = load_cif(file_or_path=get_fn("LaCl3.cif"))
+
+        assert np.all(np.isclose(lattice_manual.lattice_spacing, lattice_cif.lattice_spacing))
+        assert np.all(np.isclose(lattice_manual.angles, lattice_cif.angles))
+
+        # sort dicts first (not necessary once we support py 3.7+ only)
+        # dict sorted by keys
+        dict_manual = OrderedDict(sorted(lattice_manual.lattice_points.items(), key=lambda t: t[0]))
+        dict_cif = OrderedDict(sorted(lattice_cif.lattice_points.items(), key=lambda t: t[0]))
+        keys_m = dict_manual.keys()
+        keys_c = dict_cif.keys()
+
+        for k_man, k_cif in zip(keys_m, keys_c):
+            # sort the lists of lists
+            points_man = dict_manual[k_man]
+            points_cif = dict_cif[k_cif]
+            points_man.sort()
+            points_cif.sort()
+
+            points_man = np.asarray(points_man)
+            points_cif = np.asarray(points_cif)
+
+            assert np.all(np.isclose(points_man, points_cif))

--- a/mbuild/tests/test_cif.py
+++ b/mbuild/tests/test_cif.py
@@ -67,3 +67,44 @@ class TestCif(BaseTest):
             points_cif = np.asarray(points_cif)
 
             assert np.all(np.isclose(points_man, points_cif))
+
+    def test_cif_vs_manual_triclinic(self):
+        spacing = [0.641910000, 0.652305930, 0.704466251]
+        angles = [91.77954616, 103.97424201, 118.83663410]
+        points_dict = {"Re": [[0.94176500, 0.68947700, 0.50807400],
+                               [0.05823500, 0.31052300, 0.49192600],
+                               [0.51250400, 0.71441700, 0.50209100],
+                               [0.48749600, 0.28558300, 0.49790900]],
+                       "S": [[0.74798600, 0.13254800, 0.67588400],
+                             [0.73127300, 0.34781000, 0.26679600],
+                             [0.21989400, 0.10784400, 0.70096800],
+                             [0.25920200, 0.38690600, 0.24012300],
+                             [0.74079800, 0.61309400, 0.75987700],
+                             [0.78010600, 0.89215600, 0.29903200],
+                             [0.25201400, 0.86745200, 0.32411600],
+                             [0.26872700, 0.65219000, 0.73320400]]}
+        lattice_manual = mb.Lattice(lattice_spacing=spacing, lattice_points=points_dict, angles=angles)
+        lattice_cif = load_cif(file_or_path=get_fn("ReS2.cif"))
+
+        assert np.all(np.isclose(lattice_manual.lattice_spacing, lattice_cif.lattice_spacing))
+        assert np.all(np.isclose(lattice_manual.angles, lattice_cif.angles))
+
+        # sort dicts first (not necessary once we support py 3.7+ only)
+        # dict sorted by keys
+        dict_manual = OrderedDict(sorted(lattice_manual.lattice_points.items(), key=lambda t: t[0]))
+        dict_cif = OrderedDict(sorted(lattice_cif.lattice_points.items(), key=lambda t: t[0]))
+        keys_m = dict_manual.keys()
+        keys_c = dict_cif.keys()
+
+        for k_man, k_cif in zip(keys_m, keys_c):
+            # sort the lists of lists
+            points_man = dict_manual[k_man]
+            points_cif = dict_cif[k_cif]
+            points_man.sort()
+            points_cif.sort()
+
+            points_man = np.asarray(points_man)
+            points_cif = np.asarray(points_cif)
+
+            assert np.all(np.isclose(points_man, points_cif))
+

--- a/mbuild/utils/reference/LaCl3.cif
+++ b/mbuild/utils/reference/LaCl3.cif
@@ -1,0 +1,35 @@
+# generated using pymatgen
+data_LaCl3
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   7.60296570
+_cell_length_b   7.60296570
+_cell_length_c   4.37540800
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   90.00000000
+_cell_angle_gamma   120.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   LaCl3
+_chemical_formula_sum   'La2 Cl6'
+_cell_volume   219.03587414
+_cell_formula_units_Z   2
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  La  La0  1  0.33333333  0.66666667  0.25000000  1
+  La  La1  1  0.66666667  0.33333333  0.75000000  1
+  Cl  Cl2  1  0.69490400  0.08690400  0.25000000  1
+  Cl  Cl3  1  0.60800000  0.69490400  0.75000000  1
+  Cl  Cl4  1  0.30509600  0.91309600  0.75000000  1
+  Cl  Cl5  1  0.39200000  0.30509600  0.25000000  1
+  Cl  Cl6  1  0.91309600  0.60800000  0.25000000  1
+  Cl  Cl7  1  0.08690400  0.39200000  0.75000000  1
+

--- a/mbuild/utils/reference/ReS2.cif
+++ b/mbuild/utils/reference/ReS2.cif
@@ -1,0 +1,39 @@
+# generated using pymatgen
+data_ReS2
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   6.41910000
+_cell_length_b   6.52305930
+_cell_length_c   7.04466251
+_cell_angle_alpha   91.77954616
+_cell_angle_beta   103.97424201
+_cell_angle_gamma   118.83663410
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   ReS2
+_chemical_formula_sum   'Re4 S8'
+_cell_volume   246.94557322
+_cell_formula_units_Z   4
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Re  Re0  1  0.94176500  0.68947700  0.50807400  1
+  Re  Re1  1  0.05823500  0.31052300  0.49192600  1
+  Re  Re2  1  0.51250400  0.71441700  0.50209100  1
+  Re  Re3  1  0.48749600  0.28558300  0.49790900  1
+  S  S4  1  0.74798600  0.13254800  0.67588400  1
+  S  S5  1  0.73127300  0.34781000  0.26679600  1
+  S  S6  1  0.21989400  0.10784400  0.70096800  1
+  S  S7  1  0.25920200  0.38690600  0.24012300  1
+  S  S8  1  0.74079800  0.61309400  0.75987700  1
+  S  S9  1  0.78010600  0.89215600  0.29903200  1
+  S  S10  1  0.25201400  0.86745200  0.32411600  1
+  S  S11  1  0.26872700  0.65219000  0.73320400  1
+


### PR DESCRIPTION
### PR Summary:
Previously, when loading in from a cif file, the Lattice object used the
Box.Lx, Box.Ly, Box.Lz from the garnett trajectory; this value was in
euclidean space, not lattice space (which is what the lattice object
operates in).

This oversight would lead to discrepancies when loading in a cif file
versus building the same lattice object manually. Now, the lattice-space
lattice spacings are correctly set when loading a cif file.
This matches current manual lattice behavior.

An additional test is now included to ensure that whether building
manually, or from a cif file, that the lattice objects are functionally
equivalent.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?

Resolves #818 