### PR TITLE
Remove deprecated aliases from NumPy to built-in types

### DIFF
--- a/mbuild/box.py
+++ b/mbuild/box.py
@@ -27,8 +27,8 @@ class Box(object):
                     "You provided: "
                     "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
                 )
-            mins = np.array(mins, dtype=np.float)
-            maxs = np.array(maxs, dtype=np.float)
+            mins = np.array(mins, dtype=float)
+            maxs = np.array(maxs, dtype=float)
             assert mins.shape == (3, ), "Given mins have wrong dimensions"
             assert maxs.shape == (3, ), "Given maxs have wrong dimensions"
             assert all(mins <= maxs), "Given mins are greater than maxs"
@@ -43,9 +43,9 @@ class Box(object):
                     "lengths={} mins={} maxs={}".format(lengths, mins, maxs)
                 )
             if isinstance(lengths, int) or isinstance(lengths, float):
-                lengths = np.array(lengths*np.ones(3), dtype=np.float)
+                lengths = np.array(lengths*np.ones(3), dtype=float)
             else:
-                lengths = np.array(lengths, dtype=np.float)
+                lengths = np.array(lengths, dtype=float)
             assert lengths.shape == (3, )
             assert all(lengths >= 0), "Given lengths are negative"
             self._mins = _BoxArray(array=(0,0,0), var="mins", box=self)
@@ -75,7 +75,7 @@ class Box(object):
 
     @mins.setter
     def mins(self, mins):
-        mins = np.array(mins, dtype=np.float)
+        mins = np.array(mins, dtype=float)
         assert mins.shape == (3, )
         assert all(mins <= self.maxs), "Given mins is greater than maxs"
         self._mins = _BoxArray(array=mins, var="mins", box=self)
@@ -83,7 +83,7 @@ class Box(object):
 
     @maxs.setter
     def maxs(self, maxs):
-        maxs = np.array(maxs, dtype=np.float)
+        maxs = np.array(maxs, dtype=float)
         assert maxs.shape == (3, )
         assert all(maxs >= self.mins), "Given maxs is less than mins"
         self._maxs = _BoxArray(array=maxs, var="maxs", box=self)
@@ -92,20 +92,20 @@ class Box(object):
     @lengths.setter
     def lengths(self, lengths):
         if isinstance(lengths, int) or isinstance(lengths, float):
-            lengths = np.array(lengths*np.ones(3), dtype=np.float)
+            lengths = np.array(lengths*np.ones(3), dtype=float)
         else:
-            lengths = np.array(lengths, dtype=np.float)
+            lengths = np.array(lengths, dtype=float)
         assert lengths.shape == (3, )
         assert all(lengths >= 0), "Given lengths are negative" 
         self._maxs = _BoxArray(array=(self.maxs + (0.5*lengths - 0.5*self.lengths)), var="maxs", box=self)
         self._mins = _BoxArray(array=(self.mins - (0.5*lengths - 0.5*self.lengths)), var="mins", box=self)
-        self._lengths = _BoxArray(array=lengths, var="lengths", box=self, dtype=np.float)
+        self._lengths = _BoxArray(array=lengths, var="lengths", box=self, dtype=float)
 
     @angles.setter
     def angles(self, angles):
-        angles = np.array(angles, dtype=np.float)
+        angles = np.array(angles, dtype=float)
         assert angles.shape == (3, )
-        self._angles = _BoxArray(array=angles, var="angles", box=self, dtype=np.float)
+        self._angles = _BoxArray(array=angles, var="angles", box=self, dtype=float)
 
     def __repr__(self):
         return "Box(mins={}, maxs={}, angles={})".format(self.mins, self.maxs, self.angles)
@@ -127,7 +127,7 @@ class _BoxArray(np.ndarray):
     box : mb.Box
         This is the Box contains this attribute (one level up of this array)
     """
-    def __new__(cls, array, var=None, box=None, dtype=np.float):
+    def __new__(cls, array, var=None, box=None, dtype=float):
         _array = np.asarray(array, dtype).view(cls)
         _array.var = var
         _array.box = box

--- a/mbuild/periodic_kdtree.py
+++ b/mbuild/periodic_kdtree.py
@@ -219,14 +219,14 @@ class PeriodicCKDTree(KDTree):
         retshape = np.shape(x)[:-1]
         if not isinstance(retshape, tuple):
             if k > 1:
-                dd = np.empty(retshape + (k,), dtype=np.float)
+                dd = np.empty(retshape + (k,), dtype=float)
                 dd.fill(np.inf)
-                ii = np.empty(retshape + (k,), dtype=np.int)
+                ii = np.empty(retshape + (k,), dtype=int)
                 ii.fill(self.n)
             elif k == 1:
-                dd = np.empty(retshape, dtype=np.float)
+                dd = np.empty(retshape, dtype=float)
                 dd.fill(np.inf)
-                ii = np.empty(retshape, dtype=np.int)
+                ii = np.empty(retshape, dtype=int)
                 ii.fill(self.n)
             else:
                 raise ValueError("Requested %s nearest neighbors; acceptable "
@@ -254,9 +254,9 @@ class PeriodicCKDTree(KDTree):
                 else:
                     return np.inf, self.n
             elif k > 1:
-                dd = np.empty(k, dtype=np.float)
+                dd = np.empty(k, dtype=float)
                 dd.fill(np.inf)
-                ii = np.empty(k, dtype=np.int)
+                ii = np.empty(k, dtype=int)
                 ii.fill(self.n)
                 for j in range(len(hits)):
                     dd[j], ii[j] = hits[j]
@@ -313,7 +313,7 @@ class PeriodicCKDTree(KDTree):
         save substantial amounts of time by putting them in a
         PeriodicCKDTree and using query_ball_tree.
         """
