### PR TITLE
Create compound.bonds() list that is deterministic

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,7 +16,6 @@ dependencies:
   - numpy
   - openbabel>=3
   - rdkit
-  - oset
   - packmol>=20
   - parmed>=3.4.0
   - pip

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -16,7 +16,6 @@ dependencies:
   - numpy
   - openbabel>=3.0.0
   - rdkit
-  - oset
   - packmol=1!18.013
   - parmed>=3.4.0
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ dependencies:
   - ele
   - numpy
   - rdkit
-  - oset
   - packmol>=18
   - parmed>=3.4.0
   - python<=3.8

--- a/mbuild/bond_graph.py
+++ b/mbuild/bond_graph.py
@@ -41,6 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from collections import defaultdict
 
+from mbuild.utils.orderedset import OrderedSet
+
 
 class BondGraph(object):
     """A graph-like object used to store and manipulate bonding information.
@@ -51,12 +53,12 @@ class BondGraph(object):
     """
 
     def __init__(self):
-        self._adj = defaultdict(set)
+        self._adj = defaultdict(OrderedSet)
 
     def add_node(self, node):
         """Add a node to the bond graph."""
         if not self.has_node(node):
-            self._adj[node] = set()
+            self._adj[node] = OrderedSet()
 
     def remove_node(self, node):
         """Remove a node from the bond graph."""
@@ -109,12 +111,12 @@ class BondGraph(object):
 
     def edges(self):
         """Return all edges in the bond graph."""
-        edges = set()
+        edges = OrderedSet()
         for node, neighbors in self._adj.items():
             for neighbor in neighbors:
                 bond = (
                     (node, neighbor)
-                    if id(node) < id(neighbor)
+                    if self.nodes().index(node) > self.nodes().index(neighbor)
                     else (neighbor, node)
                 )
                 edges.add(bond)

--- a/mbuild/coarse_graining.py
+++ b/mbuild/coarse_graining.py
@@ -2,9 +2,9 @@
 from collections import OrderedDict
 from copy import deepcopy
 
-from mbuild.utils.orderedset import OrderedSet
 from mbuild.compound import Compound, clone
 from mbuild.exceptions import MBuildError
+from mbuild.utils.orderedset import OrderedSet
 
 __all__ = ["coarse_grain"]
 

--- a/mbuild/coarse_graining.py
+++ b/mbuild/coarse_graining.py
@@ -2,8 +2,7 @@
 from collections import OrderedDict
 from copy import deepcopy
 
-from oset import oset as OrderedSet
-
+from mbuild.utils.orderedset import OrderedSet
 from mbuild.compound import Compound, clone
 from mbuild.exceptions import MBuildError
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -13,7 +13,6 @@ import ele
 import numpy as np
 from ele.element import Element, element_from_name, element_from_symbol
 from ele.exceptions import ElementError
-from oset import oset as OrderedSet
 
 from mbuild import conversion
 from mbuild.bond_graph import BondGraph
@@ -24,6 +23,7 @@ from mbuild.periodic_kdtree import PeriodicCKDTree
 from mbuild.utils.exceptions import RemovedFuncError
 from mbuild.utils.io import import_, run_from_ipython
 from mbuild.utils.jsutils import overwrite_nglview_default
+from mbuild.utils.orderedset import OrderedSet
 
 
 def clone(existing_compound, clone_of=None, root_container=None):

--- a/mbuild/formats/protobuf.py
+++ b/mbuild/formats/protobuf.py
@@ -152,7 +152,7 @@ def _proto_to_mb(proto):
     ----------
     proto: compound_pb2.Compound()
     """
-    if proto.element.symbol is "":
+    if proto.element.symbol == "":
         elem = None
     else:
         elem = ele.element_from_symbol(proto.element.symbol)

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -1,4 +1,5 @@
 """Ordered set module.
+
 Based on oset by Raymond Hettinger, with the following license:
 Copyright (c) 2009, Raymond Hettinger, and others All rights reserved.
 Package structured based on the one developed to odict Copyright (c) 2010,
