### PR TITLE
Fix edge buffer for solvate in packing.py, add edge unit test

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -685,7 +685,7 @@ def solvate(
 
     # Apply edge buffer
     box_maxs -= edge * 10
-
+    box_mins += edge * 10
     # Build the input file for each compound and call packmol.
     solvated_xyz = _new_xyz_file()
     solute_xyz = _new_xyz_file()

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -248,3 +248,41 @@ class TestPacking(BaseTest):
                     sidemax=2000.0)
         assert all(big_box_of_methane.boundingbox.lengths > [900, 900, 900])
         assert all(big_sphere_of_methane.boundingbox.lengths > [1800, 1800, 1800])
+
+    def test_box_edge(self, h2o, methane):
+        system_box = mb.Box(lengths=(1.8, 1.8, 1.8))
+        packed = mb.fill_box(compound=h2o,
+                             n_compounds=100,
+                             box=system_box,
+                             edge=0.2)
+        edge_sizes = system_box.lengths - packed.boundingbox.lengths
+        assert np.allclose(edge_sizes, np.array([0.4]*3), atol=0.1)
+
+        region = mb.fill_region(compound=h2o,
+                                n_compounds=100,
+                                region=system_box,
+                                edge=0.2)
+        edge_sizes = system_box.lengths - packed.boundingbox.lengths
+        assert np.allclose(edge_sizes, np.array([0.4]*3), atol=0.1)
+
+        sphere = mb.fill_sphere(compound=h2o,
+                                n_compounds=100,
+                                sphere=[2, 2, 2, 1],
+                                edge=0.2)
+        assert np.allclose(sphere.boundingbox.mins, np.array([1.2]*3), atol=0.1)
+        assert np.allclose(sphere.boundingbox.maxs, np.array([2.8]*3), atol=0.1)
+
+        solvated = mb.solvate(solvent=h2o,
+                              solute=methane,
+                              n_solvent=100,
+                              box=system_box,
+                              overlap=0.2)
+        edge_sizes = system_box.lengths - solvated.boundingbox.lengths
+        assert np.allclose(edge_sizes, np.array([0.4]*3), atol=0.1)
+
+
+
+        
+        
+
+


### PR DESCRIPTION
### PR Summary:
It looks like I missed the `solvate` function when fixing the edge buffer being applied to the box mins in #837.  This PR adds the same fix that was used in `fill_box` and `fill_region`. Also, I added a unit test that tests that the buffer is working as expected for each of the packing functions.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
