### PR TITLE
Fix line continuation error in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /mbuild
 RUN conda update conda -yq && \
 	conda config --set always_yes yes --set changeps1 no && \
 	. /opt/conda/etc/profile.d/conda.sh && \
-    sed -i -E "s/python.*$/python="$(PY_VERSION)"/" environment-dev.yml
+    sed -i -E "s/python.*$/python="$(PY_VERSION)"/" environment-dev.yml && \
 	conda env create nomkl --file environment-dev.yml && \
 	conda activate mbuild-dev && \
     python setup.py install && \


### PR DESCRIPTION
### PR Summary:
Fix line continuation error in Dockerfile. Docker cannot build the image without this addition.
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