@@ -43,7 +44,9 @@ T = TypeVar("T")
 
 class OrderedSet(MutableSet):
     """An ordered set object with additional convenience methods.
+
     Based on oset by Raymond Hettinger (see module for license)
+
     Methods
     -------
     add
@@ -71,6 +74,7 @@ class OrderedSet(MutableSet):
         return key in self.map
 
     def __iter__(self):
+        """Return an iterable of the set."""
         end = self.end
         curr = end[2]
         while curr is not end:
@@ -105,11 +109,13 @@ class OrderedSet(MutableSet):
         """Delete the set."""
         self.clear()
 
-    def union(self, *sets: Union[Sequence[T], Set[T]]) -> "OrderedSet[T]":
-        """
-        Combines all unique items.
+    def union(self, *sets: Union[Sequence[T], Set[T]]):
+        """Combine all unique items.
+
         Each items order is defined by its first appearance.
+
         Example:
+        ________
             >>> oset = OrderedSet.union(OrderedSet([3, 1, 4, 1, 5]), [1, 3], [2, 0])
             >>> print(oset)
             OrderedSet([3, 1, 4, 5, 2, 0])
@@ -124,12 +130,14 @@ class OrderedSet(MutableSet):
         return cls(items)
 
     def add(self, key):
+        """Add the key to the set."""
         if key not in self.map:
             end = self.end
             curr = end[1]
             curr[2] = end[1] = self.map[key] = [key, curr, end]
 
     def discard(self, key):
+        """Delete the key from the set."""
         if key in self.map:        
             key, prev, next = self.map.pop(key)
             prev[2] = next

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -115,7 +115,7 @@ class OrderedSet(MutableSet):
         Each items order is defined by its first appearance.
 
         Example:
-        ________
+        -------
             >>> oset = OrderedSet.union(OrderedSet([3, 1, 4, 1, 5]), [1, 3], [2, 0])
             >>> print(oset)
             OrderedSet([3, 1, 4, 5, 2, 0])

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -1,0 +1,148 @@
+"""Ordered set module.
+Based on oset by Raymond Hettinger, with the following license:
+Copyright (c) 2009, Raymond Hettinger, and others All rights reserved.
+Package structured based on the one developed to odict Copyright (c) 2010,
+    BlueDynamics Alliance, Austria
+ - Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ - Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ - Neither the name of the BlueDynamics Alliance nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY BlueDynamics Alliance AS IS AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL BlueDynamics Alliance BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+from collections.abc import MutableSet
+import itertools as it
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    MutableSet,
+    Optional,
+    Sequence,
+    Set,
+    TypeVar,
+    Union,
+    overload,
+)
+KEY, PREV, NEXT = range(3)
+T = TypeVar("T")
+
+class OrderedSet(MutableSet):
+    """An ordered set object with additional convenience methods.
+    Based on oset by Raymond Hettinger (see module for license)
+    Methods
+    -------
+    add
+    discard
+    index
+    list
+    pop
+    union
+    """
+
+    def __init__(self, iterable=None):
+        self.end = end = []
+        end += [None, end, end]  # sentinel node for doubly linked list
+        self.map = {}  # key --> [key, prev, next]
+        self._list = None
+        if iterable is not None:
+            self |= iterable
+
+    def __len__(self):
+        """Return the length."""
+        return len(self.map)
+
+    def __contains__(self, key):
+        """Determine whether the set contains a key."""
+        return key in self.map
+
+    def __iter__(self):
+        end = self.end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        """Iterate through the set in reverse."""
+        end = self.end
+        curr = end[PREV]
+        while curr is not end:
+            yield curr[KEY]
+            curr = curr[PREV]
+
+    def __getitem__(self, value):
+        """Get an item."""
+        return list(self)[value]
+
+    def __repr__(self):
+        """Get the set representation."""
+        if not self:
+            return f"{self.__class__.__name__}"
+        return f"{self.__class__.__name__}({list(self)})"
+
+    def __eq__(self, other):
+        """Determine if set is equal to other."""
+        if isinstance(other, OrderedSet):
+            return len(self) == len(other) and list(self) == list(other)
+        return set(self) == set(other)
+
+    def __del__(self):
+        """Delete the set."""
+        self.clear()
+
+    def union(self, *sets: Union[Sequence[T], Set[T]]) -> "OrderedSet[T]":
+        """
+        Combines all unique items.
+        Each items order is defined by its first appearance.
+        Example:
+            >>> oset = OrderedSet.union(OrderedSet([3, 1, 4, 1, 5]), [1, 3], [2, 0])
+            >>> print(oset)
+            OrderedSet([3, 1, 4, 5, 2, 0])
+            >>> oset.union([8, 9])
+            OrderedSet([3, 1, 4, 5, 2, 0, 8, 9])
+            >>> oset | {10}
+            OrderedSet([3, 1, 4, 5, 2, 0, 10])
+        """
+        cls = self.__class__ if isinstance(self, OrderedSet) else OrderedSet
+        containers = map(list, it.chain([self], sets))
+        items = it.chain.from_iterable(containers)
+        return cls(items)
+
+    def add(self, key):
+        if key not in self.map:
+            end = self.end
+            curr = end[1]
+            curr[2] = end[1] = self.map[key] = [key, curr, end]
+
+    def discard(self, key):
+        if key in self.map:        
+            key, prev, next = self.map.pop(key)
+            prev[2] = next
+            next[1] = prev
+
+    def pop(self, last=True):
+        """Remove a value from the set and return the value."""
+        if not self:
+            raise KeyError("set is empty")
+        key = next(reversed(self)) if last else next(iter(self))
+        self.discard(key)
+        return key
+
+    def index(self, value):
+        """Get the index of a value."""
+        return list(self).index(value)

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -23,8 +23,8 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
-from collections.abc import MutableSet
 import itertools as it
+from collections.abc import MutableSet
 from typing import (
     Any,
     Dict,
@@ -39,8 +39,10 @@ from typing import (
     Union,
     overload,
 )
+
 KEY, PREV, NEXT = range(3)
 T = TypeVar("T")
+
 
 class OrderedSet(MutableSet):
     """An ordered set object with additional convenience methods.
@@ -138,7 +140,7 @@ class OrderedSet(MutableSet):
 
     def discard(self, key):
         """Delete the key from the set."""
-        if key in self.map:        
+        if key in self.map:
             key, prev, next = self.map.pop(key)
             prev[2] = next
             next[1] = prev


### PR DESCRIPTION
### PR Summary:
This PR aims to improve the logic that creates a list of the bonds in compound.bonds(), in order to make that list fixed every time. This includes the ordering of which nodes comes first in the bond, and the ordering of the bonds that make up the list.

It will use the already deterministic list of nodes that make up the compound.bond_graph to order atoms within the bond by their index. Finally, it will take advantage of the new ordered set object from #891 to order the bonds. 

This PR will wait until #891 is merged in order to make sure it is compliant with the ordered set module. However, it should be working properly with the [simonpercivall OrderedSet module](https://github.com/simonpercivall/orderedset).

The issues this PR addresses are raised in #895 

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
