### PR TITLE
Update oset

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,7 +116,7 @@ _python_doc_base = "https://docs.python.org/3.7"
 
 intersphinx_mapping = {
     _python_doc_base: None,
-    "https://docs.scipy.org/doc/numpy": None,
+    "https://numpy.org/doc/stable": None,
     "https://docs.scipy.org/doc/scipy/reference": None,
     "https://scikit-learn.org/stable": None,
 }

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,8 +15,6 @@ dependencies:
   - nglview>=3
   - numpy
   - openbabel>=3
-  - rdkit
-  - oset
   - packmol>=20
   - parmed>=3.4.0
   - pip
@@ -28,4 +26,5 @@ dependencies:
   - pytest-azurepipelines
   - pytest-cov
   - python<=3.8
+  - rdkit
   - scipy

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -15,8 +15,6 @@ dependencies:
   - nglview>=2.7
   - numpy
   - openbabel>=3.0.0
-  - rdkit
-  - oset
   - packmol=1!18.013
   - parmed>=3.4.0
   - pip
@@ -27,4 +25,5 @@ dependencies:
   - pytest>=3.0
   - pytest-cov
   - python<=3.8
+  - rdkit
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,8 @@ channels:
 dependencies:
   - ele
   - numpy
-  - rdkit
-  - oset
   - packmol>=18
   - parmed>=3.4.0
   - python<=3.8
+  - rdkit
   - scipy

--- a/mbuild/coarse_graining.py
+++ b/mbuild/coarse_graining.py
@@ -2,10 +2,9 @@
 from collections import OrderedDict
 from copy import deepcopy
 
-from oset import oset as OrderedSet
-
 from mbuild.compound import Compound, clone
 from mbuild.exceptions import MBuildError
+from mbuild.utils.orderedset import OrderedSet
 
 __all__ = ["coarse_grain"]
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -13,7 +13,6 @@ import ele
 import numpy as np
 from ele.element import Element, element_from_name, element_from_symbol
 from ele.exceptions import ElementError
-from oset import oset as OrderedSet
 
 from mbuild import conversion
 from mbuild.bond_graph import BondGraph
@@ -24,6 +23,7 @@ from mbuild.periodic_kdtree import PeriodicCKDTree
 from mbuild.utils.exceptions import RemovedFuncError
 from mbuild.utils.io import import_, run_from_ipython
 from mbuild.utils.jsutils import overwrite_nglview_default
+from mbuild.utils.orderedset import OrderedSet
 
 
 def clone(existing_compound, clone_of=None, root_container=None):
@@ -841,7 +841,6 @@ class Compound(object):
         -------
         list of mb.Compound
             A list of all Ports referenced by this Compound and its successors
