### PR TITLE
Fix 14-scaling inference if one atom has zero epsilon

### DIFF
--- a/mbuild/formats/cassandramcf.py
+++ b/mbuild/formats/cassandramcf.py
@@ -104,7 +104,12 @@ def write_mcf(structure, filename, angle_style,
             if (structure.combining_rule == 'geometric' or
                     structure.combining_rule == 'lorentz'):
                 combined_eps = sqrt(type1_eps*type2_eps)
-                lj14 = scaled_eps/combined_eps
+                if combined_eps == 0:
+                    lj14 = 0.0
+                    warnings.warn('Unable to infer LJ 1-4 scaling'
+                        'factor. Setting to {:.1f}'.format(lj14))
+                else:
+                    lj14 = scaled_eps/combined_eps
             else:
                 lj14 = 0.0
                 warnings.warn('Unable to infer LJ 1-4 scaling'

--- a/mbuild/tests/test_cassandramcf.py
+++ b/mbuild/tests/test_cassandramcf.py
@@ -371,3 +371,14 @@ class TestCassandraMCF(BaseTest):
         assert int(mcf_data[frag_section_start+4][1]) == 5
         assert int(mcf_data[frag_section_start+5][1]) == 5
         assert int(mcf_data[frag_section_start+6][1]) == 5
+
+    def test_infer_14_scaling_zero_eps(self):
+        import mbuild
+        import foyer
+        from mbuild.formats.cassandramcf import write_mcf
+        mol = mbuild.load("CO", smiles=True)
+        mol_ff = foyer.forcefields.load_OPLSAA().apply(mol)
+        with pytest.warns(UserWarning):
+            write_mcf(mol_ff, "test.mcf", angle_style="harmonic", dihedral_style="opls")
+
+


### PR DESCRIPTION
### PR Summary:

Closes #813 and adds the relevant unit test.

The MCF writer tries to infer the 1-4 scaling factors from some of the data in the `Structure.adjusts`. However, if one of the `epsilon` values is `0.0`, this results in a division by zero, and an error. An example molecule is methanol, where the `H` on the `O` has zero epsilon and the 1-4 interaction is between that and the `H` on the carbon.  

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
