### PR TITLE
Update nbfix_types index changes in parmed

### DIFF
--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -348,8 +348,8 @@ def write_lammpsdata(structure, filename, atom_style='full',
                     if combo in params.nbfix_types:
                         type1 = unique_types.index(combo[0])+1
                         type2 = unique_types.index(combo[1])+1
-                        rmin = params.nbfix_types[combo][0] # Angstrom OR lj units
-                        epsilon = params.nbfix_types[combo][1] # kcal OR lj units
+                        epsilon = params.nbfix_types[combo][0] # kcal OR lj units
+                        rmin = params.nbfix_types[combo][1] # Angstrom OR lj units
                         sigma = rmin/2**(1/6)
                         coeffs[(type1, type2)] = (round(sigma, 8), round(epsilon, 8))
                     else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ numpy
 openbabel>=3.0.0
 oset
 packmol>=1!18.013
-parmed
+parmed>=3.4.0
 protobuf
 py3Dmol
 pycifrw

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 scipy
 packmol>=1!18.013
 oset
-parmed
+parmed>=3.4.0
 ele
 openbabel>=3.0.0


### PR DESCRIPTION
See https://github.com/ParmEd/ParmEd/pull/1122 for the order change of the `nbfix_types` in newer version of `parmed`.