-
         """
         from mbuild.port import Port
 

--- a/mbuild/lib/recipes/silica_interface.py
+++ b/mbuild/lib/recipes/silica_interface.py
@@ -134,7 +134,7 @@ class SilicaInterface(Compound):
 
     def _identify_surface_sites(self, thickness):
         """Label surface sites and add ports above them."""
-        for atom in self.particles():
+        for atom in list(self.particles()):
             if len(self.bond_graph.neighbors(atom)) == 1:
                 if atom.name == "O" and atom.pos[2] > thickness:
                     atom.name = "O_surface"

--- a/mbuild/lib/recipes/tiled_compound.py
+++ b/mbuild/lib/recipes/tiled_compound.py
@@ -47,7 +47,7 @@ class TiledCompound(Compound):
         self.periodicity = np.array(tile.periodicity * n_tiles)
 
         if all(n_tiles == 1):
-            self._add_tile(tile, [(0, 0, 0)])
+            self._add_tile(tile, (0, 0, 0))
             self._hoist_ports(tile)
             return  # Don't waste time copying and checking bonds.
 
@@ -61,9 +61,7 @@ class TiledCompound(Compound):
 
         # Replicate and place periodic tiles.
         # -----------------------------------
-        for ijk in it.product(
-            range(n_tiles[0]), range(n_tiles[1]), range(n_tiles[2])
-        ):
+        for ijk in it.product(*[range(i) for i in n_tiles]):
             new_tile = clone(tile)
             new_tile.translate(np.array(ijk * tile.periodicity))
             self._add_tile(new_tile, ijk)
@@ -131,7 +129,8 @@ class TiledCompound(Compound):
 
     def _add_tile(self, new_tile, ijk):
         """Add a tile with a label indicating its tiling position."""
-        tile_label = "{0}_{1}".format(self.name, "-".join(str(d) for d in ijk))
+        i, j, k = ijk
+        tile_label = f"{self.name}_{i}-{j}-{k}"
         self.add(new_tile, label=tile_label, inherit_periodicity=False)
 
     def _hoist_ports(self, new_tile):

--- a/mbuild/lib/surfaces/amorphous_silica_surface.py
+++ b/mbuild/lib/surfaces/amorphous_silica_surface.py
@@ -25,7 +25,7 @@ class AmorphousSilicaSurface(mb.Compound):
                 "add it! ".format(surface_roughness)
             )
         count = 0
-        for particle in self.particles():
+        for particle in list(self.particles()):
             if particle.name == "OB":
                 count += 1
                 port = mb.Port(

--- a/mbuild/lib/surfaces/betacristobalite.py
+++ b/mbuild/lib/surfaces/betacristobalite.py
@@ -32,7 +32,7 @@ class Betacristobalite(mb.Compound):
         self.periodicity = np.array([5.3888, 4.6669, 0.0])
 
         count = 0
-        for particle in self.particles():
+        for particle in list(self.particles()):
             if particle.name.startswith("O") and particle.pos[2] > 1.0:
                 count += 1
                 port = mb.Port(

--- a/mbuild/tests/test_rigid.py
+++ b/mbuild/tests/test_rigid.py
@@ -451,7 +451,7 @@ class TestRigid(BaseTest):
         filled = mb.fill_box(
             rigid_benzene, n_compounds=n_benzenes, box=[0, 0, 0, 4, 4, 4]
         )
-        for particle in filled.children[0].particles():
+        for particle in list(filled.children[0].particles()):
             filled.remove(particle)
 
         assert filled.max_rigid_id == n_benzenes - 2

--- a/mbuild/tests/test_tiled_compound.py
+++ b/mbuild/tests/test_tiled_compound.py
@@ -1,6 +1,5 @@
 import pytest
 
-import mbuild as mb
 from mbuild.lib.recipes import TiledCompound
 from mbuild.tests.base_test import BaseTest
 
@@ -10,7 +9,7 @@ class TestTiledCompound(BaseTest):
         nx = 2
         ny = 3
         nz = 1
-        tiled = mb.recipes.TiledCompound(betacristobalite, [nx, ny, nz])
+        tiled = TiledCompound(betacristobalite, [nx, ny, nz])
         assert tiled.n_particles == 1900 * nx * ny
         assert tiled.n_bonds == 2400 * nx * ny
         for at in tiled.particles():
@@ -29,7 +28,7 @@ class TestTiledCompound(BaseTest):
         nx = 1
         ny = 1
         nz = 1
-        tiled = mb.recipes.TiledCompound(betacristobalite, [nx, ny, nz])
+        tiled = TiledCompound(betacristobalite, [nx, ny, nz])
         assert tiled.n_particles == 1900 * nx * ny
         assert tiled.n_bonds == 2400 * nx * ny
 
@@ -38,11 +37,11 @@ class TestTiledCompound(BaseTest):
         ny = 3
         nz = 2
         with pytest.raises(ValueError):
-            mb.recipes.TiledCompound(betacristobalite, [nx, ny, nz])
+            TiledCompound(betacristobalite, [nx, ny, nz])
 
     def test_negative_periodicity(self, betacristobalite):
         nx = -2
         ny = 3
         nz = 2
         with pytest.raises(ValueError):
-            mb.recipes.TiledCompound(betacristobalite, [nx, ny, nz])
+            TiledCompound(betacristobalite, [nx, ny, nz])

--- a/mbuild/tests/test_utils.py
+++ b/mbuild/tests/test_utils.py
@@ -37,6 +37,28 @@ class TestUtils(BaseTest):
 
         assert [i for i in oset] == [0, 1, "this"]
 
+    def test_orderedset_setmethods(self):
+        oset = OrderedSet(1, 2, 3, 4)
+        oset2 = OrderedSet(2, 4, 6, 8)
+
+        union = oset.union(oset2)
+        union2 = oset2.union(oset)
+
+        assert union == union2
+        assert union == set([1, 2, 3, 4, 6, 8])
+
+        inter = oset.intersection(oset2)
+        inter2 = oset2.intersection(oset)
+
+        assert inter == inter2
+        assert inter == set([2, 4])
+
+        diff = oset.difference(oset2)
+        diff2 = oset2.difference(oset)
+
+        assert diff == set([1, 3])
+        assert diff2 == set([6, 8])
+
     def test_assert_port_exists(self, ch2):
         assert_port_exists("up", ch2)
         with pytest.raises(ValueError):

--- a/mbuild/tests/test_utils.py
+++ b/mbuild/tests/test_utils.py
@@ -9,10 +9,34 @@ from mbuild.utils.exceptions import RemovedFuncError
 from mbuild.utils.geometry import wrap_coords
 from mbuild.utils.io import get_fn, import_, run_from_ipython
 from mbuild.utils.jsutils import overwrite_nglview_default
+from mbuild.utils.orderedset import OrderedSet
 from mbuild.utils.validation import assert_port_exists
 
 
 class TestUtils(BaseTest):
+    def test_orderedset(self):
+        oset_empty = OrderedSet()
+
+        assert isinstance(oset_empty, OrderedSet)
+        assert len(oset_empty) == 0
+
+        oset = OrderedSet("heck", 0, 1)
+
+        assert isinstance(oset, OrderedSet)
+        assert len(oset) == 3
+        assert "heck" in oset
+        assert oset[1] == 0
+
+        oset.add("this")
+
+        assert "this" in oset
+
+        oset.discard("heck")
+
+        assert "heck" not in oset
+
+        assert [i for i in oset] == [0, 1, "this"]
+
     def test_assert_port_exists(self, ch2):
         assert_port_exists("up", ch2)
         with pytest.raises(ValueError):

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -59,7 +59,10 @@ class OrderedSet(MutableSet):
 
     def intersection(self, iterable):
         """Return the intersection of this set and an iterable."""
-        return OrderedSet(*[i for i in self if i in iterable])
+        new = OrderedSet()
+        data = {i: None for i in self._data if i in iterable}
+        new._data = data
+        return new
 
     def difference(self, iterable):
         """Return the difference of this set and an iterable."""

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -32,7 +32,7 @@ class OrderedSet(MutableSet):
 
     def __getitem__(self, value):
         """Get an item at index `value`."""
-        return list(self._data)[value]
+        return self._list[value]
 
     def __iter__(self):
         """Iterate through the set."""
@@ -42,12 +42,21 @@ class OrderedSet(MutableSet):
         """Return the length."""
         return len(self._data)
 
+    @property
+    def _list(self):
+        try:
+            return self._cached_list
+        except AttributeError:
+            self._cached_list = list(self._data)
+
     def add(self, value):
         """Add a value."""
+        self.__dict__.pop("_cached_list", None)
         self._data[value] = None
 
     def discard(self, value):
         """Remove a value."""
+        self.__dict__.pop("_cached_list", None)
         self._data.pop(value, None)
 
     def remove(self, value):

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -52,10 +52,11 @@ class OrderedSet(MutableSet):
 
     def union(self, iterable):
         """Return the union of this set and an iterable."""
-        newone = deepcopy(self)
-        for i in iterable:
-            newone.add(i)
-        return newone
+        new = OrderedSet()
+        data = {**{i: None for i in self._data},
+                **{i: None for i in iterable}}
+        new._data = data
+        return new
 
     def intersection(self, iterable):
         """Return the intersection of this set and an iterable."""

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -23,7 +23,7 @@ class OrderedSet(MutableSet):
 
     def __repr__(self):
         """Return the OrderedSet representation."""
-        data = ", ".join([str(i) for i in self._data])
+        data = ", ".join(str(i) for i in self._data)
         return f"{self.__class__.__name__}({data})"
 
     def __contains__(self, key):

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -1,5 +1,6 @@
 """Ordered set module."""
 from collections.abc import MutableSet
+from copy import deepcopy
 
 
 class OrderedSet(MutableSet):
@@ -19,6 +20,11 @@ class OrderedSet(MutableSet):
 
     def __init__(self, *args):
         self._data = {value: None for value in args}
+
+    def __repr__(self):
+        """Return the OrderedSet representation."""
+        data = ", ".join([str(i) for i in self._data])
+        return f"{self.__class__.__name__}({data})"
 
     def __contains__(self, key):
         """Determine whether the element `key` is in the set."""
@@ -46,12 +52,15 @@ class OrderedSet(MutableSet):
 
     def union(self, iterable):
         """Return the union of this set and an iterable."""
-        return set(self._data) | set(iterable)
+        newone = deepcopy(self)
+        for i in iterable:
+            newone.add(i)
+        return newone
 
     def intersection(self, iterable):
         """Return the intersection of this set and an iterable."""
-        return set(self._data) & set(iterable)
+        return OrderedSet(*[i for i in self if i in iterable])
 
     def difference(self, iterable):
         """Return the difference of this set and an iterable."""
-        return set(self._data) - set(iterable)
+        return OrderedSet(*[i for i in self if i not in iterable])

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -5,13 +5,13 @@ from collections.abc import MutableSet
 class OrderedSet(MutableSet):
     """An ordered set object with additional convenience methods.
 