-        x = np.asarray(x).astype(np.float)
+        x = np.asarray(x).astype(float)
         if x.shape[-1] != self.m:
             raise ValueError(
                 "Searching for a {}d-dimensional point in a {}d-dimensional KDTree".format(

--- a/mbuild/tests/test_box.py
+++ b/mbuild/tests/test_box.py
@@ -79,24 +79,24 @@ class TestBox(BaseTest):
         
         box.maxs[0] = 5
         box.mins[2] = 1
-        assert np.allclose(box.mins, np.array([0, 0, 1], dtype=np.float))
-        assert np.allclose(box.maxs, np.array([5, 4, 4], dtype=np.float))
-        assert np.allclose(box.lengths, np.array([5, 4, 3], dtype=np.float))
+        assert np.allclose(box.mins, np.array([0, 0, 1], dtype=float))
+        assert np.allclose(box.maxs, np.array([5, 4, 4], dtype=float))
+        assert np.allclose(box.lengths, np.array([5, 4, 3], dtype=float))
 
         box.lengths[1] = 6
-        assert np.allclose(box.mins, np.array([0, -1, 1], dtype=np.float))
-        assert np.allclose(box.maxs, np.array([5, 5, 4], dtype=np.float))
-        assert np.allclose(box.lengths, np.array([5, 6, 3], dtype=np.float))
+        assert np.allclose(box.mins, np.array([0, -1, 1], dtype=float))
+        assert np.allclose(box.maxs, np.array([5, 5, 4], dtype=float))
+        assert np.allclose(box.lengths, np.array([5, 6, 3], dtype=float))
 
         new_box = mb.Box(5)
-        assert np.allclose(new_box.lengths, np.array([5, 5, 5], dtype=np.float))
-        assert np.allclose(new_box.mins, np.array([0, 0, 0], dtype=np.float))
-        assert np.allclose(new_box.maxs, np.array([5, 5, 5], dtype=np.float))
+        assert np.allclose(new_box.lengths, np.array([5, 5, 5], dtype=float))
+        assert np.allclose(new_box.mins, np.array([0, 0, 0], dtype=float))
+        assert np.allclose(new_box.maxs, np.array([5, 5, 5], dtype=float))
 
         new_box.lengths = 4
-        assert np.allclose(new_box.lengths, np.array([4, 4, 4], dtype=np.float))
-        assert np.allclose(new_box.mins, np.array([0.5, 0.5, 0.5], dtype=np.float))
-        assert np.allclose(new_box.maxs, np.array([4.5, 4.5, 4.5], dtype=np.float))
+        assert np.allclose(new_box.lengths, np.array([4, 4, 4], dtype=float))
+        assert np.allclose(new_box.mins, np.array([0.5, 0.5, 0.5], dtype=float))
+        assert np.allclose(new_box.maxs, np.array([4.5, 4.5, 4.5], dtype=float))
 
     def test_sanity_checks(self):
         # Initialization step

--- a/mbuild/tests/test_coordinate_transform.py
+++ b/mbuild/tests/test_coordinate_transform.py
@@ -354,21 +354,21 @@ class TestCoordinateTransform(BaseTest):
     def test_spin(self):
         points = np.asarray(
                 [[0, 0, 0], [1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]],
-                dtype=np.float)
+                dtype=float)
         new_points_should_be = np.asarray(
                 [[0, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0], [1, 0, 0]],
-                dtype=np.float)
+                dtype=float)
         spun_points = _spin(points, np.pi/2, [0, 0, 1])
         assert np.allclose(spun_points, new_points_should_be, atol=1e-15)
 
     def test_spin_away_from_origin(self):
         points = np.asarray(
                 [[0, 0, 0], [1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]],
-                dtype=np.float)
+                dtype=float)
         points += [2, 2, 69]
         new_points_should_be = np.asarray(
                 [[2, 2, 69], [2, 3, 69], [1, 2, 69], [2, 1, 69], [3, 2, 69]],
-                dtype=np.float)
+                dtype=float)
         spun_points = _spin(points, np.pi/2, [0, 0, 1])
         assert np.allclose(spun_points, new_points_should_be, atol=1e-15)
     def test_xyz_axis_transform(self):


### PR DESCRIPTION
### PR Summary:
This PR updates some types that are now deprecated as of NumPy 1.20, released last weekend. To reproduce:

```shell
$ python -c "import mbuild; mbuild.Box([4, 4, 4])"                               240b30c7  ✱
/Users/mwt/software/mbuild/mbuild/box.py:48: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  lengths = np.array(lengths, dtype=np.float)
```

Or run `pytest -v | grep DeprecationWarning`. These warnings annoyingly trigger when the box class is imported. For more: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
