### PR TITLE
Add write_atomnames option to xyz writer

### DIFF
--- a/mbuild/formats/xyz.py
+++ b/mbuild/formats/xyz.py
@@ -89,7 +89,7 @@ def read_xyz(filename, compound=None):
     return compound
 
 
-def write_xyz(structure, filename):
+def write_xyz(structure, filename, write_atomtypes=False):
     """Output an XYZ file.
 
     Parameters
@@ -98,11 +98,14 @@ def write_xyz(structure, filename):
         ParmEd structure object
     filename : str
         Path of the output file
+    write_atomtypes : bool
+        Write the `atom.name` attribute of the parmed structure
+        to the first column of the xyz file rather than the element
 
     Notes
     -----
-    Coordatates are written in Angstroms. This follows the convention for the
-    XYZ file format.
+    Coordinates are written in Angstroms. By default, the first column is the
+    element. These choices follow the conventions for the XYZ file format.
 
     The XYZ file format neglects many important details, notably as bonds,
     residues, and box information.
@@ -111,12 +114,15 @@ def write_xyz(structure, filename):
         raise ValueError("Expected a ParmEd structure, got an mbuild.Compound")
 
     xyz = np.array([[atom.xx, atom.xy, atom.xz] for atom in structure.atoms])
-    types = [atom.name for atom in structure.atoms]
+    if write_atomtypes:
+        names = [atom.name for atom in structure.atoms]
+    else:
+        names = [atom.element_name for atom in structure.atoms]
 
     with open(filename, "w") as xyz_file:
         xyz_file.write(str(len(structure.atoms)))
         xyz_file.write("\n" + filename + " - created by mBuild\n")
-        for typ, coords in zip(types, xyz):
+        for name, coords in zip(names, xyz):
             xyz_file.write(
-                "{:s} {:11.6f} {:11.6f} {:11.6f}\n".format(typ, *coords)
+                "{:s} {:11.6f} {:11.6f} {:11.6f}\n".format(name, *coords)
             )

--- a/mbuild/formats/xyz.py
+++ b/mbuild/formats/xyz.py
@@ -89,7 +89,7 @@ def read_xyz(filename, compound=None):
     return compound
 
 
-def write_xyz(structure, filename, write_atomtypes=False):
+def write_xyz(structure, filename, write_atomnames=False):
     """Output an XYZ file.
 
     Parameters
@@ -98,7 +98,7 @@ def write_xyz(structure, filename, write_atomtypes=False):
         ParmEd structure object
     filename : str
         Path of the output file
-    write_atomtypes : bool
+    write_atomnames : bool
         Write the `atom.name` attribute of the parmed structure
         to the first column of the xyz file rather than the element
 
@@ -114,7 +114,7 @@ def write_xyz(structure, filename, write_atomtypes=False):
         raise ValueError("Expected a ParmEd structure, got an mbuild.Compound")
 
     xyz = np.array([[atom.xx, atom.xy, atom.xz] for atom in structure.atoms])
-    if write_atomtypes:
+    if write_atomnames:
         names = [atom.name for atom in structure.atoms]
     else:
         names = [atom.element_name for atom in structure.atoms]

--- a/mbuild/tests/test_xyz.py
+++ b/mbuild/tests/test_xyz.py
@@ -55,7 +55,7 @@ class TestXYZ(BaseTest):
 
     def test_write_atomtypes(self):
         tip3p_water = mb.load(get_fn("tip3p_water.xyz"))
-        tip3p_water.save(filename="test.xyz", write_atomtypes=True)
+        tip3p_water.save(filename="test.xyz", write_atomnames=True)
         lines = []
         with open("test.xyz") as f:
             for line in f:

--- a/mbuild/tests/test_xyz.py
+++ b/mbuild/tests/test_xyz.py
@@ -52,3 +52,21 @@ class TestXYZ(BaseTest):
         assert tip3p_water[1].name == "opls_112"
         assert tip3p_water[2].element is None
         assert tip3p_water[2].name == "opls_112"
+
+    def test_write_atomtypes(self):
+        tip3p_water = mb.load(get_fn("tip3p_water.xyz"))
+        tip3p_water.save(filename="test.xyz", write_atomtypes=True)
+        lines = []
+        with open("test.xyz") as f:
+            for line in f:
+                lines.append(line.split())
+        assert lines[2][0] == "opls_111"
+        assert lines[3][0] == "opls_112"
+        assert lines[4][0] == "opls_112"
+        tip3p_water_in = mb.load("test.xyz")
+        assert tip3p_water_in[0].element is None
+        assert tip3p_water_in[0].name == "opls_111"
+        assert tip3p_water_in[1].element is None
+        assert tip3p_water_in[1].name == "opls_112"
+        assert tip3p_water_in[2].element is None
+        assert tip3p_water_in[2].name == "opls_112"


### PR DESCRIPTION
### PR Summary:
Right now the `xyz` writer writes the `atom.name` attribute from the `parmed.Structure` to the first column of the `xyz` file. This PR changes the default behavior, so the `atom.element_name` attribute is written. A `write_atomnames` boolean argument is added to `write_xyz` that flips back to the original behavior (where `atom.name` is saved instead).

The motivation for this PR is two-fold:
* Bring the behavior of our xyz writer into better alignment with our `xyz` reader
* Fix the following quirk: `mbuild.Compound` -> `.xyz` -> `mbuild.Compound` will lose the element information unless the `Compound.name` is the same as the two character element code. Of course now we'll lose the `Compound.name`, but that seems better IMO. 

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