+    Taken from code suggested by Vyas in
     https://github.com/mosdef-hub/mbuild/issues/865
 
     Methods
     -------
     add
     discard
-    index
     """
 
     def __init__(self, *args):
@@ -26,8 +26,8 @@ class OrderedSet(MutableSet):
         return list(self._data)[value]
 
     def __iter__(self):
-        """Iterate through a copy."""
-        return iter(list(self._data))
+        """Iterate through the set."""
+        return iter(self._data)
 
     def __len__(self):
         """Return the length."""
@@ -40,7 +40,3 @@ class OrderedSet(MutableSet):
     def discard(self, value):
         """Remove a value."""
         self._data.pop(value, None)
-
-    def index(self, value):
-        """Get the index of a value."""
-        return list(self._data).index(value)

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -1,0 +1,46 @@
+"""Ordered set module."""
+from collections.abc import MutableSet
+
+
+class OrderedSet(MutableSet):
+    """An ordered set object with additional convenience methods.
+
+    https://github.com/mosdef-hub/mbuild/issues/865
+
+    Methods
+    -------
+    add
+    discard
+    index
+    """
+
+    def __init__(self, *args):
+        self._data = {value: None for value in args}
+
+    def __contains__(self, key):
+        """Determine whether the set contains a key."""
+        return key in self._data
+
+    def __getitem__(self, value):
+        """Get an item."""
+        return list(self._data)[value]
+
+    def __iter__(self):
+        """Iterate through a copy."""
+        return iter(list(self._data))
+
+    def __len__(self):
+        """Return the length."""
+        return len(self._data)
+
+    def add(self, value):
+        """Add a value."""
+        self._data[value] = None
+
+    def discard(self, value):
+        """Remove a value."""
+        self._data.pop(value, None)
+
+    def index(self, value):
+        """Get the index of a value."""
+        return list(self._data).index(value)

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -18,7 +18,7 @@ class OrderedSet(MutableSet):
         self._data = {value: None for value in args}
 
     def __contains__(self, key):
-        """Determine whether the set contains a key."""
+        """Determine whether the element `key` is in the set."""
         return key in self._data
 
     def __getitem__(self, value):

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -53,17 +53,20 @@ class OrderedSet(MutableSet):
     def union(self, iterable):
         """Return the union of this set and an iterable."""
         new = OrderedSet()
-        data = {**{i: None for i in self._data}, **{i: None for i in iterable}}
-        new._data = data
+        new._data = {
+            **{i: None for i in self._data},
+            **{i: None for i in iterable},
+        }
         return new
 
     def intersection(self, iterable):
         """Return the intersection of this set and an iterable."""
         new = OrderedSet()
-        data = {i: None for i in self._data if i in iterable}
-        new._data = data
+        new._data = {i: None for i in self._data if i in iterable}
         return new
 
     def difference(self, iterable):
         """Return the difference of this set and an iterable."""
-        return OrderedSet(*[i for i in self if i not in iterable])
+        new = OrderedSet()
+        new._data = {i: None for i in self._data if i not in iterable}
+        return new

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -53,8 +53,7 @@ class OrderedSet(MutableSet):
     def union(self, iterable):
         """Return the union of this set and an iterable."""
         new = OrderedSet()
-        data = {**{i: None for i in self._data},
-                **{i: None for i in iterable}}
+        data = {**{i: None for i in self._data}, **{i: None for i in iterable}}
         new._data = data
         return new
 

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -32,7 +32,7 @@ class OrderedSet(MutableSet):
 
     def __getitem__(self, value):
         """Get an item at index `value`."""
-        return self._list[value]
+        return list(self._data)[value]
 
     def __iter__(self):
         """Iterate through the set."""
@@ -42,21 +42,12 @@ class OrderedSet(MutableSet):
         """Return the length."""
         return len(self._data)
 
-    @property
-    def _list(self):
-        try:
-            return self._cached_list
-        except AttributeError:
-            self._cached_list = list(self._data)
-
     def add(self, value):
         """Add a value."""
-        self.__dict__.pop("_cached_list", None)
         self._data[value] = None
 
     def discard(self, value):
         """Remove a value."""
-        self.__dict__.pop("_cached_list", None)
         self._data.pop(value, None)
 
     def remove(self, value):

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -1,6 +1,5 @@
 """Ordered set module."""
 from collections.abc import MutableSet
-from copy import deepcopy
 
 
 class OrderedSet(MutableSet):

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -12,6 +12,9 @@ class OrderedSet(MutableSet):
     -------
     add
     discard
+    union
+    intersection
+    difference
     """
 
     def __init__(self, *args):
