### PR TITLE
Intermol fixes

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2138,7 +2138,8 @@ class Compound(object):
         mbuild.conversion.to_intermol
 
         """
-        return conversion.to_intermol(compound=self, molecule_types=None)
+        return conversion.to_intermol(compound=self,
+                                      molecule_types=molecule_types)
 
     def get_smiles(self):
         """Get SMILES string for compound

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1470,16 +1470,20 @@ def to_intermol(compound, molecule_types=None):  # pragma: no cover
     import simtk.unit as u
 
     if isinstance(molecule_types, list):
+        print(f'my moltypes: {molecule_types}')
         molecule_types = tuple(molecule_types)
     elif molecule_types is None:
-        molecule_types = (type(compound),)
+        print(f'my moltype none: {molecule_types}')
+        molecule_types = (compound.name,)
     intermol_system = System()
 
     last_molecule_compound = None
     for atom_index, atom in enumerate(compound.particles()):
         for parent in atom.ancestors():
             # Don't want inheritance via isinstance().
-            if type(parent) in molecule_types:
+            print(parent.name)
+            print(parent.name in molecule_types)
+            if parent.name in molecule_types:
                 # Check if we have encountered this molecule type before.
                 if parent.name not in intermol_system.molecule_types:
                     _add_intermol_molecule_type(intermol_system, parent)

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1470,10 +1470,8 @@ def to_intermol(compound, molecule_types=None):  # pragma: no cover
     import simtk.unit as u
 
     if isinstance(molecule_types, list):
-        print(f'my moltypes: {molecule_types}')
         molecule_types = tuple(molecule_types)
     elif molecule_types is None:
-        print(f'my moltype none: {molecule_types}')
         molecule_types = (compound.name,)
     intermol_system = System()
 
@@ -1481,8 +1479,6 @@ def to_intermol(compound, molecule_types=None):  # pragma: no cover
     for atom_index, atom in enumerate(compound.particles()):
         for parent in atom.ancestors():
             # Don't want inheritance via isinstance().
-            print(parent.name)
-            print(parent.name in molecule_types)
             if parent.name in molecule_types:
                 # Check if we have encountered this molecule type before.
                 if parent.name not in intermol_system.molecule_types:

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -671,19 +671,19 @@ class TestCompound(BaseTest):
         molecules = list(intermol_system.molecule_types['Compound'].molecules)
         assert len(molecules[0].atoms) == 11
 
-    @pytest.mark.xfail(strict=False)
     @pytest.mark.skipif(not has_intermol, reason="InterMol is not installed")
     def test_intermol_conversion2(self, ethane, h2o):
         # 2 distinct Ethane objects.
         compound = mb.Compound([ethane, mb.clone(ethane), h2o])
 
-        molecule_types = [type(ethane), type(h2o)]
+        molecule_types = [ethane.name, h2o.name]
         intermol_system = compound.to_intermol(molecule_types=molecule_types)
         assert len(intermol_system.molecule_types) == 2
         assert 'Ethane' in intermol_system.molecule_types
         assert 'H2O' in intermol_system.molecule_types
-        assert len(intermol_system.molecule_types['Ethane'].bonds) == 7
-        assert len(intermol_system.molecule_types['H2O'].bonds) == 2
+
+        assert len(intermol_system.molecule_types['Ethane'].bond_forces) == 7
+        assert len(intermol_system.molecule_types['H2O'].bond_forces) == 2
 
         assert len(intermol_system.molecule_types['Ethane'].molecules) == 2
         ethanes = list(intermol_system.molecule_types['Ethane'].molecules)


### PR DESCRIPTION
### PR Summary:
Previously, (h/t to @jennyfothergill) our `intermol` converters had
silently been skipping their unit tests, this has now been fixed.

There was some malformed logic in some of the tests when converting an
`mbuild.Compound` to an `intermol.System`. This was due to a few
factors, where the `molecule_types` function argument was always being
set to `None` and not the user-provided values. This caused issues when
naming and distinguishing different `Compounds` during conversion. Also,
to determine if the correct number of bonds were present for each
`molecule_type`, you have to access the `bond_forces` for that
`molecule_type`, which was being incorrectly called.

NOTE: The `#pragma no cover` has not been removed, but testing should be happening again.
### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?

Tangentially closes #399 
