### PR TITLE
Silence Jupyter Error

### DIFF
--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -16,9 +16,17 @@ from mbuild.utils.io import (get_fn,
                              has_intermol,
                              has_openbabel,
                              has_networkx,
-                             has_py3Dmol,
-                             has_nglview)
+                             has_py3Dmol)
 from mbuild.tests.base_test import BaseTest
+
+
+try:
+    import nglview
+    has_nglview = True
+    del nglview
+except ImportError:
+    has_nglview = False
+
 
 class TestCompound(BaseTest):
 

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -252,13 +252,6 @@ except ImportError:
     has_hoomd = False
 
 try:
-    import nglview
-    has_nglview = True
-    del nglview
-except ImportError:
-    has_nglview = False
-
-try:
     import py3Dmol
     has_py3Dmol = True
     del py3Dmol


### PR DESCRIPTION
Importing mbuild was giving an error in jupyter when the nglview labextension was not installed. Fixes #840 

"Error displaying widget: model not found"

It was coming from the has_nglview variable in mbuild/utils/io. This PR just moves that variable to the test where it is used.

### PR Summary:

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