@@ -22,7 +25,7 @@ class OrderedSet(MutableSet):
         return key in self._data
 
     def __getitem__(self, value):
-        """Get an item at index `value`"""
+        """Get an item at index `value`."""
         return list(self._data)[value]
 
     def __iter__(self):
@@ -40,3 +43,15 @@ class OrderedSet(MutableSet):
     def discard(self, value):
         """Remove a value."""
         self._data.pop(value, None)
+
+    def union(self, iterable):
+        """Return the union of this set and an iterable."""
+        return set(self._data) | set(iterable)
+
+    def intersection(self, iterable):
+        """Return the intersection of this set and an iterable."""
+        return set(self._data) & set(iterable)
+
+    def difference(self, iterable):
+        """Return the difference of this set and an iterable."""
+        return set(self._data) - set(iterable)

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -22,7 +22,7 @@ class OrderedSet(MutableSet):
         return key in self._data
 
     def __getitem__(self, value):
-        """Get an item."""
+        """Get an item at index `value`"""
         return list(self._data)[value]
 
     def __iter__(self):

--- a/mbuild/utils/orderedset.py
+++ b/mbuild/utils/orderedset.py
@@ -50,6 +50,10 @@ class OrderedSet(MutableSet):
         """Remove a value."""
         self._data.pop(value, None)
 
+    def remove(self, value):
+        """Remove a value. Alias for discard."""
+        self.discard(value)
+
     def union(self, iterable):
         """Return the union of this set and an iterable."""
         new = OrderedSet()


### PR DESCRIPTION
### PR Summary:

fixes #865 

(this is a clean version of https://github.com/mosdef-hub/mbuild/pull/891)

Big shout out to @vyasr who suggested that we create our own OrderedSet class! Most of the code in this implementation is straight from his comment. This pr removes an unmaintained dependency and replaces it with <50 lines including documentation.

**This is a breaking change!** 
This PR will break the functionality of adding or removing children while iterating: e.g.
```
# this is broken
for p in compound.particles():
    if p.name == "H":
        compound.remove(p)
```
It can be fixed by making a copy to a list (or tuple)
```
# this is fine
for p in list(compound.particles()):
    if p.name == "H":
        compound.remove(p)
```
I looked into if we could catch the error that will be thrown if a user tries to modify while iterating, but it is thrown by the `dict_keyiterator` object and I'm not sure how to catch it... 

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
