### PR TITLE
Install jupyter so the entrypoint does not fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN conda update conda -yq && \
     sed -i -E "s/python.*$/python="$(PY_VERSION)"/" environment-dev.yml && \
 	conda env create nomkl --file environment-dev.yml && \
 	conda activate mbuild-dev && \
-	conda install -c conda-forge jupyter && \
+	conda install -c conda-forge nomkl jupyter && \
     python setup.py install && \
 	echo "source activate mbuild-dev" >> \
 	/home/anaconda/.profile && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN conda update conda -yq && \
     sed -i -E "s/python.*$/python="$(PY_VERSION)"/" environment-dev.yml && \
 	conda env create nomkl --file environment-dev.yml && \
 	conda activate mbuild-dev && \
+	conda install -c conda-forge jupyter && \
     python setup.py install && \
 	echo "source activate mbuild-dev" >> \
 	/home/anaconda/.profile && \


### PR DESCRIPTION
### PR Summary:
After testing @rmatsum836 's [dockerfile update for gmso](https://github.com/mosdef-hub/gmso/pull/537) I realized that our conda environment.yml files do not contain `jupyter` which is necessary for our docker images. This patch installs jupyter after the `mbuild-dev` env has been created. 
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
