### PR TITLE
Fix edge adjustment to include box minimums

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -225,8 +225,9 @@ def fill_box(
     box_maxs = box.maxs * 10
     overlap *= 10
 
-    # Apply 1nm edge buffer
+    # Apply edge buffer
     box_maxs -= edge * 10
+    box_mins += edge * 10
 
     # Build the input file for each compound and call packmol.
     filled_xyz = _new_xyz_file()
@@ -380,6 +381,7 @@ def fill_region(
             reg_mins = reg.mins * 10
             reg_maxs = reg.maxs * 10
             reg_maxs -= edge * 10  # Apply edge buffer
+            reg_mins += edge * 10
             input_text += PACKMOL_BOX.format(
                 compound_xyz.name,
                 m_compounds,


### PR DESCRIPTION
### PR Summary:
Addresses issue #836 

Previously, `fill_box` and `fill_regions` in `packing.py` would only adjust the maximums of the box used by PACKMOL during packing. As a result, the packed compound would only have buffers on 3 of the 6 faces of the box or region.

I added a couple lines that makes the same adjustment to the minimums of the box. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
