### PR TITLE
GOMC non-orthogonal box updates

### DIFF
--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -1873,13 +1873,12 @@ class Charmm:
             angles=self.structure_box_0_ff.box[3:6],
         )
 
-        # create box 0 vector list and convert from nm to Ang and round to 6 decimals
-        box_0_vectors_mod = mb_box._lengths_angles_to_vectors(self.box_0.lengths, self.box_0.angles, 8)
-        # create box 0 vector list and convert from nm to Ang and round to 6 decimals
-        print(" test = " + str(mb_box._lengths_angles_to_vectors([1,2,3], [90,90,90], 8)))
-        print(" box_0_vectors_mod = " +str( box_0_vectors_mod))
-        self.box_0_vectors = np.around(box_0_vectors_mod * 10, decimals=6)
-        print("self.box_0_vectors = " + str(self.box_0_vectors))
+        # create box 0 vector list and convert from nm to Ang and round to 6 decimals ()
+        # First, import the values in nm and rounding to 8 decimals and multiply by 10 to get angstroms
+        box_0_vectors_mod = mb_box._lengths_angles_to_vectors(self.box_0.lengths, self.box_0.angles, 7) * 10
+        # create box 0 vector list and round to 6 decimals to avoid errors in the gomc_writer script
+        # still leaves some floating values in some cases
+        self.box_0_vectors =  np.around(box_0_vectors_mod, decimals=6)
 
         # Internally use nm
         if self.structure_box_1:
@@ -1893,11 +1892,13 @@ class Charmm:
                 angles=self.structure_box_1_ff.box[3:6],
             )
 
-            # create box 0 vector list and convert from nm to Ang and round to 6 decimals
-            box_1_vectors_mod = mb_box._lengths_angles_to_vectors(self.box_1.lengths, self.box_1.angles, 6)
-            # create box 0 vector list and convert from nm to Ang and round to 6 decimals
-            print("self.box_0_vectors = " + str(self.box_0_vectors))
-            self.box_1_vectors = np.around(box_1_vectors_mod * 10, decimals=6)
+            # create box 1 vector list and convert from nm to Ang and round to 6 decimals (7 decimals in nm)
+            # First, import the values in nm and rounding to 7 decimals and multiply by 10 to get angstroms
+            box_1_vectors_mod = mb_box._lengths_angles_to_vectors(self.box_1.lengths, self.box_1.angles, 7) * 10
+            # create box 1 vector list and round to 6 decimals to avoid errors in the gomc_writer script
+            # still leaves some floating values in some cases
+            self.box_1_vectors =  np.around(box_1_vectors_mod, decimals=6)
+
 
         # if self.structure_box_1 != None:
         if self.structure_box_1:

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -1256,12 +1256,12 @@ class Charmm:
             residue names in the 'residues' list that was entered.
         box_0 : Box
             The Box class that contains the attributes Lx, Ly, Lz for the length
-            of the box 1 in nm. It also contains the xy, xz, and yz Tilt factors
+            of the box 0 (units in nanometers (nm)). It also contains the xy, xz, and yz Tilt factors
             needed to displace an orthogonal box's xy face to its
             parallelepiped structure for box 0.
         box_1 : Box
             The Box class that contains the attributes Lx, Ly, Lz for the length
-            of the box 1 (units in Angstroms (Ang)). It also contains the xy, xz, and yz Tilt factors
+            of the box 1 (units in nanometers (nm)). It also contains the xy, xz, and yz Tilt factors
             needed to displace an orthogonal box's xy face to its
             parallelepiped structure for box 0.
         box_0_vectors : numpy.ndarray, [[float, float, float], [float, float, float], [float, float, float]]
@@ -1934,7 +1934,6 @@ class Charmm:
                                                         self.box_0.angles,
                                                         precision=6
                                                         )
-
 
         # Internally use nm
         if self.structure_box_1:

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -2110,7 +2110,7 @@ class Charmm:
 
     def write_inp(self):
         """This write_inp function writes the Charmm style parameter (force field) file, which can be utilized
-        in the GOMC and NAMD engines. """
+        in the GOMC and NAMD engines."""
         print("******************************")
         print("")
         print(

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -133,7 +133,7 @@ def _get_angle_type_key(
 
 
 def _get_dihedral_rb_torsion_key(dihedral, epsilon_conversion_factor):
-    """ Get the dihedral_type key for a Ryckaert-Bellemans (RB) dihedrals/torsions
+    """Get the dihedral_type key for a Ryckaert-Bellemans (RB) dihedrals/torsions
 
     Parameters
     ----------
@@ -225,7 +225,7 @@ def _get_dihedral_rb_torsion_key(dihedral, epsilon_conversion_factor):
 
 
 def _get_improper_type_key(improper, epsilon_conversion_factor):
-    """ Get the improper_type key for the harmonic improper
+    """Get the improper_type key for the harmonic improper
 
     Parameters
     ----------
@@ -290,7 +290,7 @@ def _get_improper_type_key(improper, epsilon_conversion_factor):
 def _get_unique_bond_types(
     structure, sigma_conversion_factor, epsilon_conversion_factor
 ):
-    """ Get the unique bond types for a structure in a dictionary
+    """Get the unique bond types for a structure in a dictionary
 
     Parameters
     ----------
@@ -333,7 +333,7 @@ def _get_unique_bond_types(
 def _get_unique_angle_types(
     structure, sigma_conversion_factor, epsilon_conversion_factor
 ):
-    """ Get the unique angle types for a structure and return a dictionary
+    """Get the unique angle types for a structure and return a dictionary
 
     Parameters
     ----------
@@ -377,7 +377,7 @@ def _get_unique_angle_types(
 
 
 def _get_unique_rb_torsion_types(structure, epsilon_conversion_factor):
-    """ Get the unique rb torsion types for a structure and return a dictionary
+    """Get the unique rb torsion types for a structure and return a dictionary
 
     Parameters
     ----------
@@ -426,7 +426,7 @@ def _get_unique_rb_torsion_types(structure, epsilon_conversion_factor):
 
 
 def _get_unique_improper_types(structure, epsilon_conversion_factor):
-    """ Get the unique improper types for a structure  and return a dictionary
+    """Get the unique improper types for a structure  and return a dictionary
 
     Parameters
     ----------
@@ -585,7 +585,7 @@ def _get_angle_types(
                      (angle_k_constant, angle_theta_o, angle_center_atom_type_2,
                      (angle_end_atom_type_1, angle_end_atom_type_3),
                      angle_residue_atom_1, angle_residue_atom_2, angle_residue_atom_3), n])
-        """
+    """
 
     if use_urey_bradleys:
         print_warn_text = (
@@ -789,7 +789,7 @@ def _get_impropers(structure, epsilon_conversion_factor):
           improper_atom_1_res_type, (improper_atom_2_res_type,
           improper_atom_3_res_type, improper_atom_4_res_type)
          ), n ])
-         """
+    """
     unique_improper_types = _get_unique_improper_types(
         structure, epsilon_conversion_factor
     )
@@ -2014,7 +2014,7 @@ class Charmm:
             residue_id_list = []
             residue_id_adder_fixed_struct_wo_bonds = 0 # for example zeolite used as fixed atoms wo bonds
             for f, PSF_atom_iteration_0 in enumerate(
-                    stuct_only_iteration.atoms
+                stuct_only_iteration.atoms
             ):
 
                 if f > 0:
@@ -2109,8 +2109,8 @@ class Charmm:
         )
 
     def write_inp(self):
-        """ This write_inp function writes the Charmm style parameter (force field) file, which can be utilized
-             in the GOMC and NAMD engines. """
+        """This write_inp function writes the Charmm style parameter (force field) file, which can be utilized
+        in the GOMC and NAMD engines. """
         print("******************************")
         print("")
         print(
@@ -3055,8 +3055,8 @@ class Charmm:
         # **********************************
 
     def write_psf(self):
-        """ This write_psf function writes the Charmm style PSF (topology) file, which can be utilized
-                 in the GOMC and NAMD engines. """
+        """This write_psf function writes the Charmm style PSF (topology) file, which can be utilized
+        in the GOMC and NAMD engines."""
         # **********************************
         # **********************************
         # psf writer (start)
@@ -3552,8 +3552,8 @@ class Charmm:
         # **********************************
 
     def write_pdb(self):
-        """ This write_psf function writes the Charmm style PDB (coordinate file), which can be utilized
-                         in the GOMC and NAMD engines. """
+        """This write_psf function writes the Charmm style PDB (coordinate file), which can be utilized
+        in the GOMC and NAMD engines."""
         # **********************************
         # **********************************
         # pdb writer (start)

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -1926,14 +1926,14 @@ class Charmm:
 
         # create box 0 vector list and convert from nm to Ang and round to 6 decimals.
         # note mbuild standard lengths are in nm, so round to 6+1 = 7 then mutlipy by 10
-        box_0_lengths_ang = (self.box_0.lengths[0] * 10,
-                             self.box_0.lengths[1] * 10,
-                             self.box_0.lengths[2] * 10,
-                             )
-        self.box_0_vectors = _lengths_angles_to_vectors(box_0_lengths_ang,
-                                                        self.box_0.angles,
-                                                        precision=6
-                                                        )
+        box_0_lengths_ang = (
+            self.box_0.lengths[0] * 10,
+            self.box_0.lengths[1] * 10,
+            self.box_0.lengths[2] * 10,
+        )
+        self.box_0_vectors = _lengths_angles_to_vectors(
+            box_0_lengths_ang, self.box_0.angles, precision=6
+        )
 
         # Internally use nm
         if self.structure_box_1:
@@ -1949,14 +1949,14 @@ class Charmm:
 
             # create box 1 vector list and convert from nm to Ang and round to 6 decimals.
             # note mbuild standard lengths are in nm, so round to 6+1 = 7 then mutlipy by 10
-            box_1_lengths_ang = (self.box_1.lengths[0] * 10,
-                                 self.box_1.lengths[1] * 10,
-                                 self.box_1.lengths[2] * 10,
-                                 )
-            self.box_1_vectors = _lengths_angles_to_vectors(box_1_lengths_ang,
-                                                            self.box_1.angles,
-                                                            precision=6
-                                                            )
+            box_1_lengths_ang = (
+                self.box_1.lengths[0] * 10,
+                self.box_1.lengths[1] * 10,
+                self.box_1.lengths[2] * 10,
+            )
+            self.box_1_vectors = _lengths_angles_to_vectors(
+                box_1_lengths_ang, self.box_1.angles, precision=6
+            )
 
         # if self.structure_box_1 != None:
         if self.structure_box_1:
@@ -2068,16 +2068,21 @@ class Charmm:
             self.max_residue_no = 9999
             self.max_resname_char = 4
 
-            res_no_chain_iter_corrected= []
+            res_no_chain_iter_corrected = []
             residue_id_list = []
-            residue_id_adder_fixed_struct_wo_bonds = 0 # for example zeolite used as fixed atoms wo bonds
+            residue_id_adder_fixed_struct_wo_bonds = (
+                0  # for example zeolite used as fixed atoms wo bonds
+            )
             for f, PSF_atom_iteration_0 in enumerate(
                 stuct_only_iteration.atoms
             ):
 
                 if f > 0:
-                    if PSF_atom_iteration_0.residue.chain == previous_residue_chain and \
-                            len(PSF_atom_iteration_0.bonds) == 0:
+                    if (
+                        PSF_atom_iteration_0.residue.chain
+                        == previous_residue_chain
+                        and len(PSF_atom_iteration_0.bonds) == 0
+                    ):
                         residue_id_adder_fixed_struct_wo_bonds += 1
 
                 previous_residue_chain = PSF_atom_iteration_0.residue.chain
@@ -3018,8 +3023,8 @@ class Charmm:
                             data.write(info_if_dihedral_error_too_large)
                             print(info_if_dihedral_error_too_large)
                         else:
-                            list_if_abs_max_values_for_dihedral_overall_max = max(
-                                list_if_abs_max_values_for_dihedral_overall
+                            list_if_abs_max_values_for_dihedral_overall_max = (
+                                max(list_if_abs_max_values_for_dihedral_overall)
                             )
                             info_if_dihedral_error_ok = (
                                 "! RB-torsion to CHARMM dihedral conversion error is OK "
@@ -3269,22 +3274,24 @@ class Charmm:
                     stuct_only_iteration.residues[m].name
                 )
 
-            res_no_chain_iter_corrected= []
+            res_no_chain_iter_corrected = []
             residue_id_list = []
             residue_id_adder_fixed_struct_wo_bonds = 0
             for f, PSF_atom_iteration_0 in enumerate(
                 stuct_only_iteration.atoms
             ):
                 if f > 0:
-                    if PSF_atom_iteration_0.residue.chain == previous_residue_chain and \
-                            len(PSF_atom_iteration_0.bonds) == 0:
+                    if (
+                        PSF_atom_iteration_0.residue.chain
+                        == previous_residue_chain
+                        and len(PSF_atom_iteration_0.bonds) == 0
+                    ):
                         residue_id_adder_fixed_struct_wo_bonds += 1
 
                 previous_residue_chain = PSF_atom_iteration_0.residue.chain
 
                 residue_id_int = int(
-                    unique_residue_data_dict[residue_data_list[f]
-                    ]
+                    unique_residue_data_dict[residue_data_list[f]]
                     + residue_id_adder_fixed_struct_wo_bonds
                 )
                 res_id_adder = int(
@@ -3438,7 +3445,12 @@ class Charmm:
                 first_indent % no_dihedrals + " !NPHI: dihedrals\n"
             )
             for i_dihedral, dihedral_iter in enumerate(dihedrals_list):
-                dihedral_atom_1, dihedral_atom_2, dihedral_atom_3, dihedral_atom_4 = (
+                (
+                    dihedral_atom_1,
+                    dihedral_atom_2,
+                    dihedral_atom_3,
+                    dihedral_atom_4,
+                ) = (
                     dihedral_iter.atom1,
                     dihedral_iter.atom2,
                     dihedral_iter.atom3,
@@ -3471,7 +3483,12 @@ class Charmm:
                 first_indent % no_impropers + " !NIMPHI: impropers\n"
             )
             for i_improper, improper_iter in enumerate(impropers_list):
-                improper_atom_1, improper_atom_2, improper_atom_3, improper_atom_4 = (
+                (
+                    improper_atom_1,
+                    improper_atom_2,
+                    improper_atom_3,
+                    improper_atom_4,
+                ) = (
                     improper_iter.atom1,
                     improper_iter.atom2,
                     improper_iter.atom3,
@@ -3754,20 +3771,23 @@ class Charmm:
             locked_occupany_factor = 1.00
             max_no_atoms_in_base10 = 99999  # 99,999 for atoms in psf/pdb
 
-            res_no_chain_iter_corrected= []
+            res_no_chain_iter_corrected = []
             res_chain_iteration_corrected_list = []
             residue_id_list = []
-            residue_id_adder_fixed_struct_wo_bonds = 0  # for example zeolite used as fixed atoms wo bonds
+            residue_id_adder_fixed_struct_wo_bonds = (
+                0  # for example zeolite used as fixed atoms wo bonds
+            )
             for i, atom_iter in enumerate(stuct_only_iteration.atoms):
                 if i > 0:
-                    if atom_iter.residue.chain == previous_residue_chain and \
-                            len(atom_iter.bonds) == 0:
+                    if (
+                        atom_iter.residue.chain == previous_residue_chain
+                        and len(atom_iter.bonds) == 0
+                    ):
                         residue_id_adder_fixed_struct_wo_bonds += 1
 
                 previous_residue_chain = atom_iter.residue.chain
                 residue_id_int = int(
-                    unique_residue_data_dict[residue_data_list[i]
-                    ]
+                    unique_residue_data_dict[residue_data_list[i]]
                     + residue_id_adder_fixed_struct_wo_bonds
                 )
                 res_chain_iteration_corrected_list.append(

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -6,6 +6,7 @@ from warnings import warn
 import numpy as np
 from parmed.periodic_table import Element
 from parmed.utils.io import genopen
+import mbuild.box as mb_box
 
 from mbuild.box import Box
 from mbuild.compound import Compound
@@ -132,7 +133,7 @@ def _get_angle_type_key(
 
 
 def _get_dihedral_rb_torsion_key(dihedral, epsilon_conversion_factor):
-    """Get the dihedral_type key for a Ryckaert-Bellemans (RB) dihedrals/torsions
+    """ Get the dihedral_type key for a Ryckaert-Bellemans (RB) dihedrals/torsions
 
     Parameters
     ----------
@@ -224,7 +225,7 @@ def _get_dihedral_rb_torsion_key(dihedral, epsilon_conversion_factor):
 
 
 def _get_improper_type_key(improper, epsilon_conversion_factor):
-    """Get the improper_type key for the harmonic improper
+    """ Get the improper_type key for the harmonic improper
 
     Parameters
     ----------
@@ -289,7 +290,7 @@ def _get_improper_type_key(improper, epsilon_conversion_factor):
 def _get_unique_bond_types(
     structure, sigma_conversion_factor, epsilon_conversion_factor
 ):
-    """Get the unique bond types for a structure in a dictionary
+    """ Get the unique bond types for a structure in a dictionary
 
     Parameters
     ----------
@@ -332,7 +333,7 @@ def _get_unique_bond_types(
 def _get_unique_angle_types(
     structure, sigma_conversion_factor, epsilon_conversion_factor
 ):
-    """Get the unique angle types for a structure and return a dictionary
+    """ Get the unique angle types for a structure and return a dictionary
 
     Parameters
     ----------
@@ -376,7 +377,7 @@ def _get_unique_angle_types(
 
 
 def _get_unique_rb_torsion_types(structure, epsilon_conversion_factor):
-    """Get the unique rb torsion types for a structure and return a dictionary
+    """ Get the unique rb torsion types for a structure and return a dictionary
 
     Parameters
     ----------
@@ -425,7 +426,7 @@ def _get_unique_rb_torsion_types(structure, epsilon_conversion_factor):
 
 
 def _get_unique_improper_types(structure, epsilon_conversion_factor):
-    """Get the unique improper types for a structure  and return a dictionary
+    """ Get the unique improper types for a structure  and return a dictionary
 
     Parameters
     ----------
@@ -584,7 +585,7 @@ def _get_angle_types(
                      (angle_k_constant, angle_theta_o, angle_center_atom_type_2,
                      (angle_end_atom_type_1, angle_end_atom_type_3),
                      angle_residue_atom_1, angle_residue_atom_2, angle_residue_atom_3), n])
-    """
+        """
 
     if use_urey_bradleys:
         print_warn_text = (
@@ -788,7 +789,7 @@ def _get_impropers(structure, epsilon_conversion_factor):
           improper_atom_1_res_type, (improper_atom_2_res_type,
           improper_atom_3_res_type, improper_atom_4_res_type)
          ), n ])
-    """
+         """
     unique_improper_types = _get_unique_improper_types(
         structure, epsilon_conversion_factor
     )
@@ -1015,8 +1016,6 @@ class Charmm:
         fix_residue_in_box=None,
         ff_filename=None,
         reorder_res_in_pdb_psf=False,
-        box_0=None,
-        box_1=None,
     ):
 
         """Generates a Charmm object that is required to produce the Charmm style parameter
@@ -1122,14 +1121,6 @@ class Charmm:
             its original order, as in the Compound sent to the writer.
             If True, the order of the atoms is reordered based on their
             residue names in the 'residues' list that was entered.
-        box_0 : list, [x-dim, y-dim ,z-dim]
-            A list of 3 positive float values or the dimensions [x, y ,z]
-            for structure_box_0 in nanometers (nm)
-            This is to add/override or change the structures dimensions. Ex: [1,2,3]
-        box_1 : list, [x-dim, y-dim ,z-dim]
-            A list of 3 positive float values or the dimensions [x, y ,z]
-            for structure_box_1 in nanometers (nm)
-            This is to add/override or change the structures dimensions. Ex: [1,2,3]
 
         Attributes
         ----------
@@ -1212,14 +1203,22 @@ class Charmm:
             its original order, as in the Compound sent to the writer.
             If True, the order of the atoms is reordered based on their
             residue names in the 'residues' list that was entered.
-        box_0 : list, [x-dim, y-dim ,z-dim]
-            A list of 3 positive float values or the dimensions [x, y ,z]
-            for structure_box_0 in nanometers (nm)
-            This is to add/override or change the structures dimensions. Ex: [1,2,3]
-        box_1 : list, [x-dim, y-dim ,z-dim]
-            A list of 3 positive float values or the dimensions [x, y ,z]
-            for structure_box_1 in nanometers (nm)
-            This is to add/override or change the structures dimensions. Ex: [1,2,3]
+        box_0 : Box
+            The Box class that contains the attributes Lx, Ly, Lz for the length
+            of the box 1 in nm. It also contains the xy, xz, and yz Tilt factors
+            needed to displace an orthogonal box's xy face to its
+            parallelepiped structure for box 0.
+        box_1 : Box
+            The Box class that contains the attributes Lx, Ly, Lz for the length
+            of the box 1 (units in Angstroms (Ang)). It also contains the xy, xz, and yz Tilt factors
+            needed to displace an orthogonal box's xy face to its
+            parallelepiped structure for box 0.
+        box_0_vectors : numpy.ndarray, [[float, float, float], [float, float, float], [float, float, float]]
+            Three (3) sets vectors for box 0 each with 3 float values, which represent
+            the vectors for the Charmm-style systems (units in Angstroms (Ang))
+        box_1_vectors : numpy.ndarray, [[float, float, float], [float, float, float], [float, float, float]]
+            Three (3) sets vectors for box 1 each with 3 float values, which represent
+            the vectors for the Charmm-style systems (units in Angstroms (Ang))
         structure_box_0_ff : parmed.structure.Structure
             The box 0 structure (structure_box_0) after all the provided
             force fields are applied.
@@ -1348,8 +1347,7 @@ class Charmm:
         self.fix_residue_in_box = fix_residue_in_box
         self.ff_filename = ff_filename
         self.reorder_res_in_pdb_psf = reorder_res_in_pdb_psf
-        self.box_0 = box_0
-        self.box_1 = box_1
+
         # value to check for errors, with  self.input_error = True or False. Set to False initally
         self.input_error = False
 
@@ -1446,11 +1444,6 @@ class Charmm:
             print_error_message = (
                 "ERROR: Please enter the filename_box_1 as a string."
             )
-            raise TypeError(print_error_message)
-
-        if self.structure_box_1 is None and self.box_1 is not None:
-            self.input_error = True
-            print_error_message = "ERROR: box_1 is set to a value but there is not a structure 1 to use it on."
             raise TypeError(print_error_message)
 
         if self.ff_filename is not None:
@@ -1608,36 +1601,6 @@ class Charmm:
                     print_error_message = "ERROR: Please enter the bead_to_atom_name_dict with only string inputs."
                     raise TypeError(print_error_message)
 
-        if self.box_0 is not None:
-            box_length = len(self.box_0)
-            if box_length != 3:
-                self.input_error = True
-                print_error_message = "ERROR: Please enter all 3 values and only 3 values for the box_0 dimensions."
-                raise ValueError(print_error_message)
-            for box_iter in self.box_0:
-                if isinstance(box_iter, str) or box_iter <= 0:
-                    self.input_error = True
-                    print_error_message = (
-                        "ERROR: Please enter float or integer values, which are all "
-                        "positive values for the box_0 dimensions."
-                    )
-                    raise ValueError(print_error_message)
-
-        if self.box_1 is not None:
-            box_length = len(self.box_1)
-            if box_length != 3:
-                self.input_error = True
-                print_error_message = "ERROR: Please enter all 3 values and only 3 values for the box_1 dimensions."
-                raise ValueError(print_error_message)
-            for box_iter in self.box_1:
-                if isinstance(box_iter, str) or box_iter <= 0:
-                    self.input_error = True
-                    print_error_message = (
-                        "ERROR: Please enter float or integer values, which are all "
-                        "positive values for the box_1 dimensions."
-                    )
-                    raise ValueError(print_error_message)
-
         print("******************************")
         print("")
 
@@ -1667,7 +1630,6 @@ class Charmm:
                 forcefield_selection=self.forcefield_selection,
                 residues=self.residues,
                 reorder_res_in_pdb_psf=self.reorder_res_in_pdb_psf,
-                box=self.box_0,
                 boxes_for_simulation=self.boxes_for_simulation,
             )
 
@@ -1684,7 +1646,6 @@ class Charmm:
                 forcefield_selection=self.forcefield_selection,
                 residues=self.residues,
                 reorder_res_in_pdb_psf=self.reorder_res_in_pdb_psf,
-                box=self.box_1,
                 boxes_for_simulation=self.boxes_for_simulation,
             )
 
@@ -1774,7 +1735,6 @@ class Charmm:
                 forcefield_selection=self.forcefield_selection,
                 residues=self.residues,
                 reorder_res_in_pdb_psf=self.reorder_res_in_pdb_psf,
-                box=self.box_0,
                 boxes_for_simulation=self.boxes_for_simulation,
             )
 
@@ -1913,6 +1873,14 @@ class Charmm:
             angles=self.structure_box_0_ff.box[3:6],
         )
 
+        # create box 0 vector list and convert from nm to Ang and round to 6 decimals
+        box_0_vectors_mod = mb_box._lengths_angles_to_vectors(self.box_0.lengths, self.box_0.angles, 8)
+        # create box 0 vector list and convert from nm to Ang and round to 6 decimals
+        print(" test = " + str(mb_box._lengths_angles_to_vectors([1,2,3], [90,90,90], 8)))
+        print(" box_0_vectors_mod = " +str( box_0_vectors_mod))
+        self.box_0_vectors = np.around(box_0_vectors_mod * 10, decimals=6)
+        print("self.box_0_vectors = " + str(self.box_0_vectors))
+
         # Internally use nm
         if self.structure_box_1:
             self.box_1 = Box(
@@ -1924,6 +1892,12 @@ class Charmm:
                 ),
                 angles=self.structure_box_1_ff.box[3:6],
             )
+
+            # create box 0 vector list and convert from nm to Ang and round to 6 decimals
+            box_1_vectors_mod = mb_box._lengths_angles_to_vectors(self.box_1.lengths, self.box_1.angles, 6)
+            # create box 0 vector list and convert from nm to Ang and round to 6 decimals
+            print("self.box_0_vectors = " + str(self.box_0_vectors))
+            self.box_1_vectors = np.around(box_1_vectors_mod * 10, decimals=6)
 
         # if self.structure_box_1 != None:
         if self.structure_box_1:
@@ -1947,6 +1921,7 @@ class Charmm:
         residues_all_list = [
             atom.residue.name for atom in self.structure_selection.atoms
         ]
+
         self.epsilon_dict = dict(
             [
                 (self.unique_types.index(atom_type), epsilon)
@@ -2034,15 +2009,25 @@ class Charmm:
             self.max_residue_no = 9999
             self.max_resname_char = 4
 
-            ff_name = []
+            res_no_chain_iter_corrected= []
             residue_id_list = []
+            residue_id_adder_fixed_struct_wo_bonds = 0 # for example zeolite used as fixed atoms wo bonds
             for f, PSF_atom_iteration_0 in enumerate(
-                stuct_only_iteration.atoms
+                    stuct_only_iteration.atoms
             ):
+
+                if f > 0:
+                    if PSF_atom_iteration_0.residue.chain == previous_residue_chain and \
+                            len(PSF_atom_iteration_0.bonds) == 0:
+                        residue_id_adder_fixed_struct_wo_bonds += 1
+
+                previous_residue_chain = PSF_atom_iteration_0.residue.chain
 
                 residue_id_int = int(
                     unique_residue_data_dict[residue_data_list[f]]
+                    + residue_id_adder_fixed_struct_wo_bonds
                 )
+
                 res_id_adder = int(
                     (residue_id_int % self.max_residue_no) % self.max_residue_no
                 )
@@ -2051,7 +2036,7 @@ class Charmm:
                 else:
                     res_no_iteration_corrected = res_id_adder
 
-                ff_name.append(res_no_iteration_corrected)
+                res_no_chain_iter_corrected.append(res_no_iteration_corrected)
                 residue_id_list.append(residue_id_int)
 
             # This converts the atom name in the GOMC psf and pdb files to unique atom names
@@ -2123,8 +2108,8 @@ class Charmm:
         )
 
     def write_inp(self):
-        """This write_inp function writes the Charmm style parameter (force field) file, which can be utilized
-        in the GOMC and NAMD engines."""
+        """ This write_inp function writes the Charmm style parameter (force field) file, which can be utilized
+             in the GOMC and NAMD engines. """
         print("******************************")
         print("")
         print(
@@ -2974,8 +2959,8 @@ class Charmm:
                             data.write(info_if_dihedral_error_too_large)
                             print(info_if_dihedral_error_too_large)
                         else:
-                            list_if_abs_max_values_for_dihedral_overall_max = (
-                                max(list_if_abs_max_values_for_dihedral_overall)
+                            list_if_abs_max_values_for_dihedral_overall_max = max(
+                                list_if_abs_max_values_for_dihedral_overall
                             )
                             info_if_dihedral_error_ok = (
                                 "! RB-torsion to CHARMM dihedral conversion error is OK "
@@ -3069,8 +3054,8 @@ class Charmm:
         # **********************************
 
     def write_psf(self):
-        """This write_psf function writes the Charmm style PSF (topology) file, which can be utilized
-        in the GOMC and NAMD engines."""
+        """ This write_psf function writes the Charmm style PSF (topology) file, which can be utilized
+                 in the GOMC and NAMD engines. """
         # **********************************
         # **********************************
         # psf writer (start)
@@ -3225,14 +3210,23 @@ class Charmm:
                     stuct_only_iteration.residues[m].name
                 )
 
-            ff_name = []
+            res_no_chain_iter_corrected= []
             residue_id_list = []
+            residue_id_adder_fixed_struct_wo_bonds = 0
             for f, PSF_atom_iteration_0 in enumerate(
                 stuct_only_iteration.atoms
             ):
+                if f > 0:
+                    if PSF_atom_iteration_0.residue.chain == previous_residue_chain and \
+                            len(PSF_atom_iteration_0.bonds) == 0:
+                        residue_id_adder_fixed_struct_wo_bonds += 1
+
+                previous_residue_chain = PSF_atom_iteration_0.residue.chain
 
                 residue_id_int = int(
-                    unique_residue_data_dict[residue_data_list[f]]
+                    unique_residue_data_dict[residue_data_list[f]
+                    ]
+                    + residue_id_adder_fixed_struct_wo_bonds
                 )
                 res_id_adder = int(
                     (residue_id_int % self.max_residue_no) % self.max_residue_no
@@ -3242,7 +3236,7 @@ class Charmm:
                 else:
                     res_no_iteration_corrected = res_id_adder
 
-                ff_name.append(res_no_iteration_corrected)
+                res_no_chain_iter_corrected.append(res_no_iteration_corrected)
                 residue_id_list.append(residue_id_int)
 
             output_write = genopen(output, "w")
@@ -3320,7 +3314,7 @@ class Charmm:
                 atom_lines_iteration = psf_formating % (
                     i_atom + 1,
                     segment_id,
-                    ff_name[i_atom],
+                    res_no_chain_iter_corrected[i_atom],
                     str(residue_names_list[i_atom])[: self.max_resname_char],
                     individual_atom_names_list[i_atom],
                     atom_type_iter,
@@ -3385,12 +3379,7 @@ class Charmm:
                 first_indent % no_dihedrals + " !NPHI: dihedrals\n"
             )
             for i_dihedral, dihedral_iter in enumerate(dihedrals_list):
-                (
-                    dihedral_atom_1,
-                    dihedral_atom_2,
-                    dihedral_atom_3,
-                    dihedral_atom_4,
-                ) = (
+                dihedral_atom_1, dihedral_atom_2, dihedral_atom_3, dihedral_atom_4 = (
                     dihedral_iter.atom1,
                     dihedral_iter.atom2,
                     dihedral_iter.atom3,
@@ -3423,12 +3412,7 @@ class Charmm:
                 first_indent % no_impropers + " !NIMPHI: impropers\n"
             )
             for i_improper, improper_iter in enumerate(impropers_list):
-                (
-                    improper_atom_1,
-                    improper_atom_2,
-                    improper_atom_3,
-                    improper_atom_4,
-                ) = (
+                improper_atom_1, improper_atom_2, improper_atom_3, improper_atom_4 = (
                     improper_iter.atom1,
                     improper_iter.atom2,
                     improper_iter.atom3,
@@ -3567,8 +3551,8 @@ class Charmm:
         # **********************************
 
     def write_pdb(self):
-        """This write_psf function writes the Charmm style PDB (coordinate file), which can be utilized
-        in the GOMC and NAMD engines."""
+        """ This write_psf function writes the Charmm style PDB (coordinate file), which can be utilized
+                         in the GOMC and NAMD engines. """
         # **********************************
         # **********************************
         # pdb writer (start)
@@ -3711,12 +3695,21 @@ class Charmm:
             locked_occupany_factor = 1.00
             max_no_atoms_in_base10 = 99999  # 99,999 for atoms in psf/pdb
 
-            ff_name = []
+            res_no_chain_iter_corrected= []
             res_chain_iteration_corrected_list = []
             residue_id_list = []
+            residue_id_adder_fixed_struct_wo_bonds = 0  # for example zeolite used as fixed atoms wo bonds
             for i, atom_iter in enumerate(stuct_only_iteration.atoms):
+                if i > 0:
+                    if atom_iter.residue.chain == previous_residue_chain and \
+                            len(atom_iter.bonds) == 0:
+                        residue_id_adder_fixed_struct_wo_bonds += 1
+
+                previous_residue_chain = atom_iter.residue.chain
                 residue_id_int = int(
-                    unique_residue_data_dict[residue_data_list[i]]
+                    unique_residue_data_dict[residue_data_list[i]
+                    ]
+                    + residue_id_adder_fixed_struct_wo_bonds
                 )
                 res_chain_iteration_corrected_list.append(
                     base10_to_base26_alph(
@@ -3727,9 +3720,9 @@ class Charmm:
                     (residue_id_int % self.max_residue_no) % self.max_residue_no
                 )
                 if int(res_id_adder) == 0:
-                    ff_name.append(int(self.max_residue_no))
+                    res_no_chain_iter_corrected.append(int(self.max_residue_no))
                 else:
-                    ff_name.append(res_id_adder)
+                    res_no_chain_iter_corrected.append(res_id_adder)
 
                 residue_id_list.append(residue_id_int)
 
@@ -3799,7 +3792,7 @@ class Charmm:
                             atom_alternate_location_list[v],
                             str(residue_names_list[v])[: self.max_resname_char],
                             res_chain_iteration_corrected_list[v],
-                            ff_name[v],
+                            res_no_chain_iter_corrected[v],
                             residue_code_insertion_list[v],
                             x_list[v],
                             y_list[v],

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -6,8 +6,8 @@ from warnings import warn
 import numpy as np
 from parmed.periodic_table import Element
 from parmed.utils.io import genopen
-import mbuild.box as mb_box
 
+import mbuild.box as mb_box
 from mbuild.box import Box
 from mbuild.compound import Compound
 from mbuild.utils.conversion import (
@@ -1875,10 +1875,15 @@ class Charmm:
 
         # create box 0 vector list and convert from nm to Ang and round to 6 decimals ()
         # First, import the values in nm and rounding to 8 decimals and multiply by 10 to get angstroms
-        box_0_vectors_mod = mb_box._lengths_angles_to_vectors(self.box_0.lengths, self.box_0.angles, 7) * 10
+        box_0_vectors_mod = (
+            mb_box._lengths_angles_to_vectors(
+                self.box_0.lengths, self.box_0.angles, 7
+            )
+            * 10
+        )
         # create box 0 vector list and round to 6 decimals to avoid errors in the gomc_writer script
         # still leaves some floating values in some cases
-        self.box_0_vectors =  np.around(box_0_vectors_mod, decimals=6)
+        self.box_0_vectors = np.around(box_0_vectors_mod, decimals=6)
 
         # Internally use nm
         if self.structure_box_1:
@@ -1894,11 +1899,15 @@ class Charmm:
 
             # create box 1 vector list and convert from nm to Ang and round to 6 decimals (7 decimals in nm)
             # First, import the values in nm and rounding to 7 decimals and multiply by 10 to get angstroms
-            box_1_vectors_mod = mb_box._lengths_angles_to_vectors(self.box_1.lengths, self.box_1.angles, 7) * 10
+            box_1_vectors_mod = (
+                mb_box._lengths_angles_to_vectors(
+                    self.box_1.lengths, self.box_1.angles, 7
+                )
+                * 10
+            )
             # create box 1 vector list and round to 6 decimals to avoid errors in the gomc_writer script
             # still leaves some floating values in some cases
-            self.box_1_vectors =  np.around(box_1_vectors_mod, decimals=6)
-
+            self.box_1_vectors = np.around(box_1_vectors_mod, decimals=6)
 
         # if self.structure_box_1 != None:
         if self.structure_box_1:
@@ -2010,16 +2019,21 @@ class Charmm:
             self.max_residue_no = 9999
             self.max_resname_char = 4
 
-            res_no_chain_iter_corrected= []
+            res_no_chain_iter_corrected = []
             residue_id_list = []
-            residue_id_adder_fixed_struct_wo_bonds = 0 # for example zeolite used as fixed atoms wo bonds
+            residue_id_adder_fixed_struct_wo_bonds = (
+                0  # for example zeolite used as fixed atoms wo bonds
+            )
             for f, PSF_atom_iteration_0 in enumerate(
                 stuct_only_iteration.atoms
             ):
 
                 if f > 0:
-                    if PSF_atom_iteration_0.residue.chain == previous_residue_chain and \
-                            len(PSF_atom_iteration_0.bonds) == 0:
+                    if (
+                        PSF_atom_iteration_0.residue.chain
+                        == previous_residue_chain
+                        and len(PSF_atom_iteration_0.bonds) == 0
+                    ):
                         residue_id_adder_fixed_struct_wo_bonds += 1
 
                 previous_residue_chain = PSF_atom_iteration_0.residue.chain
@@ -2960,8 +2974,8 @@ class Charmm:
                             data.write(info_if_dihedral_error_too_large)
                             print(info_if_dihedral_error_too_large)
                         else:
-                            list_if_abs_max_values_for_dihedral_overall_max = max(
-                                list_if_abs_max_values_for_dihedral_overall
+                            list_if_abs_max_values_for_dihedral_overall_max = (
+                                max(list_if_abs_max_values_for_dihedral_overall)
                             )
                             info_if_dihedral_error_ok = (
                                 "! RB-torsion to CHARMM dihedral conversion error is OK "
@@ -3211,22 +3225,24 @@ class Charmm:
                     stuct_only_iteration.residues[m].name
                 )
 
-            res_no_chain_iter_corrected= []
+            res_no_chain_iter_corrected = []
             residue_id_list = []
             residue_id_adder_fixed_struct_wo_bonds = 0
             for f, PSF_atom_iteration_0 in enumerate(
                 stuct_only_iteration.atoms
             ):
                 if f > 0:
-                    if PSF_atom_iteration_0.residue.chain == previous_residue_chain and \
-                            len(PSF_atom_iteration_0.bonds) == 0:
+                    if (
+                        PSF_atom_iteration_0.residue.chain
+                        == previous_residue_chain
+                        and len(PSF_atom_iteration_0.bonds) == 0
+                    ):
                         residue_id_adder_fixed_struct_wo_bonds += 1
 
                 previous_residue_chain = PSF_atom_iteration_0.residue.chain
 
                 residue_id_int = int(
-                    unique_residue_data_dict[residue_data_list[f]
-                    ]
+                    unique_residue_data_dict[residue_data_list[f]]
                     + residue_id_adder_fixed_struct_wo_bonds
                 )
                 res_id_adder = int(
@@ -3380,7 +3396,12 @@ class Charmm:
                 first_indent % no_dihedrals + " !NPHI: dihedrals\n"
             )
             for i_dihedral, dihedral_iter in enumerate(dihedrals_list):
-                dihedral_atom_1, dihedral_atom_2, dihedral_atom_3, dihedral_atom_4 = (
+                (
+                    dihedral_atom_1,
+                    dihedral_atom_2,
+                    dihedral_atom_3,
+                    dihedral_atom_4,
+                ) = (
                     dihedral_iter.atom1,
                     dihedral_iter.atom2,
                     dihedral_iter.atom3,
@@ -3413,7 +3434,12 @@ class Charmm:
                 first_indent % no_impropers + " !NIMPHI: impropers\n"
             )
             for i_improper, improper_iter in enumerate(impropers_list):
-                improper_atom_1, improper_atom_2, improper_atom_3, improper_atom_4 = (
+                (
+                    improper_atom_1,
+                    improper_atom_2,
+                    improper_atom_3,
+                    improper_atom_4,
+                ) = (
                     improper_iter.atom1,
                     improper_iter.atom2,
                     improper_iter.atom3,
@@ -3696,20 +3722,23 @@ class Charmm:
             locked_occupany_factor = 1.00
             max_no_atoms_in_base10 = 99999  # 99,999 for atoms in psf/pdb
 
-            res_no_chain_iter_corrected= []
+            res_no_chain_iter_corrected = []
             res_chain_iteration_corrected_list = []
             residue_id_list = []
-            residue_id_adder_fixed_struct_wo_bonds = 0  # for example zeolite used as fixed atoms wo bonds
+            residue_id_adder_fixed_struct_wo_bonds = (
+                0  # for example zeolite used as fixed atoms wo bonds
+            )
             for i, atom_iter in enumerate(stuct_only_iteration.atoms):
                 if i > 0:
-                    if atom_iter.residue.chain == previous_residue_chain and \
-                            len(atom_iter.bonds) == 0:
+                    if (
+                        atom_iter.residue.chain == previous_residue_chain
+                        and len(atom_iter.bonds) == 0
+                    ):
                         residue_id_adder_fixed_struct_wo_bonds += 1
 
                 previous_residue_chain = atom_iter.residue.chain
                 residue_id_int = int(
-                    unique_residue_data_dict[residue_data_list[i]
-                    ]
+                    unique_residue_data_dict[residue_data_list[i]]
                     + residue_id_adder_fixed_struct_wo_bonds
                 )
                 res_chain_iteration_corrected_list.append(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1,8 +1,8 @@
 import datetime
 import os
-import mbuild.formats.charmm_writer as mf_charmm
-
 from warnings import warn
+
+import mbuild.formats.charmm_writer as mf_charmm
 
 
 def dict_keys_to_list(dict):
@@ -2011,18 +2011,19 @@ class GOMCControl:
         box_vectors_char_limit = 16
         self.box_0_vectors = charmm_object.box_0_vectors
 
-        box_0_vectors_char_ok = _check_box_vectors_char_limit(self.box_0_vectors,
-                                                              box_vectors_char_limit
-                                                              )
+        box_0_vectors_char_ok = _check_box_vectors_char_limit(
+            self.box_0_vectors, box_vectors_char_limit
+        )
 
         if box_0_vectors_char_ok == False:
             self.input_error = True
             print_error_message = (
                 "ERROR: At lease one of the individual box {} vectors are too large "
                 "or greater than {} characters."
-                "".format(0,
-                          box_vectors_char_limit,
-                          )
+                "".format(
+                    0,
+                    box_vectors_char_limit,
+                )
             )
             raise ValueError(print_error_message)
         if self.ensemble_type in ["GEMC_NVT", "GEMC_NPT", "GCMC"]:
@@ -2032,18 +2033,19 @@ class GOMCControl:
             ):
                 self.box_1_vectors = charmm_object.box_1_vectors
 
-                box_1_vectors_char_ok = _check_box_vectors_char_limit(self.box_1_vectors,
-                                                                      box_vectors_char_limit
-                                                                      )
+                box_1_vectors_char_ok = _check_box_vectors_char_limit(
+                    self.box_1_vectors, box_vectors_char_limit
+                )
 
                 if box_1_vectors_char_ok == False:
                     self.input_error = True
                     print_error_message = (
                         "ERROR: At lease one of the individual box {} vectors are too large "
                         "or greater than {} characters."
-                        "".format(1,
-                                  box_vectors_char_limit,
-                                  )
+                        "".format(
+                            1,
+                            box_vectors_char_limit,
+                        )
                     )
                     raise ValueError(print_error_message)
             else:
@@ -2382,8 +2384,8 @@ class GOMCControl:
         # verify all input variable values are valid, for their keys
         input_var_keys_list = dict_keys_to_list(self.input_variables_dict)
 
-        possible_ensemble_variables_list = _get_possible_ensemble_input_variables(
-            self.ensemble_type
+        possible_ensemble_variables_list = (
+            _get_possible_ensemble_input_variables(self.ensemble_type)
         )
 
         # check to make sure the VDW FF (ParaTypeCHARMM) is set true  for multiple ones by the user
@@ -4312,16 +4314,12 @@ class GOMCControl:
             if isinstance(self.LambdaVDW, list):
                 if len(self.LambdaVDW) > 0:
                     if self.LambdaVDW[-1] != 1.0:
-                        print_error_message = (
-                            "ERROR: The last value in the LambdaVDW variable list must be a 1.0"
-                        )
+                        print_error_message = "ERROR: The last value in the LambdaVDW variable list must be a 1.0"
                         raise ValueError(print_error_message)
             if isinstance(self.LambdaCoulomb, list):
                 if len(self.LambdaCoulomb) > 0:
                     if self.LambdaCoulomb[-1] != 1.0:
-                        print_error_message = (
-                            "ERROR: The last value in the LambdaCoulomb variable list must be a 1.0"
-                        )
+                        print_error_message = "ERROR: The last value in the LambdaCoulomb variable list must be a 1.0"
                         raise ValueError(print_error_message)
 
     # write the control file
@@ -4431,14 +4429,20 @@ class GOMCControl:
             data_control_file.write("{:25s} {}\n".format("PRNG", self.PRNG))
         elif isinstance(self.PRNG, int):
             data_control_file.write("PRNG \t\t " + "INTSEED \n")
-            data_control_file.write("{:25s} {}\n".format("Random_Seed", self.PRNG))
+            data_control_file.write(
+                "{:25s} {}\n".format("Random_Seed", self.PRNG)
+            )
         data_control_file.write(" \n")
         data_control_file.write("####################################\n")
         data_control_file.write("# FORCE FIELD\n")
         data_control_file.write("####################################\n")
-        data_control_file.write("{:25s} {}\n".format(str(self.VDW_type), str(True)))
+        data_control_file.write(
+            "{:25s} {}\n".format(str(self.VDW_type), str(True))
+        )
         data_control_file.write(" \n")
-        data_control_file.write("{:25s} {}\n".format("Parameters", self.ff_filename))
+        data_control_file.write(
+            "{:25s} {}\n".format("Parameters", self.ff_filename)
+        )
         data_control_file.write("####################################\n")
         data_control_file.write("# INPUT PDB FILES\n")
         data_control_file.write("####################################\n")
@@ -4513,7 +4517,7 @@ class GOMCControl:
                     "{:25s} {:10s} {}\n".format(
                         "ChemPot",
                         chem_pot_residue_iter,
-                        self.ChemPot[chem_pot_residue_iter]
+                        self.ChemPot[chem_pot_residue_iter],
                     )
                 )
 
@@ -4536,16 +4540,22 @@ class GOMCControl:
                 )
 
         data_control_file.write(" \n")
-        data_control_file.write("{:25s} {}\n".format("Potential", self.Potential))
+        data_control_file.write(
+            "{:25s} {}\n".format("Potential", self.Potential)
+        )
         data_control_file.write("{:25s} {}\n".format("LRC", self.LRC))
         data_control_file.write("{:25s} {}\n".format("Rcut", self.Rcut))
         data_control_file.write("{:25s} {}\n".format("RcutLow", self.RcutLow))
         if self.Potential == "SWITCH":
-            data_control_file.write("{:25s} {}\n".format("Rswitch", self.Rswitch))
+            data_control_file.write(
+                "{:25s} {}\n".format("Rswitch", self.Rswitch)
+            )
         data_control_file.write("{:25s} {}\n".format("Exclude", self.Exclude))
         if self.VDWGeometricSigma is True:
             data_control_file.write(
-                "{:25s} {}\n".format("VDWGeometricSigma", self.VDWGeometricSigma)
+                "{:25s} {}\n".format(
+                    "VDWGeometricSigma", self.VDWGeometricSigma
+                )
             )
         data_control_file.write(" \n")
 
@@ -4566,7 +4576,9 @@ class GOMCControl:
             data_control_file.write(
                 "{:25s} {}\n".format("Dielectric", format(self.Dielectric))
             )
-        data_control_file.write("{:25s} {}\n".format("1-4scaling", self.coul_1_4))
+        data_control_file.write(
+            "{:25s} {}\n".format("1-4scaling", self.coul_1_4)
+        )
         data_control_file.write(" \n")
         if self.RcutCoulomb_box_0 is not None:
             data_control_file.write(
@@ -4586,9 +4598,10 @@ class GOMCControl:
         data_control_file.write("# PRESSURE CALCULATION\n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("PressureCalc",
-                                        str(self.PressureCalc[0]),
-                                        self.PressureCalc[1],
+            "{:25s} {:10s} {}\n".format(
+                "PressureCalc",
+                str(self.PressureCalc[0]),
+                self.PressureCalc[1],
             )
         )
         data_control_file.write(" \n")
@@ -4623,15 +4636,21 @@ class GOMCControl:
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-1Freq", self.IntraMEMC_1Freq)
         )
-        data_control_file.write("{:25s} {}\n".format("MEMC-1Freq", self.MEMC_1Freq))
+        data_control_file.write(
+            "{:25s} {}\n".format("MEMC-1Freq", self.MEMC_1Freq)
+        )
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-2Freq", self.IntraMEMC_2Freq)
         )
-        data_control_file.write("{:25s} {}\n".format("MEMC-2Freq", self.MEMC_2Freq))
+        data_control_file.write(
+            "{:25s} {}\n".format("MEMC-2Freq", self.MEMC_2Freq)
+        )
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-3Freq", self.IntraMEMC_3Freq)
         )
-        data_control_file.write("{:25s} {}\n".format("MEMC-3Freq", self.MEMC_3Freq))
+        data_control_file.write(
+            "{:25s} {}\n".format("MEMC-3Freq", self.MEMC_3Freq)
+        )
         data_control_file.write(" \n")
 
         # sort and print the MEMC data if MEMC is used for the simulation
@@ -4706,13 +4725,17 @@ class GOMCControl:
                 or self.IntraMEMC_3Freq > 0
             ):
                 data_control_file.write(
-                    "{:25s} {}\n".format("LargeKindBackBone", LargeKindBackBone_str)
+                    "{:25s} {}\n".format(
+                        "LargeKindBackBone", LargeKindBackBone_str
+                    )
                 )
             if self.MEMC_DataInput is not None and (
                 self.MEMC_2Freq > 0 or self.IntraMEMC_2Freq > 0
             ):
                 data_control_file.write(
-                    "{:25s} {}\n".format("SmallKindBackBone", SmallKindBackBone_str)
+                    "{:25s} {}\n".format(
+                        "SmallKindBackBone", SmallKindBackBone_str
+                    )
                 )
 
         data_control_file.write(" \n")
@@ -4841,14 +4864,16 @@ class GOMCControl:
 
             if self.LambdaCoulomb is not None:
                 data_control_file.write(
-                     "{:25s} {}\n".format("LambdaCoulomb", Lambda_Coul_str)
+                    "{:25s} {}\n".format("LambdaCoulomb", Lambda_Coul_str)
                 )
             data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# CBMC TRIALS \n")
         data_control_file.write("####################################\n")
-        data_control_file.write("{:25s} {}\n".format("CBMC_First", self.CBMC_First))
+        data_control_file.write(
+            "{:25s} {}\n".format("CBMC_First", self.CBMC_First)
+        )
         data_control_file.write("{:25s} {}\n".format("CBMC_Nth", self.CBMC_Nth))
         data_control_file.write("{:25s} {}\n".format("CBMC_Ang", self.CBMC_Ang))
         data_control_file.write("{:25s} {}\n".format("CBMC_Dih", self.CBMC_Dih))
@@ -4868,46 +4893,50 @@ class GOMCControl:
         data_control_file.write("####################################\n")
         data_control_file.write("# statistics filename add\n")
         data_control_file.write("####################################\n")
-        data_control_file.write("{:25s} {}\n".format("OutputName", self.OutputName))
+        data_control_file.write(
+            "{:25s} {}\n".format("OutputName", self.OutputName)
+        )
         data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# enable, frequency \n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("RestartFreq",
-                                 str(self.RestartFreq[0]),
-                                 self.RestartFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "RestartFreq", str(self.RestartFreq[0]), self.RestartFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("CheckpointFreq",
-                                        str(self.CheckpointFreq[0]),
-                                        self.CheckpointFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "CheckpointFreq",
+                str(self.CheckpointFreq[0]),
+                self.CheckpointFreq[1],
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("CoordinatesFreq",
-                                        str(self.CoordinatesFreq[0]),
-                                        self.CoordinatesFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "CoordinatesFreq",
+                str(self.CoordinatesFreq[0]),
+                self.CoordinatesFreq[1],
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("ConsoleFreq",
-                                        str(self.ConsoleFreq[0]),
-                                        self.ConsoleFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "ConsoleFreq", str(self.ConsoleFreq[0]), self.ConsoleFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("BlockAverageFreq",
-                                        str(self.BlockAverageFreq[0]),
-                                        self.BlockAverageFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "BlockAverageFreq",
+                str(self.BlockAverageFreq[0]),
+                self.BlockAverageFreq[1],
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("HistogramFreq",
-                                        str(self.HistogramFreq[0]),
-                                        self.HistogramFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "HistogramFreq",
+                str(self.HistogramFreq[0]),
+                self.HistogramFreq[1],
             )
         )
         data_control_file.write(" \n")
@@ -4917,49 +4946,61 @@ class GOMCControl:
         data_control_file.write("####################################\n")
         data_control_file.write("{:25s} {}\n".format("DistName", self.DistName))
         data_control_file.write("{:25s} {}\n".format("HistName", self.HistName))
-        data_control_file.write("{:25s} {}\n".format("RunNumber", self.RunNumber))
-        data_control_file.write("{:25s} {}\n".format("RunLetter", self.RunLetter))
-        data_control_file.write("{:25s} {}\n".format("SampleFreq", self.SampleFreq))
-        #print("{:10s}:    {}".format(arg, description))
+        data_control_file.write(
+            "{:25s} {}\n".format("RunNumber", self.RunNumber)
+        )
+        data_control_file.write(
+            "{:25s} {}\n".format("RunLetter", self.RunLetter)
+        )
+        data_control_file.write(
+            "{:25s} {}\n".format("SampleFreq", self.SampleFreq)
+        )
+        # print("{:10s}:    {}".format(arg, description))
         data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# enable: blk avg., fluct. \n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutEnergy",
-                                        str(self.OutEnergy[0]),
-                                        str(self.OutEnergy[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutEnergy",
+                str(self.OutEnergy[0]),
+                str(self.OutEnergy[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutPressure",
-                                            str(self.OutPressure[0]),
-                                            str(self.OutPressure[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutPressure",
+                str(self.OutPressure[0]),
+                str(self.OutPressure[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutMolNumber",
-                                            str(self.OutMolNumber[0]),
-                                            str(self.OutMolNumber[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutMolNumber",
+                str(self.OutMolNumber[0]),
+                str(self.OutMolNumber[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutDensity",
-                                            str(self.OutDensity[0]),
-                                            str(self.OutDensity[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutDensity",
+                str(self.OutDensity[0]),
+                str(self.OutDensity[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutVolume",
-                                            str(self.OutVolume[0]),
-                                            str(self.OutVolume[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutVolume",
+                str(self.OutVolume[0]),
+                str(self.OutVolume[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutSurfaceTension",
-                                            str(self.OutSurfaceTension[0]),
-                                            str(self.OutSurfaceTension[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutSurfaceTension",
+                str(self.OutSurfaceTension[0]),
+                str(self.OutSurfaceTension[1]),
             )
         )
         data_control_file.write("\n")
@@ -5850,6 +5891,7 @@ def ck_box_dim_is_float_or_int_greater_0(
 
     return None
 
+
 def _check_box_vectors_char_limit(vectors, char_limit):
     """
     Checks to see if the vectors exceed the specified character limit
@@ -5871,12 +5913,10 @@ def _check_box_vectors_char_limit(vectors, char_limit):
 
     for x_i in range(0, 3):
         for y_i in range(0, 3):
-            if (
-                len(str(vectors[x_i][y_i]))
-                > char_limit
-            ):
+            if len(str(vectors[x_i][y_i])) > char_limit:
                 return False
     return True
+
 
 # user callable function to write the GOMC control file
 def write_gomc_control_file(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1,8 +1,8 @@
 import datetime
 import os
-from warnings import warn
-
 import mbuild.formats.charmm_writer as mf_charmm
+
+from warnings import warn
 
 
 def dict_keys_to_list(dict):
@@ -2010,24 +2010,19 @@ class GOMCControl:
         # Get and test and make sure vectors are not too large for the 16 spaces allotted
         box_vectors_char_limit = 16
         self.box_0_vectors = charmm_object.box_0_vectors
-        box_0_vectors_char_ok = True
-        for x_i in range(0, 3):
-            for y_i in range(0, 3):
-                if (
-                    len(str(self.box_0_vectors[x_i][y_i]))
-                    > box_vectors_char_limit
-                ):
-                    box_0_vectors_char_ok = False
+
+        box_0_vectors_char_ok = _check_box_vectors_char_limit(self.box_0_vectors,
+                                                              box_vectors_char_limit
+                                                              )
 
         if box_0_vectors_char_ok == False:
             self.input_error = True
             print_error_message = (
                 "ERROR: At lease one of the individual box {} vectors are too large "
                 "or greater than {} characters."
-                "".format(
-                    0,
-                    box_vectors_char_limit,
-                )
+                "".format(0,
+                          box_vectors_char_limit,
+                          )
             )
             raise ValueError(print_error_message)
         if self.ensemble_type in ["GEMC_NVT", "GEMC_NPT", "GCMC"]:
@@ -2036,24 +2031,19 @@ class GOMCControl:
                 and isinstance(charmm_object.filename_box_1, str) is True
             ):
                 self.box_1_vectors = charmm_object.box_1_vectors
-                box_1_vectors_char_ok = True
-                for x_i in range(0, 3):
-                    for y_i in range(0, 3):
-                        if (
-                            len(str(self.box_1_vectors[x_i][y_i]))
-                            > box_vectors_char_limit
-                        ):
-                            box_1_vectors_char_ok = False
+
+                box_1_vectors_char_ok = _check_box_vectors_char_limit(self.box_1_vectors,
+                                                                      box_vectors_char_limit
+                                                                      )
 
                 if box_1_vectors_char_ok == False:
                     self.input_error = True
                     print_error_message = (
                         "ERROR: At lease one of the individual box {} vectors are too large "
                         "or greater than {} characters."
-                        "".format(
-                            1,
-                            box_vectors_char_limit,
-                        )
+                        "".format(1,
+                                  box_vectors_char_limit,
+                                  )
                     )
                     raise ValueError(print_error_message)
             else:
@@ -2392,8 +2382,8 @@ class GOMCControl:
         # verify all input variable values are valid, for their keys
         input_var_keys_list = dict_keys_to_list(self.input_variables_dict)
 
-        possible_ensemble_variables_list = (
-            _get_possible_ensemble_input_variables(self.ensemble_type)
+        possible_ensemble_variables_list = _get_possible_ensemble_input_variables(
+            self.ensemble_type
         )
 
         # check to make sure the VDW FF (ParaTypeCHARMM) is set true  for multiple ones by the user
@@ -4322,12 +4312,16 @@ class GOMCControl:
             if isinstance(self.LambdaVDW, list):
                 if len(self.LambdaVDW) > 0:
                     if self.LambdaVDW[-1] != 1.0:
-                        print_error_message = "ERROR: The last value in the LambdaVDW variable list must be a 1.0"
+                        print_error_message = (
+                            "ERROR: The last value in the LambdaVDW variable list must be a 1.0"
+                        )
                         raise ValueError(print_error_message)
             if isinstance(self.LambdaCoulomb, list):
                 if len(self.LambdaCoulomb) > 0:
                     if self.LambdaCoulomb[-1] != 1.0:
-                        print_error_message = "ERROR: The last value in the LambdaCoulomb variable list must be a 1.0"
+                        print_error_message = (
+                            "ERROR: The last value in the LambdaCoulomb variable list must be a 1.0"
+                        )
                         raise ValueError(print_error_message)
 
     # write the control file
@@ -4437,20 +4431,14 @@ class GOMCControl:
             data_control_file.write("{:25s} {}\n".format("PRNG", self.PRNG))
         elif isinstance(self.PRNG, int):
             data_control_file.write("PRNG \t\t " + "INTSEED \n")
-            data_control_file.write(
-                "{:25s} {}\n".format("Random_Seed", self.PRNG)
-            )
+            data_control_file.write("{:25s} {}\n".format("Random_Seed", self.PRNG))
         data_control_file.write(" \n")
         data_control_file.write("####################################\n")
         data_control_file.write("# FORCE FIELD\n")
         data_control_file.write("####################################\n")
-        data_control_file.write(
-            "{:25s} {}\n".format(str(self.VDW_type), str(True))
-        )
+        data_control_file.write("{:25s} {}\n".format(str(self.VDW_type), str(True)))
         data_control_file.write(" \n")
-        data_control_file.write(
-            "{:25s} {}\n".format("Parameters", self.ff_filename)
-        )
+        data_control_file.write("{:25s} {}\n".format("Parameters", self.ff_filename))
         data_control_file.write("####################################\n")
         data_control_file.write("# INPUT PDB FILES\n")
         data_control_file.write("####################################\n")
@@ -4525,7 +4513,7 @@ class GOMCControl:
                     "{:25s} {:10s} {}\n".format(
                         "ChemPot",
                         chem_pot_residue_iter,
-                        self.ChemPot[chem_pot_residue_iter],
+                        self.ChemPot[chem_pot_residue_iter]
                     )
                 )
 
@@ -4548,22 +4536,16 @@ class GOMCControl:
                 )
 
         data_control_file.write(" \n")
-        data_control_file.write(
-            "{:25s} {}\n".format("Potential", self.Potential)
-        )
+        data_control_file.write("{:25s} {}\n".format("Potential", self.Potential))
         data_control_file.write("{:25s} {}\n".format("LRC", self.LRC))
         data_control_file.write("{:25s} {}\n".format("Rcut", self.Rcut))
         data_control_file.write("{:25s} {}\n".format("RcutLow", self.RcutLow))
         if self.Potential == "SWITCH":
-            data_control_file.write(
-                "{:25s} {}\n".format("Rswitch", self.Rswitch)
-            )
+            data_control_file.write("{:25s} {}\n".format("Rswitch", self.Rswitch))
         data_control_file.write("{:25s} {}\n".format("Exclude", self.Exclude))
         if self.VDWGeometricSigma is True:
             data_control_file.write(
-                "{:25s} {}\n".format(
-                    "VDWGeometricSigma", self.VDWGeometricSigma
-                )
+                "{:25s} {}\n".format("VDWGeometricSigma", self.VDWGeometricSigma)
             )
         data_control_file.write(" \n")
 
@@ -4584,9 +4566,7 @@ class GOMCControl:
             data_control_file.write(
                 "{:25s} {}\n".format("Dielectric", format(self.Dielectric))
             )
-        data_control_file.write(
-            "{:25s} {}\n".format("1-4scaling", self.coul_1_4)
-        )
+        data_control_file.write("{:25s} {}\n".format("1-4scaling", self.coul_1_4))
         data_control_file.write(" \n")
         if self.RcutCoulomb_box_0 is not None:
             data_control_file.write(
@@ -4606,10 +4586,9 @@ class GOMCControl:
         data_control_file.write("# PRESSURE CALCULATION\n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format(
-                "PressureCalc",
-                str(self.PressureCalc[0]),
-                self.PressureCalc[1],
+            "{:25s} {:10s} {}\n".format("PressureCalc",
+                                        str(self.PressureCalc[0]),
+                                        self.PressureCalc[1],
             )
         )
         data_control_file.write(" \n")
@@ -4644,21 +4623,15 @@ class GOMCControl:
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-1Freq", self.IntraMEMC_1Freq)
         )
-        data_control_file.write(
-            "{:25s} {}\n".format("MEMC-1Freq", self.MEMC_1Freq)
-        )
+        data_control_file.write("{:25s} {}\n".format("MEMC-1Freq", self.MEMC_1Freq))
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-2Freq", self.IntraMEMC_2Freq)
         )
-        data_control_file.write(
-            "{:25s} {}\n".format("MEMC-2Freq", self.MEMC_2Freq)
-        )
+        data_control_file.write("{:25s} {}\n".format("MEMC-2Freq", self.MEMC_2Freq))
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-3Freq", self.IntraMEMC_3Freq)
         )
-        data_control_file.write(
-            "{:25s} {}\n".format("MEMC-3Freq", self.MEMC_3Freq)
-        )
+        data_control_file.write("{:25s} {}\n".format("MEMC-3Freq", self.MEMC_3Freq))
         data_control_file.write(" \n")
 
         # sort and print the MEMC data if MEMC is used for the simulation
@@ -4733,17 +4706,13 @@ class GOMCControl:
                 or self.IntraMEMC_3Freq > 0
             ):
                 data_control_file.write(
-                    "{:25s} {}\n".format(
-                        "LargeKindBackBone", LargeKindBackBone_str
-                    )
+                    "{:25s} {}\n".format("LargeKindBackBone", LargeKindBackBone_str)
                 )
             if self.MEMC_DataInput is not None and (
                 self.MEMC_2Freq > 0 or self.IntraMEMC_2Freq > 0
             ):
                 data_control_file.write(
-                    "{:25s} {}\n".format(
-                        "SmallKindBackBone", SmallKindBackBone_str
-                    )
+                    "{:25s} {}\n".format("SmallKindBackBone", SmallKindBackBone_str)
                 )
 
         data_control_file.write(" \n")
@@ -4872,16 +4841,14 @@ class GOMCControl:
 
             if self.LambdaCoulomb is not None:
                 data_control_file.write(
-                    "{:25s} {}\n".format("LambdaCoulomb", Lambda_Coul_str)
+                     "{:25s} {}\n".format("LambdaCoulomb", Lambda_Coul_str)
                 )
             data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# CBMC TRIALS \n")
         data_control_file.write("####################################\n")
-        data_control_file.write(
-            "{:25s} {}\n".format("CBMC_First", self.CBMC_First)
-        )
+        data_control_file.write("{:25s} {}\n".format("CBMC_First", self.CBMC_First))
         data_control_file.write("{:25s} {}\n".format("CBMC_Nth", self.CBMC_Nth))
         data_control_file.write("{:25s} {}\n".format("CBMC_Ang", self.CBMC_Ang))
         data_control_file.write("{:25s} {}\n".format("CBMC_Dih", self.CBMC_Dih))
@@ -4901,50 +4868,46 @@ class GOMCControl:
         data_control_file.write("####################################\n")
         data_control_file.write("# statistics filename add\n")
         data_control_file.write("####################################\n")
-        data_control_file.write(
-            "{:25s} {}\n".format("OutputName", self.OutputName)
-        )
+        data_control_file.write("{:25s} {}\n".format("OutputName", self.OutputName))
         data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# enable, frequency \n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format(
-                "RestartFreq", str(self.RestartFreq[0]), self.RestartFreq[1]
+            "{:25s} {:10s} {}\n".format("RestartFreq",
+                                 str(self.RestartFreq[0]),
+                                 self.RestartFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format(
-                "CheckpointFreq",
-                str(self.CheckpointFreq[0]),
-                self.CheckpointFreq[1],
+            "{:25s} {:10s} {}\n".format("CheckpointFreq",
+                                        str(self.CheckpointFreq[0]),
+                                        self.CheckpointFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format(
-                "CoordinatesFreq",
-                str(self.CoordinatesFreq[0]),
-                self.CoordinatesFreq[1],
+            "{:25s} {:10s} {}\n".format("CoordinatesFreq",
+                                        str(self.CoordinatesFreq[0]),
+                                        self.CoordinatesFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format(
-                "ConsoleFreq", str(self.ConsoleFreq[0]), self.ConsoleFreq[1]
+            "{:25s} {:10s} {}\n".format("ConsoleFreq",
+                                        str(self.ConsoleFreq[0]),
+                                        self.ConsoleFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format(
-                "BlockAverageFreq",
-                str(self.BlockAverageFreq[0]),
-                self.BlockAverageFreq[1],
+            "{:25s} {:10s} {}\n".format("BlockAverageFreq",
+                                        str(self.BlockAverageFreq[0]),
+                                        self.BlockAverageFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format(
-                "HistogramFreq",
-                str(self.HistogramFreq[0]),
-                self.HistogramFreq[1],
+            "{:25s} {:10s} {}\n".format("HistogramFreq",
+                                        str(self.HistogramFreq[0]),
+                                        self.HistogramFreq[1]
             )
         )
         data_control_file.write(" \n")
@@ -4954,61 +4917,49 @@ class GOMCControl:
         data_control_file.write("####################################\n")
         data_control_file.write("{:25s} {}\n".format("DistName", self.DistName))
         data_control_file.write("{:25s} {}\n".format("HistName", self.HistName))
-        data_control_file.write(
-            "{:25s} {}\n".format("RunNumber", self.RunNumber)
-        )
-        data_control_file.write(
-            "{:25s} {}\n".format("RunLetter", self.RunLetter)
-        )
-        data_control_file.write(
-            "{:25s} {}\n".format("SampleFreq", self.SampleFreq)
-        )
-        # print("{:10s}:    {}".format(arg, description))
+        data_control_file.write("{:25s} {}\n".format("RunNumber", self.RunNumber))
+        data_control_file.write("{:25s} {}\n".format("RunLetter", self.RunLetter))
+        data_control_file.write("{:25s} {}\n".format("SampleFreq", self.SampleFreq))
+        #print("{:10s}:    {}".format(arg, description))
         data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# enable: blk avg., fluct. \n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format(
-                "OutEnergy",
-                str(self.OutEnergy[0]),
-                str(self.OutEnergy[1]),
+            "{:25s} {:10s} {:10s}\n".format("OutEnergy",
+                                        str(self.OutEnergy[0]),
+                                        str(self.OutEnergy[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format(
-                "OutPressure",
-                str(self.OutPressure[0]),
-                str(self.OutPressure[1]),
+            "{:25s} {:10s} {:10s}\n".format("OutPressure",
+                                            str(self.OutPressure[0]),
+                                            str(self.OutPressure[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format(
-                "OutMolNumber",
-                str(self.OutMolNumber[0]),
-                str(self.OutMolNumber[1]),
+            "{:25s} {:10s} {:10s}\n".format("OutMolNumber",
+                                            str(self.OutMolNumber[0]),
+                                            str(self.OutMolNumber[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format(
-                "OutDensity",
-                str(self.OutDensity[0]),
-                str(self.OutDensity[1]),
+            "{:25s} {:10s} {:10s}\n".format("OutDensity",
+                                            str(self.OutDensity[0]),
+                                            str(self.OutDensity[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format(
-                "OutVolume",
-                str(self.OutVolume[0]),
-                str(self.OutVolume[1]),
+            "{:25s} {:10s} {:10s}\n".format("OutVolume",
+                                            str(self.OutVolume[0]),
+                                            str(self.OutVolume[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format(
-                "OutSurfaceTension",
-                str(self.OutSurfaceTension[0]),
-                str(self.OutSurfaceTension[1]),
+            "{:25s} {:10s} {:10s}\n".format("OutSurfaceTension",
+                                            str(self.OutSurfaceTension[0]),
+                                            str(self.OutSurfaceTension[1]),
             )
         )
         data_control_file.write("\n")
@@ -5899,6 +5850,33 @@ def ck_box_dim_is_float_or_int_greater_0(
 
     return None
 
+def _check_box_vectors_char_limit(vectors, char_limit):
+    """
+    Checks to see if the vectors exceed the specified character limit
+
+    Parameters
+    ----------
+    vectors : numpy.ndarray, [[float, float, float], [float, float, float], [float, float, float]]
+        Three (3) sets vectors for box 0 each with 3 float values, which represent
+        the vectors for the Charmm-style systems (i.e, the CellBasisVectors).
+    char_limit : int
+        The specified number of allowable characters for each individual value in the vectors.
+
+    Returns
+    -------
+    bool:
+        True, if within the allowable character limit
+        False, if not within the allowable character limit
+    """
+
+    for x_i in range(0, 3):
+        for y_i in range(0, 3):
+            if (
+                len(str(vectors[x_i][y_i]))
+                > char_limit
+            ):
+                return False
+    return True
 
 # user callable function to write the GOMC control file
 def write_gomc_control_file(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2029,8 +2029,8 @@ class GOMCControl:
             raise ValueError(print_error_message)
         if self.ensemble_type in ["GEMC_NVT", "GEMC_NPT", "GCMC"]:
             if (
-                    charmm_object.filename_box_1 is not None
-                    and isinstance(charmm_object.filename_box_1, str) is True
+                charmm_object.filename_box_1 is not None
+                and isinstance(charmm_object.filename_box_1, str) is True
             ):
                 self.box_1_vectors = charmm_object.box_1_vectors
                 box_1_vectors_char_ok = True

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1,8 +1,8 @@
 import datetime
 import os
-import mbuild.formats.charmm_writer as mf_charmm
-
 from warnings import warn
+
+import mbuild.formats.charmm_writer as mf_charmm
 
 
 def dict_keys_to_list(dict):
@@ -2013,7 +2013,10 @@ class GOMCControl:
         box_0_vectors_char_ok = True
         for x_i in range(0, 3):
             for y_i in range(0, 3):
-                if len(str(self.box_0_vectors[x_i][y_i])) > box_vectors_char_limit:
+                if (
+                    len(str(self.box_0_vectors[x_i][y_i]))
+                    > box_vectors_char_limit
+                ):
                     box_0_vectors_char_ok = False
 
         if box_0_vectors_char_ok == False:
@@ -2021,9 +2024,10 @@ class GOMCControl:
             print_error_message = (
                 "ERROR: At lease one of the individual box {} vectors are too large "
                 "or greater than {} characters."
-                "".format(0,
-                          box_vectors_char_limit,
-                          )
+                "".format(
+                    0,
+                    box_vectors_char_limit,
+                )
             )
             raise ValueError(print_error_message)
         if self.ensemble_type in ["GEMC_NVT", "GEMC_NPT", "GCMC"]:
@@ -2035,7 +2039,10 @@ class GOMCControl:
                 box_1_vectors_char_ok = True
                 for x_i in range(0, 3):
                     for y_i in range(0, 3):
-                        if len(str(self.box_1_vectors[x_i][y_i])) > box_vectors_char_limit:
+                        if (
+                            len(str(self.box_1_vectors[x_i][y_i]))
+                            > box_vectors_char_limit
+                        ):
                             box_1_vectors_char_ok = False
 
                 if box_1_vectors_char_ok == False:
@@ -2043,9 +2050,10 @@ class GOMCControl:
                     print_error_message = (
                         "ERROR: At lease one of the individual box {} vectors are too large "
                         "or greater than {} characters."
-                        "".format(1,
-                                  box_vectors_char_limit,
-                                  )
+                        "".format(
+                            1,
+                            box_vectors_char_limit,
+                        )
                     )
                     raise ValueError(print_error_message)
             else:
@@ -2384,8 +2392,8 @@ class GOMCControl:
         # verify all input variable values are valid, for their keys
         input_var_keys_list = dict_keys_to_list(self.input_variables_dict)
 
-        possible_ensemble_variables_list = _get_possible_ensemble_input_variables(
-            self.ensemble_type
+        possible_ensemble_variables_list = (
+            _get_possible_ensemble_input_variables(self.ensemble_type)
         )
 
         # check to make sure the VDW FF (ParaTypeCHARMM) is set true  for multiple ones by the user
@@ -4314,16 +4322,12 @@ class GOMCControl:
             if isinstance(self.LambdaVDW, list):
                 if len(self.LambdaVDW) > 0:
                     if self.LambdaVDW[-1] != 1.0:
-                        print_error_message = (
-                            "ERROR: The last value in the LambdaVDW variable list must be a 1.0"
-                        )
+                        print_error_message = "ERROR: The last value in the LambdaVDW variable list must be a 1.0"
                         raise ValueError(print_error_message)
             if isinstance(self.LambdaCoulomb, list):
                 if len(self.LambdaCoulomb) > 0:
                     if self.LambdaCoulomb[-1] != 1.0:
-                        print_error_message = (
-                            "ERROR: The last value in the LambdaCoulomb variable list must be a 1.0"
-                        )
+                        print_error_message = "ERROR: The last value in the LambdaCoulomb variable list must be a 1.0"
                         raise ValueError(print_error_message)
 
     # write the control file
@@ -4433,14 +4437,20 @@ class GOMCControl:
             data_control_file.write("{:25s} {}\n".format("PRNG", self.PRNG))
         elif isinstance(self.PRNG, int):
             data_control_file.write("PRNG \t\t " + "INTSEED \n")
-            data_control_file.write("{:25s} {}\n".format("Random_Seed", self.PRNG))
+            data_control_file.write(
+                "{:25s} {}\n".format("Random_Seed", self.PRNG)
+            )
         data_control_file.write(" \n")
         data_control_file.write("####################################\n")
         data_control_file.write("# FORCE FIELD\n")
         data_control_file.write("####################################\n")
-        data_control_file.write("{:25s} {}\n".format(str(self.VDW_type), str(True)))
+        data_control_file.write(
+            "{:25s} {}\n".format(str(self.VDW_type), str(True))
+        )
         data_control_file.write(" \n")
-        data_control_file.write("{:25s} {}\n".format("Parameters", self.ff_filename))
+        data_control_file.write(
+            "{:25s} {}\n".format("Parameters", self.ff_filename)
+        )
         data_control_file.write("####################################\n")
         data_control_file.write("# INPUT PDB FILES\n")
         data_control_file.write("####################################\n")
@@ -4515,7 +4525,7 @@ class GOMCControl:
                     "{:25s} {:10s} {}\n".format(
                         "ChemPot",
                         chem_pot_residue_iter,
-                        self.ChemPot[chem_pot_residue_iter]
+                        self.ChemPot[chem_pot_residue_iter],
                     )
                 )
 
@@ -4538,16 +4548,22 @@ class GOMCControl:
                 )
 
         data_control_file.write(" \n")
-        data_control_file.write("{:25s} {}\n".format("Potential", self.Potential))
+        data_control_file.write(
+            "{:25s} {}\n".format("Potential", self.Potential)
+        )
         data_control_file.write("{:25s} {}\n".format("LRC", self.LRC))
         data_control_file.write("{:25s} {}\n".format("Rcut", self.Rcut))
         data_control_file.write("{:25s} {}\n".format("RcutLow", self.RcutLow))
         if self.Potential == "SWITCH":
-            data_control_file.write("{:25s} {}\n".format("Rswitch", self.Rswitch))
+            data_control_file.write(
+                "{:25s} {}\n".format("Rswitch", self.Rswitch)
+            )
         data_control_file.write("{:25s} {}\n".format("Exclude", self.Exclude))
         if self.VDWGeometricSigma is True:
             data_control_file.write(
-                "{:25s} {}\n".format("VDWGeometricSigma", self.VDWGeometricSigma)
+                "{:25s} {}\n".format(
+                    "VDWGeometricSigma", self.VDWGeometricSigma
+                )
             )
         data_control_file.write(" \n")
 
@@ -4568,7 +4584,9 @@ class GOMCControl:
             data_control_file.write(
                 "{:25s} {}\n".format("Dielectric", format(self.Dielectric))
             )
-        data_control_file.write("{:25s} {}\n".format("1-4scaling", self.coul_1_4))
+        data_control_file.write(
+            "{:25s} {}\n".format("1-4scaling", self.coul_1_4)
+        )
         data_control_file.write(" \n")
         if self.RcutCoulomb_box_0 is not None:
             data_control_file.write(
@@ -4588,9 +4606,10 @@ class GOMCControl:
         data_control_file.write("# PRESSURE CALCULATION\n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("PressureCalc",
-                                        str(self.PressureCalc[0]),
-                                        self.PressureCalc[1],
+            "{:25s} {:10s} {}\n".format(
+                "PressureCalc",
+                str(self.PressureCalc[0]),
+                self.PressureCalc[1],
             )
         )
         data_control_file.write(" \n")
@@ -4625,15 +4644,21 @@ class GOMCControl:
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-1Freq", self.IntraMEMC_1Freq)
         )
-        data_control_file.write("{:25s} {}\n".format("MEMC-1Freq", self.MEMC_1Freq))
+        data_control_file.write(
+            "{:25s} {}\n".format("MEMC-1Freq", self.MEMC_1Freq)
+        )
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-2Freq", self.IntraMEMC_2Freq)
         )
-        data_control_file.write("{:25s} {}\n".format("MEMC-2Freq", self.MEMC_2Freq))
+        data_control_file.write(
+            "{:25s} {}\n".format("MEMC-2Freq", self.MEMC_2Freq)
+        )
         data_control_file.write(
             "{:25s} {}\n".format("IntraMEMC-3Freq", self.IntraMEMC_3Freq)
         )
-        data_control_file.write("{:25s} {}\n".format("MEMC-3Freq", self.MEMC_3Freq))
+        data_control_file.write(
+            "{:25s} {}\n".format("MEMC-3Freq", self.MEMC_3Freq)
+        )
         data_control_file.write(" \n")
 
         # sort and print the MEMC data if MEMC is used for the simulation
@@ -4708,13 +4733,17 @@ class GOMCControl:
                 or self.IntraMEMC_3Freq > 0
             ):
                 data_control_file.write(
-                    "{:25s} {}\n".format("LargeKindBackBone", LargeKindBackBone_str)
+                    "{:25s} {}\n".format(
+                        "LargeKindBackBone", LargeKindBackBone_str
+                    )
                 )
             if self.MEMC_DataInput is not None and (
                 self.MEMC_2Freq > 0 or self.IntraMEMC_2Freq > 0
             ):
                 data_control_file.write(
-                    "{:25s} {}\n".format("SmallKindBackBone", SmallKindBackBone_str)
+                    "{:25s} {}\n".format(
+                        "SmallKindBackBone", SmallKindBackBone_str
+                    )
                 )
 
         data_control_file.write(" \n")
@@ -4843,14 +4872,16 @@ class GOMCControl:
 
             if self.LambdaCoulomb is not None:
                 data_control_file.write(
-                     "{:25s} {}\n".format("LambdaCoulomb", Lambda_Coul_str)
+                    "{:25s} {}\n".format("LambdaCoulomb", Lambda_Coul_str)
                 )
             data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# CBMC TRIALS \n")
         data_control_file.write("####################################\n")
-        data_control_file.write("{:25s} {}\n".format("CBMC_First", self.CBMC_First))
+        data_control_file.write(
+            "{:25s} {}\n".format("CBMC_First", self.CBMC_First)
+        )
         data_control_file.write("{:25s} {}\n".format("CBMC_Nth", self.CBMC_Nth))
         data_control_file.write("{:25s} {}\n".format("CBMC_Ang", self.CBMC_Ang))
         data_control_file.write("{:25s} {}\n".format("CBMC_Dih", self.CBMC_Dih))
@@ -4870,46 +4901,50 @@ class GOMCControl:
         data_control_file.write("####################################\n")
         data_control_file.write("# statistics filename add\n")
         data_control_file.write("####################################\n")
-        data_control_file.write("{:25s} {}\n".format("OutputName", self.OutputName))
+        data_control_file.write(
+            "{:25s} {}\n".format("OutputName", self.OutputName)
+        )
         data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# enable, frequency \n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("RestartFreq",
-                                 str(self.RestartFreq[0]),
-                                 self.RestartFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "RestartFreq", str(self.RestartFreq[0]), self.RestartFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("CheckpointFreq",
-                                        str(self.CheckpointFreq[0]),
-                                        self.CheckpointFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "CheckpointFreq",
+                str(self.CheckpointFreq[0]),
+                self.CheckpointFreq[1],
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("CoordinatesFreq",
-                                        str(self.CoordinatesFreq[0]),
-                                        self.CoordinatesFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "CoordinatesFreq",
+                str(self.CoordinatesFreq[0]),
+                self.CoordinatesFreq[1],
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("ConsoleFreq",
-                                        str(self.ConsoleFreq[0]),
-                                        self.ConsoleFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "ConsoleFreq", str(self.ConsoleFreq[0]), self.ConsoleFreq[1]
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("BlockAverageFreq",
-                                        str(self.BlockAverageFreq[0]),
-                                        self.BlockAverageFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "BlockAverageFreq",
+                str(self.BlockAverageFreq[0]),
+                self.BlockAverageFreq[1],
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {}\n".format("HistogramFreq",
-                                        str(self.HistogramFreq[0]),
-                                        self.HistogramFreq[1]
+            "{:25s} {:10s} {}\n".format(
+                "HistogramFreq",
+                str(self.HistogramFreq[0]),
+                self.HistogramFreq[1],
             )
         )
         data_control_file.write(" \n")
@@ -4919,49 +4954,61 @@ class GOMCControl:
         data_control_file.write("####################################\n")
         data_control_file.write("{:25s} {}\n".format("DistName", self.DistName))
         data_control_file.write("{:25s} {}\n".format("HistName", self.HistName))
-        data_control_file.write("{:25s} {}\n".format("RunNumber", self.RunNumber))
-        data_control_file.write("{:25s} {}\n".format("RunLetter", self.RunLetter))
-        data_control_file.write("{:25s} {}\n".format("SampleFreq", self.SampleFreq))
-        #print("{:10s}:    {}".format(arg, description))
+        data_control_file.write(
+            "{:25s} {}\n".format("RunNumber", self.RunNumber)
+        )
+        data_control_file.write(
+            "{:25s} {}\n".format("RunLetter", self.RunLetter)
+        )
+        data_control_file.write(
+            "{:25s} {}\n".format("SampleFreq", self.SampleFreq)
+        )
+        # print("{:10s}:    {}".format(arg, description))
         data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")
         data_control_file.write("# enable: blk avg., fluct. \n")
         data_control_file.write("####################################\n")
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutEnergy",
-                                        str(self.OutEnergy[0]),
-                                        str(self.OutEnergy[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutEnergy",
+                str(self.OutEnergy[0]),
+                str(self.OutEnergy[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutPressure",
-                                            str(self.OutPressure[0]),
-                                            str(self.OutPressure[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutPressure",
+                str(self.OutPressure[0]),
+                str(self.OutPressure[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutMolNumber",
-                                            str(self.OutMolNumber[0]),
-                                            str(self.OutMolNumber[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutMolNumber",
+                str(self.OutMolNumber[0]),
+                str(self.OutMolNumber[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutDensity",
-                                            str(self.OutDensity[0]),
-                                            str(self.OutDensity[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutDensity",
+                str(self.OutDensity[0]),
+                str(self.OutDensity[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutVolume",
-                                            str(self.OutVolume[0]),
-                                            str(self.OutVolume[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutVolume",
+                str(self.OutVolume[0]),
+                str(self.OutVolume[1]),
             )
         )
         data_control_file.write(
-            "{:25s} {:10s} {:10s}\n".format("OutSurfaceTension",
-                                            str(self.OutSurfaceTension[0]),
-                                            str(self.OutSurfaceTension[1]),
+            "{:25s} {:10s} {:10s}\n".format(
+                "OutSurfaceTension",
+                str(self.OutSurfaceTension[0]),
+                str(self.OutSurfaceTension[1]),
             )
         )
         data_control_file.write("\n")

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1,8 +1,9 @@
 import datetime
 import os
-from warnings import warn
-
+import mbuild.box as mb_box
 import mbuild.formats.charmm_writer as mf_charmm
+
+from warnings import warn
 
 
 def dict_keys_to_list(dict):
@@ -1872,18 +1873,12 @@ class GOMCControl:
         The structure file or PSF file for box 1 in the simulation.  This is only for
             GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
             simulation, the value will be None.
-        x_dim_box_0 : float or int
-            The x-dimension of box 0.  Currently, only orthogonal boxes are supported.
-        y_dim_box_0 : float or int
-            The y-dimension of box 0.  Currently, only orthogonal boxes are supported.
-        z_dim_box_0 : float or int
-            The z-dimension of box 0.  Currently, only orthogonal boxes are supported.
-        x_dim_box_1 : float or int
-            The x-dimension of box 1.  Currently, only orthogonal boxes are supported.
-        y_dim_box_1 : float or int
-            The y-dimension of box 1.  Currently, only orthogonal boxes are supported.
-        z_dim_box_1 : float or int
-            The z-dimension of box 1.  Currently, only orthogonal boxes are supported.
+        box_0_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
+            Three (3) sets vectors for box 0 each with 3 float values, which represent
+            the vectors for the Charmm-style systems (units in in nanometers (nm))
+        box_1_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
+            Three (3) sets vectors for box 1 each with 3 float values, which represent
+            the vectors for the Charmm-style systems (units in in nanometers (nm))
         coul_1_4 : float or int
             The non-bonded 1-4 coulombic scaling factor, which is the
             same for all the residues/molecules, regardless if
@@ -2013,43 +2008,49 @@ class GOMCControl:
             charmm_object.all_res_unique_atom_name_dict
         )
 
-        self.x_dim_box_0 = (
-            charmm_object.box_0.Lx * 10
-        )  # times 10 to convert from nm to Angstroms
-        self.y_dim_box_0 = (
-            charmm_object.box_0.Ly * 10
-        )  # times 10 to convert from nm to Angstroms
-        self.z_dim_box_0 = (
-            charmm_object.box_0.Lz * 10
-        )  # times 10 to convert from nm to Angstroms
+        # Get and test and make sure vectors are not too large for the 16 spaces allotted
+        box_vectors_char_limit = 16
+        self.box_0_vectors = charmm_object.box_0_vectors
+        box_0_vectors_char_ok = True
+        for x_i in range(0, 3):
+            for y_i in range(0, 3):
+                if len(str(self.box_0_vectors[x_i][y_i])) > box_vectors_char_limit:
+                    box_0_vectors_char_ok = False
 
-        print(
-            "charmm_object.filename_box_1 = ",
-            format(str(charmm_object.filename_box_1)),
-        )
-        print(
-            "type(charmm_object.filename_box_1) = ",
-            format(str(type(charmm_object.filename_box_1))),
-        )
-
+        if box_0_vectors_char_ok == False:
+            self.input_error = True
+            print_error_message = (
+                "ERROR: At lease one of the individual box {} vectors are too large "
+                "or greater than {} characters."
+                "".format(0,
+                          box_vectors_char_limit,
+                          )
+            )
+            raise ValueError(print_error_message)
         if self.ensemble_type in ["GEMC_NVT", "GEMC_NPT", "GCMC"]:
             if (
-                charmm_object.filename_box_1 is not None
-                and isinstance(charmm_object.filename_box_1, str) is True
+                    charmm_object.filename_box_1 is not None
+                    and isinstance(charmm_object.filename_box_1, str) is True
             ):
-                self.x_dim_box_1 = (
-                    charmm_object.box_1.Lx * 10
-                )  # times 10 to convert from nm to Angstroms
-                self.y_dim_box_1 = (
-                    charmm_object.box_1.Ly * 10
-                )  # times 10 to convert from nm to Angstroms
-                self.z_dim_box_1 = (
-                    charmm_object.box_1.Lz * 10
-                )  # times 10 to convert from nm to Angstroms
+                self.box_1_vectors = charmm_object.box_1_vectors
+                box_1_vectors_char_ok = True
+                for x_i in range(0, 3):
+                    for y_i in range(0, 3):
+                        if len(str(self.box_1_vectors[x_i][y_i])) > box_vectors_char_limit:
+                            box_1_vectors_char_ok = False
+
+                if box_1_vectors_char_ok == False:
+                    self.input_error = True
+                    print_error_message = (
+                        "ERROR: At lease one of the individual box {} vectors are too large "
+                        "or greater than {} characters."
+                        "".format(1,
+                                  box_vectors_char_limit,
+                                  )
+                    )
+                    raise ValueError(print_error_message)
             else:
-                self.x_dim_box_1 = None
-                self.y_dim_box_1 = None
-                self.z_dim_box_1 = None
+                self.box_1_vectors = None
 
         # check if the ensembles have the correct number of boxes in the charmm object
         if (
@@ -2079,28 +2080,6 @@ class GOMCControl:
                 "".format(ensemble_type, ensemble_type)
             )
             raise ValueError(print_error_message)
-
-        # check the box dimensions
-        ck_box_dim_is_float_or_int_greater_0(
-            self.x_dim_box_0, "x", 0, self.ensemble_type
-        )
-        ck_box_dim_is_float_or_int_greater_0(
-            self.y_dim_box_0, "y", 0, self.ensemble_type
-        )
-        ck_box_dim_is_float_or_int_greater_0(
-            self.z_dim_box_0, "z", 0, self.ensemble_type
-        )
-
-        if self.ensemble_type in ["GEMC_NVT", "GEMC_NPT", "GCMC"]:
-            ck_box_dim_is_float_or_int_greater_0(
-                self.x_dim_box_1, "x", 1, self.ensemble_type
-            )
-            ck_box_dim_is_float_or_int_greater_0(
-                self.y_dim_box_1, "y", 1, self.ensemble_type
-            )
-            ck_box_dim_is_float_or_int_greater_0(
-                self.z_dim_box_1, "z", 1, self.ensemble_type
-            )
 
         # the future control file name is entered now as None
         self.conf_filename = None
@@ -2406,8 +2385,8 @@ class GOMCControl:
         # verify all input variable values are valid, for their keys
         input_var_keys_list = dict_keys_to_list(self.input_variables_dict)
 
-        possible_ensemble_variables_list = (
-            _get_possible_ensemble_input_variables(self.ensemble_type)
+        possible_ensemble_variables_list = _get_possible_ensemble_input_variables(
+            self.ensemble_type
         )
 
         # check to make sure the VDW FF (ParaTypeCHARMM) is set true  for multiple ones by the user
@@ -4331,6 +4310,23 @@ class GOMCControl:
                 print_error_message = "ERROR: The LambdaVDW and LambdaCoulomb list must be of equal length."
                 raise ValueError(print_error_message)
 
+        # check self.LambdaVDW and LambdaCoulomb last value is 1.0
+        if self.ensemble_type in ["NVT", "NPT"]:
+            if isinstance(self.LambdaVDW, list):
+                if len(self.LambdaVDW) > 0:
+                    if self.LambdaVDW[-1] != 1.0:
+                        print_error_message = (
+                            "ERROR: The last value in the LambdaVDW variable list must be a 1.0"
+                        )
+                        raise ValueError(print_error_message)
+            if isinstance(self.LambdaCoulomb, list):
+                if len(self.LambdaCoulomb) > 0:
+                    if self.LambdaCoulomb[-1] != 1.0:
+                        print_error_message = (
+                            "ERROR: The last value in the LambdaCoulomb variable list must be a 1.0"
+                        )
+                        raise ValueError(print_error_message)
+
     # write the control file
     def write_conf_file(self, conf_filename):
         """
@@ -4422,40 +4418,40 @@ class GOMCControl:
             "############################################################################\n"
         )
         data_control_file.write(" \n")
-        data_control_file.write("#########################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# enable, step\n")
-        data_control_file.write("#########################\n")
-        data_control_file.write("Restart \t {}\n".format(self.Restart))
+        data_control_file.write("####################################\n")
+        data_control_file.write("{:25s} {}\n".format("Restart", self.Restart))
         data_control_file.write("\n")
         data_control_file.write(
-            "RestartCheckpoint \t {}\n".format(self.RestartCheckpoint)
+            "{:25s} {}\n".format("RestartCheckpoint", self.RestartCheckpoint)
         )
         data_control_file.write("\n")
         data_control_file.write("####################################\n")
         data_control_file.write("# kind {RESTART, RANDOM, INTSEED}\n")
         data_control_file.write("####################################\n")
         if self.PRNG == "RANDOM":
-            data_control_file.write("PRNG \t\t {}\n".format(self.PRNG))
+            data_control_file.write("{:25s} {}\n".format("PRNG", self.PRNG))
         elif isinstance(self.PRNG, int):
             data_control_file.write("PRNG \t\t " + "INTSEED \n")
-            data_control_file.write("Random_Seed \t {}\n".format(self.PRNG))
+            data_control_file.write("{:25s} {}\n".format("Random_Seed", self.PRNG))
         data_control_file.write(" \n")
         data_control_file.write("####################################\n")
         data_control_file.write("# FORCE FIELD\n")
         data_control_file.write("####################################\n")
-        data_control_file.write("{}\t\t {}\n".format(self.VDW_type, True))
+        data_control_file.write("{:25s} {}\n".format(str(self.VDW_type), str(True)))
         data_control_file.write(" \n")
-        data_control_file.write("Parameters \t\t {}\n".format(self.ff_filename))
+        data_control_file.write("{:25s} {}\n".format("Parameters", self.ff_filename))
         data_control_file.write("####################################\n")
         data_control_file.write("# INPUT PDB FILES\n")
         data_control_file.write("####################################\n")
         if self.ensemble_type in ["NVT", "NPT", "GEMC_NPT", "GEMC_NVT", "GCMC"]:
             data_control_file.write(
-                "Coordinates 0 \t\t {}\n".format(self.Coordinates_box_0)
+                "{:25s} {}\n".format("Coordinates 0", self.Coordinates_box_0)
             )
         if self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]:
             data_control_file.write(
-                "Coordinates 1 \t\t {}\n".format(self.Coordinates_box_1)
+                "{:25s} {}\n".format("Coordinates 1", self.Coordinates_box_1)
             )
         data_control_file.write(" \n")
         data_control_file.write("####################################\n")
@@ -4463,11 +4459,11 @@ class GOMCControl:
         data_control_file.write("####################################\n")
         if self.ensemble_type in ["NVT", "NPT", "GEMC_NPT", "GEMC_NVT", "GCMC"]:
             data_control_file.write(
-                "Structure 0 \t\t {}\n".format(self.Structures_box_0)
+                "{:25s} {}\n".format("Structure 0", self.Structures_box_0)
             )
         if self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]:
             data_control_file.write(
-                "Structure 1 \t\t {}\n".format(self.Structures_box_1)
+                "{:25s} {}\n".format("Structure 1", self.Structures_box_1)
             )
         data_control_file.write(" \n")
         data_control_file.write(
@@ -4481,29 +4477,31 @@ class GOMCControl:
         )
         data_control_file.write(" \n")
         if self.ensemble_type in ["GEMC_NPT", "GEMC_NVT"]:
-            data_control_file.write("##################################\n")
+            data_control_file.write("####################################\n")
             data_control_file.write("# GEMC TYPE \n")
-            data_control_file.write("##################################\n")
+            data_control_file.write("####################################\n")
             if self.ensemble_type in "GEMC_NPT":
                 data_control_file.write("GEMC \t\t NPT \n")
             elif self.ensemble_type in "GEMC_NVT":
                 data_control_file.write("GEMC \t\t NVT \n")
         data_control_file.write(" \n")
-        data_control_file.write("#############################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# SIMULATION CONDITION\n")
-        data_control_file.write("#############################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write(
-            "Temperature \t\t {}\n".format(self.Temperature)
+            "{:25s} {}\n".format("Temperature", self.Temperature)
         )
         if self.ensemble_type in ["GEMC_NPT", "NPT"]:
-            data_control_file.write("Pressure \t\t {}\n".format(self.Pressure))
             data_control_file.write(
-                "useConstantArea \t {}\n".format(self.useConstantArea)
+                "{:25s} {}\n".format("Pressure", self.Pressure)
+            )
+            data_control_file.write(
+                "{:25s} {}\n".format("useConstantArea", self.useConstantArea)
             )
 
         if self.ensemble_type in ["GEMC_NPT"] and self.FixVolBox0 is True:
             data_control_file.write(
-                "FixVolBox0 \t\t {}\n".format(self.FixVolBox0)
+                "{:25s} {}\n".format("FixVolBox0", self.FixVolBox0)
             )
 
         if (
@@ -4515,9 +4513,10 @@ class GOMCControl:
             for chem_pot_iter in range(0, len(chem_pot_dict_key_list)):
                 chem_pot_residue_iter = chem_pot_dict_key_list[chem_pot_iter]
                 data_control_file.write(
-                    "ChemPot \t\t {} \t\t {}\n".format(
+                    "{:25s} {:10s} {}\n".format(
+                        "ChemPot",
                         chem_pot_residue_iter,
-                        self.ChemPot[chem_pot_residue_iter],
+                        self.ChemPot[chem_pot_residue_iter]
                     )
                 )
 
@@ -4532,48 +4531,49 @@ class GOMCControl:
                     fugacity_iter
                 ]
                 data_control_file.write(
-                    "Fugacity \t\t {} \t\t {}\n".format(
+                    "{:25s} {:10s} {}\n".format(
+                        "Fugacity",
                         fugacity_residue_iter,
                         self.Fugacity[fugacity_residue_iter],
                     )
                 )
 
         data_control_file.write(" \n")
-        data_control_file.write("Potential \t\t {}\n".format(self.Potential))
-        data_control_file.write("LRC \t\t\t {}\n".format(self.LRC))
-        data_control_file.write("Rcut \t\t\t {}\n".format(self.Rcut))
-        data_control_file.write("RcutLow \t\t {}\n".format(self.RcutLow))
+        data_control_file.write("{:25s} {}\n".format("Potential", self.Potential))
+        data_control_file.write("{:25s} {}\n".format("LRC", self.LRC))
+        data_control_file.write("{:25s} {}\n".format("Rcut", self.Rcut))
+        data_control_file.write("{:25s} {}\n".format("RcutLow", self.RcutLow))
         if self.Potential == "SWITCH":
-            data_control_file.write("Rswitch \t\t {}\n".format(self.Rswitch))
-        data_control_file.write("Exclude \t\t {}\n".format(self.Exclude))
+            data_control_file.write("{:25s} {}\n".format("Rswitch", self.Rswitch))
+        data_control_file.write("{:25s} {}\n".format("Exclude", self.Exclude))
         if self.VDWGeometricSigma is True:
             data_control_file.write(
-                "VDWGeometricSigma \t {}\n".format(self.VDWGeometricSigma)
+                "{:25s} {}\n".format("VDWGeometricSigma", self.VDWGeometricSigma)
             )
         data_control_file.write(" \n")
 
-        data_control_file.write("#############################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# ELECTROSTATIC   \n")
-        data_control_file.write("#############################\n")
-        data_control_file.write("Ewald \t\t {}\n".format(self.Ewald))
+        data_control_file.write("####################################\n")
+        data_control_file.write("{:25s} {}\n".format("Ewald", self.Ewald))
         data_control_file.write(
-            "ElectroStatic \t {}\n".format(self.ElectroStatic)
+            "{:25s} {}\n".format("ElectroStatic", self.ElectroStatic)
         )
         data_control_file.write(
-            "CachedFourier \t {}\n".format(self.CachedFourier)
+            "{:25s} {}\n".format("CachedFourier", self.CachedFourier)
         )
         data_control_file.write(
-            "Tolerance \t {}\n".format(format(self.Tolerance, ".12f"))
+            "{:25s} {}\n".format("Tolerance", str(self.Tolerance))
         )
         if self.VDW_type in ["ParaTypeMARTINI"]:
             data_control_file.write(
-                "Dielectric \t {}\n".format(format(self.Dielectric))
+                "{:25s} {}\n".format("Dielectric", format(self.Dielectric))
             )
-        data_control_file.write("1-4scaling \t {}\n".format(self.coul_1_4))
+        data_control_file.write("{:25s} {}\n".format("1-4scaling", self.coul_1_4))
         data_control_file.write(" \n")
         if self.RcutCoulomb_box_0 is not None:
             data_control_file.write(
-                "RcutCoulomb 0 \t {}\n".format(self.RcutCoulomb_box_0)
+                "{:25s} {}\n".format("RcutCoulomb 0", self.RcutCoulomb_box_0)
             )
         if self.RcutCoulomb_box_1 is not None and self.ensemble_type in [
             "GEMC_NPT",
@@ -4581,59 +4581,60 @@ class GOMCControl:
             "GCMC",
         ]:
             data_control_file.write(
-                "RcutCoulomb 1 \t {}\n".format(self.RcutCoulomb_box_1)
+                "{:25s} {}\n".format("RcutCoulomb 1", self.RcutCoulomb_box_1)
             )
         data_control_file.write(" \n")
 
-        data_control_file.write("################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# PRESSURE CALCULATION\n")
-        data_control_file.write("################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write(
-            "PressureCalc \t {} \t\t {}\n".format(
-                self.PressureCalc[0], self.PressureCalc[1]
+            "{:25s} {:10s} {}\n".format("PressureCalc",
+                                        str(self.PressureCalc[0]),
+                                        self.PressureCalc[1],
             )
         )
         data_control_file.write(" \n")
 
-        data_control_file.write("################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# STEPS \n")
-        data_control_file.write("################################\n")
-        data_control_file.write("RunSteps \t {}\n".format(self.RunSteps))
-        data_control_file.write("EqSteps \t {}\n".format(self.EqSteps))
-        data_control_file.write("AdjSteps \t {}\n".format(self.AdjSteps))
+        data_control_file.write("####################################\n")
+        data_control_file.write("{:25s} {}\n".format("RunSteps", self.RunSteps))
+        data_control_file.write("{:25s} {}\n".format("EqSteps", self.EqSteps))
+        data_control_file.write("{:25s} {}\n".format("AdjSteps", self.AdjSteps))
         data_control_file.write(" \n")
 
-        data_control_file.write("################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# MOVE FREQUENCY \n")
-        data_control_file.write("################################\n")
-        data_control_file.write("DisFreq \t\t {}\n".format(self.DisFreq))
-        data_control_file.write("RotFreq \t\t {}\n".format(self.RotFreq))
+        data_control_file.write("####################################\n")
+        data_control_file.write("{:25s} {}\n".format("DisFreq", self.DisFreq))
+        data_control_file.write("{:25s} {}\n".format("RotFreq", self.RotFreq))
         data_control_file.write(
-            "IntraSwapFreq \t\t {}\n".format(self.IntraSwapFreq)
+            "{:25s} {}\n".format("IntraSwapFreq", self.IntraSwapFreq)
         )
-        data_control_file.write("SwapFreq \t\t {}\n".format(self.SwapFreq))
+        data_control_file.write("{:25s} {}\n".format("SwapFreq", self.SwapFreq))
         data_control_file.write(
-            "RegrowthFreq \t\t {}\n".format(self.RegrowthFreq)
-        )
-        data_control_file.write(
-            "CrankShaftFreq \t\t {}\n".format(self.CrankShaftFreq)
-        )
-        data_control_file.write("VolFreq \t\t {}\n".format(self.VolFreq))
-        data_control_file.write(
-            "MultiParticleFreq \t {}\n".format(self.MultiParticleFreq)
+            "{:25s} {}\n".format("RegrowthFreq", self.RegrowthFreq)
         )
         data_control_file.write(
-            "IntraMEMC-1Freq \t {}\n".format(self.IntraMEMC_1Freq)
+            "{:25s} {}\n".format("CrankShaftFreq", self.CrankShaftFreq)
         )
-        data_control_file.write("MEMC-1Freq \t\t {}\n".format(self.MEMC_1Freq))
+        data_control_file.write("{:25s} {}\n".format("VolFreq", self.VolFreq))
         data_control_file.write(
-            "IntraMEMC-2Freq \t {}\n".format(self.IntraMEMC_2Freq)
+            "{:25s} {}\n".format("MultiParticleFreq", self.MultiParticleFreq)
         )
-        data_control_file.write("MEMC-2Freq \t\t {}\n".format(self.MEMC_2Freq))
         data_control_file.write(
-            "IntraMEMC-3Freq \t {}\n".format(self.IntraMEMC_3Freq)
+            "{:25s} {}\n".format("IntraMEMC-1Freq", self.IntraMEMC_1Freq)
         )
-        data_control_file.write("MEMC-3Freq \t\t {}\n".format(self.MEMC_3Freq))
+        data_control_file.write("{:25s} {}\n".format("MEMC-1Freq", self.MEMC_1Freq))
+        data_control_file.write(
+            "{:25s} {}\n".format("IntraMEMC-2Freq", self.IntraMEMC_2Freq)
+        )
+        data_control_file.write("{:25s} {}\n".format("MEMC-2Freq", self.MEMC_2Freq))
+        data_control_file.write(
+            "{:25s} {}\n".format("IntraMEMC-3Freq", self.IntraMEMC_3Freq)
+        )
+        data_control_file.write("{:25s} {}\n".format("MEMC-3Freq", self.MEMC_3Freq))
         data_control_file.write(" \n")
 
         # sort and print the MEMC data if MEMC is used for the simulation
@@ -4654,24 +4655,24 @@ class GOMCControl:
 
             for memc_i in range(0, len(self.MEMC_DataInput)):
                 ExchangeRatio_list.append(
-                    str("{} \t\t".format(self.MEMC_DataInput[memc_i][0]))
+                    str("{:10s} \t".format(str(self.MEMC_DataInput[memc_i][0])))
                 )
                 ExchangeLargeKind_list.append(
-                    "{} \t\t".format(self.MEMC_DataInput[memc_i][1])
+                    "{:10s} \t".format(str(self.MEMC_DataInput[memc_i][1]))
                 )
                 LargeKindBackBone_list.append(
-                    "{}   {} \t".format(
-                        self.MEMC_DataInput[memc_i][2][0],
-                        self.MEMC_DataInput[memc_i][2][1],
+                    "{:4s}  {:4s} \t".format(
+                        str(self.MEMC_DataInput[memc_i][2][0]),
+                        str(self.MEMC_DataInput[memc_i][2][1]),
                     )
                 )
                 ExchangeSmallKind_list.append(
-                    "{} \t\t".format(self.MEMC_DataInput[memc_i][3])
+                    "{:10s} \t".format(str(self.MEMC_DataInput[memc_i][3]))
                 )
                 SmallKindBackBone_list.append(
-                    "{}   {} \t".format(
-                        self.MEMC_DataInput[memc_i][4][0],
-                        self.MEMC_DataInput[memc_i][4][1],
+                    "{:4s}  {:4s} \t".format(
+                        str(self.MEMC_DataInput[memc_i][4][0]),
+                        str(self.MEMC_DataInput[memc_i][4][1]),
                     )
                 )
 
@@ -4681,24 +4682,25 @@ class GOMCControl:
             ExchangeSmallKind_str = "".join(ExchangeSmallKind_list)
             SmallKindBackBone_str = "".join(SmallKindBackBone_list)
 
-            data_control_file.write("###############################\n")
+            data_control_file.write("####################################\n")
             data_control_file.write("# MEMC PARAMETER \n")
-            data_control_file.write("###############################\n")
+            data_control_file.write("####################################\n")
             data_control_file.write(
-                "ExchangeVolumeDim \t {}\t{}\t{} \n".format(
+                "{:25s} {}\t{}\t{}\n".format(
+                    "ExchangeVolumeDim",
                     self.ExchangeVolumeDim[0],
                     self.ExchangeVolumeDim[1],
                     self.ExchangeVolumeDim[2],
                 )
             )
             data_control_file.write(
-                "ExchangeRatio \t\t {}\n".format(ExchangeRatio_str)
+                "{:25s} {}\n".format("ExchangeRatio", ExchangeRatio_str)
             )
             data_control_file.write(
-                "ExchangeLargeKind \t {}\n".format(ExchangeLargeKind_str)
+                "{:25s} {}\n".format("ExchangeLargeKind", ExchangeLargeKind_str)
             )
             data_control_file.write(
-                "ExchangeSmallKind \t {}\n".format(ExchangeSmallKind_str)
+                "{:25s} {}\n".format("ExchangeSmallKind", ExchangeSmallKind_str)
             )
             if self.MEMC_DataInput is not None and (
                 self.MEMC_2Freq > 0
@@ -4707,53 +4709,71 @@ class GOMCControl:
                 or self.IntraMEMC_3Freq > 0
             ):
                 data_control_file.write(
-                    "LargeKindBackBone \t {}\n".format(LargeKindBackBone_str)
+                    "{:25s} {}\n".format("LargeKindBackBone", LargeKindBackBone_str)
                 )
             if self.MEMC_DataInput is not None and (
                 self.MEMC_2Freq > 0 or self.IntraMEMC_2Freq > 0
             ):
                 data_control_file.write(
-                    "SmallKindBackBone \t {}\n".format(SmallKindBackBone_str)
+                    "{:25s} {}\n".format("SmallKindBackBone", SmallKindBackBone_str)
                 )
 
         data_control_file.write(" \n")
 
-        data_control_file.write("################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write(
-            "# BOX DIMENSION #, X, Y, Z    (only orthoganal boxes are currently "
+            "# BOX DIMENSION #, X, Y, Z    (only orthoganol boxes are currently "
             "available in this control file writer)\n"
         )
-        data_control_file.write("################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write(
-            "CellBasisVector1 0 \t {}\t\t0.00\t\t0.00\n".format(
-                self.x_dim_box_0
+            "{:25s} {:20s} {:20s} {:20s}\n".format(
+                "CellBasisVector1 0",
+                str(self.box_0_vectors[0][0]),
+                str(self.box_0_vectors[0][1]),
+                str(self.box_0_vectors[0][2]),
             )
         )
         data_control_file.write(
-            "CellBasisVector2 0 \t 0.00\t\t{}\t\t0.00\n".format(
-                self.y_dim_box_0
+            "{:25s} {:20s} {:20s} {:20s}\n".format(
+                "CellBasisVector2 0",
+                str(self.box_0_vectors[1][0]),
+                str(self.box_0_vectors[1][1]),
+                str(self.box_0_vectors[1][2]),
             )
         )
         data_control_file.write(
-            "CellBasisVector3 0 \t 0.00\t\t0.00\t\t{}\n".format(
-                self.z_dim_box_0
+            "{:25s} {:20s} {:20s} {:20s}\n".format(
+                "CellBasisVector3 0",
+                str(self.box_0_vectors[2][0]),
+                str(self.box_0_vectors[2][1]),
+                str(self.box_0_vectors[2][2]),
             )
         )
         data_control_file.write(" \n")
         if self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]:
             data_control_file.write(
-                "CellBasisVector1 1 \t {}\t\t0.00\t\t0.00\n".format(
-                    self.x_dim_box_1
+                "{:25s} {:20s} {:20s} {:20s}\n".format(
+                    "CellBasisVector1 1",
+                    str(self.box_1_vectors[0][0]),
+                    str(self.box_1_vectors[0][1]),
+                    str(self.box_1_vectors[0][2]),
                 )
             )
             data_control_file.write(
-                "CellBasisVector2 1 \t 0.00\t\t{}\t\t0.00\n".format(
-                    self.y_dim_box_1
+                "{:25s} {:20s} {:20s} {:20s}\n".format(
+                    "CellBasisVector2 1",
+                    str(self.box_1_vectors[1][0]),
+                    str(self.box_1_vectors[1][1]),
+                    str(self.box_1_vectors[1][2]),
                 )
             )
             data_control_file.write(
-                "CellBasisVector3 1 \t 0.00\t\t0.00\t\t{}\n".format(
-                    self.z_dim_box_1
+                "{:25s} {:20s} {:20s} {:20s}\n".format(
+                    "CellBasisVector3 1",
+                    str(self.box_1_vectors[2][0]),
+                    str(self.box_1_vectors[2][1]),
+                    str(self.box_1_vectors[2][2]),
                 )
             )
             data_control_file.write(" \n")
@@ -4780,43 +4800,11 @@ class GOMCControl:
             Lambda_VDW_str = "\t".join(Lambda_VDW_list)
             Lambda_Coul_str = "\t".join(Lambda_Coul_list)
 
-            data_control_file.write("##############################\n")
+            data_control_file.write("####################################\n")
             data_control_file.write(
                 "# FREE ENERGY PARAMETERS (only available in NPT and NVT ensembles) \n"
             )
-            data_control_file.write("##############################\n")
-            data_control_file.write(
-                "FreeEnergyCalc \t {}\t\t{}\n".format(
-                    self.FreeEnergyCalc[0], self.FreeEnergyCalc[1]
-                )
-            )
-            data_control_file.write(
-                "MoleculeType \t {}\t\t{}\n".format(
-                    self.MoleculeType[0], self.MoleculeType[1]
-                )
-            )
-            data_control_file.write(
-                "InitialState \t {}\n".format(self.InitialState)
-            )
-            data_control_file.write(
-                "ScalePower \t {}\n".format(self.ScalePower)
-            )
-            data_control_file.write(
-                "ScaleAlpha \t {}\n".format(self.ScaleAlpha)
-            )
-            data_control_file.write("MinSigma \t {}\n".format(self.MinSigma))
-            data_control_file.write(
-                "ScaleCoulomb \t {}\n".format(self.ScaleCoulomb)
-            )
-            data_control_file.write(
-                "# States \t {}\n".format(Lambda_states_str)
-            )
-            data_control_file.write("LambdaVDW \t {}\n".format(Lambda_VDW_str))
-            data_control_file.write(
-                "LambdaCoulomb \t {}\n".format(Lambda_Coul_str)
-            )
-            data_control_file.write(" \n")
-
+            data_control_file.write("####################################\n")
         if (
             (self.ensemble_type in ["NPT", "NVT"])
             and self.FreeEnergyCalc is not None
@@ -4840,51 +4828,60 @@ class GOMCControl:
             if self.LambdaCoulomb is not None:
                 Lambda_Coul_str = "\t".join(Lambda_Coul_list)
 
-            data_control_file.write("##############################\n")
+            data_control_file.write("####################################\n")
             data_control_file.write(
                 "# FREE ENERGY PARAMETERS (only available in NPT and NVT ensembles) \n"
             )
-            data_control_file.write("##############################\n")
+            data_control_file.write("####################################\n")
             data_control_file.write(
-                "FreeEnergyCalc \t {}\t\t{}\n".format(
-                    self.FreeEnergyCalc[0], self.FreeEnergyCalc[1]
+                "{:25s} {:10s} {}\n".format(
+                    "FreeEnergyCalc",
+                    str(self.FreeEnergyCalc[0]),
+                    self.FreeEnergyCalc[1],
                 )
             )
             data_control_file.write(
-                "MoleculeType \t {}\t\t{}\n".format(
-                    self.MoleculeType[0], self.MoleculeType[1]
+                "{:25s} {:10s} {}\n".format(
+                    "MoleculeType",
+                    str(self.MoleculeType[0]),
+                    self.MoleculeType[1],
                 )
             )
             data_control_file.write(
-                "InitialState \t {}\n".format(self.InitialState)
+                "{:25s} {}\n".format("InitialState", self.InitialState)
             )
             data_control_file.write(
-                "ScalePower \t {}\n".format(self.ScalePower)
+                "{:25s} {}\n".format("ScalePower", self.ScalePower)
             )
             data_control_file.write(
-                "ScaleAlpha \t {}\n".format(self.ScaleAlpha)
-            )
-            data_control_file.write("MinSigma \t {}\n".format(self.MinSigma))
-            data_control_file.write(
-                "ScaleCoulomb \t {}\n".format(self.ScaleCoulomb)
+                "{:25s} {}\n".format("ScaleAlpha", self.ScaleAlpha)
             )
             data_control_file.write(
-                "# States \t {}\n".format(Lambda_states_str)
+                "{:25s} {}\n".format("MinSigma", self.MinSigma)
             )
-            data_control_file.write("LambdaVDW \t {}\n".format(Lambda_VDW_str))
+            data_control_file.write(
+                "{:25s} {}\n".format("ScaleCoulomb", self.ScaleCoulomb)
+            )
+            data_control_file.write(
+                "{:25s} {}\n".format("# States", Lambda_states_str)
+            )
+            data_control_file.write(
+                "{:25s} {}\n".format("LambdaVDW", Lambda_VDW_str)
+            )
+
             if self.LambdaCoulomb is not None:
                 data_control_file.write(
-                    "LambdaCoulomb \t {}\n".format(Lambda_Coul_str)
+                     "{:25s} {}\n".format("LambdaCoulomb", Lambda_Coul_str)
                 )
             data_control_file.write(" \n")
 
-        data_control_file.write("##############################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# CBMC TRIALS \n")
-        data_control_file.write("##############################\n")
-        data_control_file.write("CBMC_First \t {}\n".format(self.CBMC_First))
-        data_control_file.write("CBMC_Nth \t {}\n".format(self.CBMC_Nth))
-        data_control_file.write("CBMC_Ang \t {}\n".format(self.CBMC_Ang))
-        data_control_file.write("CBMC_Dih \t {}\n".format(self.CBMC_Dih))
+        data_control_file.write("####################################\n")
+        data_control_file.write("{:25s} {}\n".format("CBMC_First", self.CBMC_First))
+        data_control_file.write("{:25s} {}\n".format("CBMC_Nth", self.CBMC_Nth))
+        data_control_file.write("{:25s} {}\n".format("CBMC_Ang", self.CBMC_Ang))
+        data_control_file.write("{:25s} {}\n".format("CBMC_Dih", self.CBMC_Dih))
         data_control_file.write(" \n")
 
         data_control_file.write(
@@ -4898,88 +4895,101 @@ class GOMCControl:
         )
         data_control_file.write(" \n")
 
-        data_control_file.write("##########################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# statistics filename add\n")
-        data_control_file.write("##########################\n")
-        data_control_file.write("OutputName \t {}\n".format(self.OutputName))
+        data_control_file.write("####################################\n")
+        data_control_file.write("{:25s} {}\n".format("OutputName", self.OutputName))
         data_control_file.write(" \n")
 
-        data_control_file.write("#####################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# enable, frequency \n")
-        data_control_file.write("#####################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write(
-            "RestartFreq  \t\t {}\t\t{}\n".format(
-                self.RestartFreq[0], self.RestartFreq[1]
+            "{:25s} {:10s} {}\n".format("RestartFreq",
+                                 str(self.RestartFreq[0]),
+                                 self.RestartFreq[1]
             )
         )
         data_control_file.write(
-            "CheckpointFreq  \t {}\t\t{}\n".format(
-                self.CheckpointFreq[0], self.CheckpointFreq[1]
+            "{:25s} {:10s} {}\n".format("CheckpointFreq",
+                                        str(self.CheckpointFreq[0]),
+                                        self.CheckpointFreq[1]
             )
         )
         data_control_file.write(
-            "CoordinatesFreq  \t {}\t\t{}\n".format(
-                self.CoordinatesFreq[0], self.CoordinatesFreq[1]
+            "{:25s} {:10s} {}\n".format("CoordinatesFreq",
+                                        str(self.CoordinatesFreq[0]),
+                                        self.CoordinatesFreq[1]
             )
         )
         data_control_file.write(
-            "ConsoleFreq  \t\t {}\t\t{}\n".format(
-                self.ConsoleFreq[0], self.ConsoleFreq[1]
+            "{:25s} {:10s} {}\n".format("ConsoleFreq",
+                                        str(self.ConsoleFreq[0]),
+                                        self.ConsoleFreq[1]
             )
         )
         data_control_file.write(
-            "BlockAverageFreq  \t {}\t\t{}\n".format(
-                self.BlockAverageFreq[0], self.BlockAverageFreq[1]
+            "{:25s} {:10s} {}\n".format("BlockAverageFreq",
+                                        str(self.BlockAverageFreq[0]),
+                                        self.BlockAverageFreq[1]
             )
         )
         data_control_file.write(
-            "HistogramFreq  \t\t {}\t\t{}\n".format(
-                self.HistogramFreq[0], self.HistogramFreq[1]
+            "{:25s} {:10s} {}\n".format("HistogramFreq",
+                                        str(self.HistogramFreq[0]),
+                                        self.HistogramFreq[1]
             )
         )
         data_control_file.write(" \n")
 
-        data_control_file.write("################################\n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# OutHistSettings \n")
-        data_control_file.write("################################\n")
-        data_control_file.write("DistName \t {}\n".format(self.DistName))
-        data_control_file.write("HistName \t {}\n".format(self.HistName))
-        data_control_file.write("RunNumber \t {}\n".format(self.RunNumber))
-        data_control_file.write("RunLetter \t {}\n".format(self.RunLetter))
-        data_control_file.write("SampleFreq \t {}\n".format(self.SampleFreq))
+        data_control_file.write("####################################\n")
+        data_control_file.write("{:25s} {}\n".format("DistName", self.DistName))
+        data_control_file.write("{:25s} {}\n".format("HistName", self.HistName))
+        data_control_file.write("{:25s} {}\n".format("RunNumber", self.RunNumber))
+        data_control_file.write("{:25s} {}\n".format("RunLetter", self.RunLetter))
+        data_control_file.write("{:25s} {}\n".format("SampleFreq", self.SampleFreq))
+        #print("{:10s}:    {}".format(arg, description))
         data_control_file.write(" \n")
 
-        data_control_file.write("################################## \n")
+        data_control_file.write("####################################\n")
         data_control_file.write("# enable: blk avg., fluct. \n")
-        data_control_file.write("################################## \n")
+        data_control_file.write("####################################\n")
         data_control_file.write(
-            "OutEnergy \t\t {}\t\t{}\n".format(
-                self.OutEnergy[0], self.OutEnergy[1]
+            "{:25s} {:10s} {:10s}\n".format("OutEnergy",
+                                        str(self.OutEnergy[0]),
+                                        str(self.OutEnergy[1]),
             )
         )
         data_control_file.write(
-            "OutPressure \t\t {}\t\t{}\n".format(
-                self.OutPressure[0], self.OutPressure[1]
+            "{:25s} {:10s} {:10s}\n".format("OutPressure",
+                                            str(self.OutPressure[0]),
+                                            str(self.OutPressure[1]),
             )
         )
         data_control_file.write(
-            "OutMolNumber \t\t {}\t\t{}\n".format(
-                self.OutMolNumber[0], self.OutMolNumber[1]
+            "{:25s} {:10s} {:10s}\n".format("OutMolNumber",
+                                            str(self.OutMolNumber[0]),
+                                            str(self.OutMolNumber[1]),
             )
         )
         data_control_file.write(
-            "OutDensity \t\t {}\t\t{}\n".format(
-                self.OutDensity[0], self.OutDensity[1]
+            "{:25s} {:10s} {:10s}\n".format("OutDensity",
+                                            str(self.OutDensity[0]),
+                                            str(self.OutDensity[1]),
             )
         )
         data_control_file.write(
-            "OutVolume \t\t {}\t\t{}\n".format(
-                self.OutVolume[0], self.OutVolume[1]
+            "{:25s} {:10s} {:10s}\n".format("OutVolume",
+                                            str(self.OutVolume[0]),
+                                            str(self.OutVolume[1]),
             )
         )
         data_control_file.write(
-            "OutSurfaceTension \t {}\t\t{}\n".format(
-                self.OutSurfaceTension[0], self.OutSurfaceTension[1]
+            "{:25s} {:10s} {:10s}\n".format("OutSurfaceTension",
+                                            str(self.OutSurfaceTension[0]),
+                                            str(self.OutSurfaceTension[1]),
             )
         )
         data_control_file.write("\n")

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1874,10 +1874,10 @@ class GOMCControl:
             simulation, the value will be None.
         box_0_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
             Three (3) sets vectors for box 0 each with 3 float values, which represent
-            the vectors for the Charmm-style systems (units in in nanometers (nm))
+            the vectors for the Charmm-style systems (units in Angstroms (Ang))
         box_1_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
             Three (3) sets vectors for box 1 each with 3 float values, which represent
-            the vectors for the Charmm-style systems (units in in nanometers (nm))
+            the vectors for the Charmm-style systems (units in Angstroms (Ang))
         coul_1_4 : float or int
             The non-bonded 1-4 coulombic scaling factor, which is the
             same for all the residues/molecules, regardless if

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import mbuild.box as mb_box
 import mbuild.formats.charmm_writer as mf_charmm
 
 from warnings import warn
@@ -4778,33 +4777,6 @@ class GOMCControl:
             )
             data_control_file.write(" \n")
 
-        if (
-            (self.ensemble_type in ["NPT", "NVT"])
-            and self.FreeEnergyCalc is not None
-            and self.MoleculeType is not None
-            and self.InitialState is not None
-            and self.LambdaVDW is not None
-            and self.LambdaCoulomb is not None
-        ):
-
-            # make list for number of states, LambdaVDW, and Lambda_Coul, and convert the list to string for printing
-            Lambda_states_list = []
-            Lambda_VDW_list = []
-            Lambda_Coul_list = []
-            for lamda_i in range(0, len(self.LambdaVDW)):
-                Lambda_states_list.append(str(lamda_i))
-                Lambda_VDW_list.append(str(self.LambdaVDW[lamda_i]))
-                Lambda_Coul_list.append(str(self.LambdaCoulomb[lamda_i]))
-
-            Lambda_states_str = "\t".join(Lambda_states_list)
-            Lambda_VDW_str = "\t".join(Lambda_VDW_list)
-            Lambda_Coul_str = "\t".join(Lambda_Coul_list)
-
-            data_control_file.write("####################################\n")
-            data_control_file.write(
-                "# FREE ENERGY PARAMETERS (only available in NPT and NVT ensembles) \n"
-            )
-            data_control_file.write("####################################\n")
         if (
             (self.ensemble_type in ["NPT", "NVT"])
             and self.FreeEnergyCalc is not None

--- a/mbuild/tests/test_charmm_writer.py
+++ b/mbuild/tests/test_charmm_writer.py
@@ -9,6 +9,7 @@ from mbuild import Box, Compound
 from mbuild.exceptions import MBuildError
 from mbuild.formats import charmm_writer
 from mbuild.formats.charmm_writer import Charmm
+from mbuild.lattice import load_cif
 from mbuild.tests.base_test import BaseTest
 from mbuild.utils.conversion import (
     base10_to_base16_alph_num,
@@ -16,7 +17,7 @@ from mbuild.utils.conversion import (
     base10_to_base52_alph,
     base10_to_base62_alph_num,
 )
-from mbuild.utils.io import has_foyer
+from mbuild.utils.io import has_foyer, get_fn
 from mbuild.utils.specific_ff_to_residue import specific_ff_to_residue
 
 
@@ -523,6 +524,7 @@ class TestCharmmWriterData(BaseTest):
                     pass
 
     def test_save_charmm_ua_psf(self, two_propanol_ua):
+
         charmm = Charmm(
             two_propanol_ua,
             "charmm_data_UA",
@@ -858,8 +860,6 @@ class TestCharmmWriterData(BaseTest):
                 fix_residue_in_box=None,
                 gomc_fix_bonds_angles=None,
                 reorder_res_in_pdb_psf=False,
-                box_0=[3, 3, 3],
-                box_1=[4, 4, 4],
                 bead_to_atom_name_dict={"_CH3": "C"},
             )
 
@@ -869,12 +869,19 @@ class TestCharmmWriterData(BaseTest):
         test_box_ethane_ethanol_gomc = mb.fill_box(
             compound=[ethanol_gomc, ethane_gomc],
             n_compounds=[1, 1],
-            box=[2.0, 2.0, 2.0],
+            box=[3, 3, 3],
         )
+
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[4, 4, 4]
+        )
+
         charmm = Charmm(
             test_box_ethane_ethanol_gomc,
             "residue_reorder_box_sizing_box_0",
-            structure_box_1=ethane_gomc,
+            structure_box_1=test_box_ethane_gomc,
             filename_box_1="residue_reorder_box_sizing_box_1",
             ff_filename=None,
             residues=[ethane_gomc.name, ethanol_gomc.name],
@@ -885,8 +892,6 @@ class TestCharmmWriterData(BaseTest):
             fix_residue_in_box=None,
             gomc_fix_bonds_angles=None,
             reorder_res_in_pdb_psf=True,
-            box_0=[3, 3, 3],
-            box_1=[4, 4, 4],
             bead_to_atom_name_dict={"_CH3": "C"},
         )
         charmm.write_pdb()
@@ -1145,34 +1150,6 @@ class TestCharmmWriterData(BaseTest):
         ) == len(unique_entries_base_62_list)
 
     # Tests for the mbuild.utils.specific_FF_to_residue.Specific_FF_to_residue() function
-    def test_specific_ff_to_box_value_negative(self, ethane_gomc):
-        with pytest.raises(
-            ValueError,
-            match=r"Please enter positive \( > 0\) integers for the box dimensions.",
-        ):
-            specific_ff_to_residue(
-                ethane_gomc,
-                forcefield_selection={ethane_gomc.name: "oplsaa"},
-                residues=[ethane_gomc.name],
-                reorder_res_in_pdb_psf=False,
-                box=[1, -2, 3],
-                boxes_for_simulation=1,
-            )
-
-    def test_specific_ff_to_box_value_str(self, ethane_gomc):
-        with pytest.raises(
-            TypeError,
-            match=r"Please enter positive \( > 0\) integers for the box dimensions.",
-        ):
-            specific_ff_to_residue(
-                ethane_gomc,
-                forcefield_selection={ethane_gomc.name: "oplsaa"},
-                residues=[ethane_gomc.name],
-                reorder_res_in_pdb_psf=False,
-                box=[1, "2", 3],
-                boxes_for_simulation=1,
-            )
-
     def test_specific_ff_ff_is_none(self, ethane_gomc):
         with pytest.raises(
             TypeError,
@@ -1187,7 +1164,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection=None,
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1205,7 +1181,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethane_gomc.name: "oplsaa.pdb"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1227,7 +1202,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethane_gomc.name: "oplsaa"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=2,
             )
 
@@ -1246,7 +1220,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection="oplsaa",
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1260,7 +1233,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethane_gomc.name: "oplsaa"},
                 residues=None,
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1277,35 +1249,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethane_gomc.name: "oplsaa"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=None,
-                box=None,
-                boxes_for_simulation=1,
-            )
-
-    def test_specific_ff_to_box_one_dim_is_negative(self, ethane_gomc):
-        with pytest.raises(
-            ValueError,
-            match=r"Please enter all 3 values, and only 3 values for the box dimensions.",
-        ):
-            specific_ff_to_residue(
-                ethane_gomc,
-                forcefield_selection={ethane_gomc.name: "oplsaa"},
-                residues=[ethane_gomc.name],
-                reorder_res_in_pdb_psf=False,
-                box=[-2, 3, 4, 5],
-                boxes_for_simulation=1,
-            )
-
-    def test_specific_ff_to_box_one_dim_is_string(self, ethane_gomc):
-        with pytest.raises(
-            ValueError,
-            match=r"Please enter all 3 values, and only 3 values for the box dimensions.",
-        ):
-            specific_ff_to_residue(
-                ethane_gomc,
-                forcefield_selection={ethane_gomc.name: "oplsaa"},
-                residues=[ethane_gomc.name],
-                reorder_res_in_pdb_psf=False,
-                box=["string", 3, 4, 5],
                 boxes_for_simulation=1,
             )
 
@@ -1314,12 +1257,17 @@ class TestCharmmWriterData(BaseTest):
             ValueError,
             match=r"Please enter boxes_for_simulation equal the integer 1 or 2.",
         ):
+            test_box_ethane_gomc = mb.fill_box(
+                compound=[ethane_gomc],
+                n_compounds=[1],
+                box=[2, 3, 4]
+            )
+
             specific_ff_to_residue(
-                ethane_gomc,
+                test_box_ethane_gomc,
                 forcefield_selection={ethane_gomc.name: "oplsaa"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=[2, 3, 4],
                 boxes_for_simulation=3,
             )
 
@@ -1327,15 +1275,37 @@ class TestCharmmWriterData(BaseTest):
         with pytest.raises(
             ValueError,
             match=r"Please make sure you are entering the correct foyer FF path, "
-            r"including the FF file name.xml If you are using the pre-build FF "
-            r"files in foyer, please us the forcefield_names variable.",
+                    "including the FF file name.xml "
+                    "If you are using the pre-build FF files in foyer, "
+                    "only use the string name without any extension.",
         ):
+            test_box_ethane_gomc = mb.fill_box(
+                compound=[ethane_gomc],
+                n_compounds=[1],
+                box=[4, 5, 6]
+            )
+
             specific_ff_to_residue(
                 ethane_gomc,
                 forcefield_selection={ethane_gomc.name: "oplsaa.xml"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=[4, 5, 6],
+                boxes_for_simulation=1,
+            )
+
+    def test_specific_ff_wrong_path(self, ethane_gomc):
+        with pytest.raises(
+            ValueError,
+            match=r"Please make sure you are entering the correct foyer FF path, "
+                    "including the FF file name.xml "
+                    "If you are using the pre-build FF files in foyer, "
+                    "only use the string name without any extension.",
+        ):
+            specific_ff_to_residue(
+                ethane_gomc,
+                forcefield_selection={ethane_gomc.name: "/home/oplsaa.xml"},
+                residues=[ethane_gomc.name],
+                reorder_res_in_pdb_psf=False,
                 boxes_for_simulation=1,
             )
 
@@ -1351,7 +1321,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethane_gomc.name: "oplsaa"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1368,7 +1337,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethane_gomc.name: "oplsaa"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1.1,
             )
 
@@ -1383,7 +1351,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1398,23 +1365,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethane_gomc.name: "oplsaa"},
                 residues=[],
                 reorder_res_in_pdb_psf=False,
-                box=None,
-                boxes_for_simulation=1,
-            )
-
-    def test_specific_ff_wrong_path(self, ethane_gomc):
-        with pytest.raises(
-            ValueError,
-            match=r"Please make sure you are entering the correct foyer FF path, including "
-            r"the FF file name.xml If you are using the pre-build FF files in "
-            r"foyer, please us the forcefield_names variable.",
-        ):
-            specific_ff_to_residue(
-                ethane_gomc,
-                forcefield_selection={ethane_gomc.name: "/home/oplsaa.xml"},
-                residues=[ethane_gomc.name],
-                reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1429,18 +1379,23 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethane_gomc.name: "xxx"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
     def test_specific_ff_to_residue_ffselection_run(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[4, 5, 6]
+        )
+
         [
             test_value_0,
             test_value_1,
             test_value_2,
             test_value_3,
         ] = specific_ff_to_residue(
-            ethane_gomc,
+            test_box_ethane_gomc,
             forcefield_selection={
                 ethane_gomc.name: forcefields.get_ff_path()[0]
                 + "/xml/"
@@ -1448,44 +1403,11 @@ class TestCharmmWriterData(BaseTest):
             },
             residues=[ethane_gomc.name],
             reorder_res_in_pdb_psf=False,
-            box=[4, 5, 6],
             boxes_for_simulation=1,
         )
         assert test_value_1 == {"ETH": 0.5}
         assert test_value_2 == {"ETH": 0.5}
         assert test_value_3 == ["ETH"]
-
-    def test_specific_ff_to_empty_box_with_max_mins(self, ethane_gomc):
-        with pytest.raises(
-            ValueError,
-            match=r"This writer only currently supports orthogonal boxes "
-            "\(i.e., boxes with all 90 degree angles\).",
-        ):
-            empty_compound = mb.Box(lengths=[2, 2, 2], angles=[89, 90, 90])
-
-            specific_ff_to_residue(
-                empty_compound,
-                forcefield_selection={ethane_gomc.name: "oplsaa"},
-                residues=[ethane_gomc.name],
-                reorder_res_in_pdb_psf=False,
-                box=[5, 6, 7],
-                boxes_for_simulation=2,
-            )
-
-    def test_specific_ff_to_empty_box_with_length_0(self, ethane_gomc):
-        with pytest.raises(
-            MBuildError, match=r"The vectors to define the box are co-linear"
-        ):
-            empty_compound = mb.Box(lengths=[0, 1, 1])
-
-            specific_ff_to_residue(
-                empty_compound,
-                forcefield_selection={ethane_gomc.name: "oplsaa"},
-                residues=[ethane_gomc.name],
-                reorder_res_in_pdb_psf=False,
-                box=[5, 6, 7],
-                boxes_for_simulation=2,
-            )
 
     def test_specific_ff_to_no_atoms_in_residue(self):
         with pytest.raises(
@@ -1500,7 +1422,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={"empty_compound": "oplsaa"},
                 residues=[],
                 reorder_res_in_pdb_psf=False,
-                box=[5, 6, 7],
                 boxes_for_simulation=1,
             )
 
@@ -1517,7 +1438,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={methane_ua_gomc.name: "trappe-ua"},
                 residues=[methane_ua_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1545,7 +1465,6 @@ class TestCharmmWriterData(BaseTest):
             },
             residues=[ethanol_gomc.name, ethane_gomc.name],
             reorder_res_in_pdb_psf=False,
-            box=None,
             boxes_for_simulation=1,
         )
 
@@ -1575,7 +1494,6 @@ class TestCharmmWriterData(BaseTest):
                 forcefield_selection={ethanol_gomc.name: "oplsaa"},
                 residues=[ethanol_gomc.name, ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
-                box=None,
                 boxes_for_simulation=1,
             )
 
@@ -1665,23 +1583,6 @@ class TestCharmmWriterData(BaseTest):
                 ff_filename=None,
                 residues=[ethane_gomc.name],
                 forcefield_selection={ethane_gomc.name: "oplsaa"},
-            )
-
-    def test_charmm_box_1_not_none_no_structure_box_1(self, ethane_gomc):
-        with pytest.raises(
-            TypeError,
-            match=r"ERROR: box_1 is set to a value but there is not a "
-            r"structure 1 to use it on.",
-        ):
-            Charmm(
-                ethane_gomc,
-                "box_0",
-                structure_box_1=None,
-                filename_box_1=None,
-                ff_filename=None,
-                residues=[ethane_gomc.name],
-                forcefield_selection={ethane_gomc.name: "oplsaa"},
-                box_1=[4, 4, 4],
             )
 
     def test_charmm_gomc_filename_not_string(self, ethane_gomc):
@@ -1875,7 +1776,6 @@ class TestCharmmWriterData(BaseTest):
             },
             residues=[ethanol_gomc.name, two_propanol_gomc.name],
             reorder_res_in_pdb_psf=False,
-            box=None,
             boxes_for_simulation=1,
         )
 
@@ -1936,7 +1836,6 @@ class TestCharmmWriterData(BaseTest):
             },
             residues=[ethyl_ether_gomc.name, methyl_ether_gomc.name],
             reorder_res_in_pdb_psf=False,
-            box=None,
             boxes_for_simulation=1,
         )
 
@@ -1944,10 +1843,7 @@ class TestCharmmWriterData(BaseTest):
         use_dihedrals_1 = True
         epsilon_conversion_factor = 1
         lj_unit = 1 / epsilon_conversion_factor
-        (
-            dihedral_types_1,
-            unique_dihedral_types_1,
-        ) = charmm_writer._get_dihedral_types(
+        dihedral_types_1, unique_dihedral_types_1 = charmm_writer._get_dihedral_types(
             structure_ff,
             use_rb_torsions_1,
             use_dihedrals_1,
@@ -1959,10 +1855,7 @@ class TestCharmmWriterData(BaseTest):
         use_rb_torsions_2 = True
         use_dihedrals_2 = False
 
-        (
-            dihedral_types_2,
-            unique_dihedral_types_2,
-        ) = charmm_writer._get_dihedral_types(
+        dihedral_types_2, unique_dihedral_types_2 = charmm_writer._get_dihedral_types(
             structure_ff,
             use_rb_torsions_2,
             use_dihedrals_2,
@@ -2013,10 +1906,7 @@ class TestCharmmWriterData(BaseTest):
         # ******** NOTE*************************
         # ******** NOTE*************************
         # ******** NOTE*************************
-        (
-            improper_types_1,
-            unique_improper_types_1,
-        ) = charmm_writer._get_impropers(
+        improper_types_1, unique_improper_types_1 = charmm_writer._get_impropers(
             structure_ff, epsilon_conversion_factor
         )
 
@@ -2043,7 +1933,6 @@ class TestCharmmWriterData(BaseTest):
             },
             residues=[ethyl_ether_gomc.name, methyl_ether_gomc.name],
             reorder_res_in_pdb_psf=False,
-            box=None,
             boxes_for_simulation=1,
         )
 
@@ -2256,111 +2145,6 @@ class TestCharmmWriterData(BaseTest):
                 bead_to_atom_name_dict={0: "C"},
             )
 
-    def test_box_0_4_dims(self, two_propanol_ua):
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: Please enter all 3 values and only 3 values for "
-            r"the box_0 dimensions.",
-        ):
-            Charmm(
-                two_propanol_ua,
-                "charmm_data_UA_box_0",
-                ff_filename="charmm_data_UA",
-                residues=[two_propanol_ua.name],
-                forcefield_selection="trappe-ua",
-                bead_to_atom_name_dict={"_CH3": "C"},
-                box_0=[4, 5, 6, 6],
-            )
-
-    def test_box_1_4_dims(self, two_propanol_ua):
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: Please enter all 3 values and only 3 values for "
-            r"the box_1 dimensions.",
-        ):
-            Charmm(
-                two_propanol_ua,
-                "charmm_data_UA_box_0",
-                structure_box_1=two_propanol_ua,
-                filename_box_1="charmm_data_UA_box_1",
-                ff_filename="charmm_data_UA",
-                residues=[two_propanol_ua.name],
-                forcefield_selection="trappe-ua",
-                bead_to_atom_name_dict={"_CH3": "C"},
-                box_0=[4, 5, 6],
-                box_1=[3, 4, 5, 6],
-            )
-
-    def test_box_0_negative_dims(self, two_propanol_ua):
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: Please enter float or integer values, which are all "
-            r"positive values for the box_0 dimensions.",
-        ):
-            Charmm(
-                two_propanol_ua,
-                "charmm_data_UA",
-                ff_filename="charmm_data_UA",
-                residues=[two_propanol_ua.name],
-                forcefield_selection="trappe-ua",
-                bead_to_atom_name_dict={"_CH3": "C"},
-                box_0=[-3, 4, 5],
-            )
-
-    def test_box_1_negative_dims(self, two_propanol_ua):
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: Please enter float or integer values, which are all "
-            r"positive values for the box_1 dimensions.",
-        ):
-            Charmm(
-                two_propanol_ua,
-                "charmm_data_UA_box_0",
-                structure_box_1=two_propanol_ua,
-                filename_box_1="charmm_data_UA_box_1",
-                ff_filename="charmm_data_UA",
-                residues=[two_propanol_ua.name],
-                forcefield_selection="trappe-ua",
-                bead_to_atom_name_dict={"_CH3": "C"},
-                box_0=[4, 5, 6],
-                box_1=[-3, 4, 5],
-            )
-
-    def test_box_0_string_dims(self, two_propanol_ua):
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: Please enter float or integer values, which are all "
-            r"positive values for the box_0 dimensions.",
-        ):
-            Charmm(
-                two_propanol_ua,
-                "charmm_data_UA",
-                ff_filename="charmm_data_UA",
-                residues=[two_propanol_ua.name],
-                forcefield_selection="trappe-ua",
-                bead_to_atom_name_dict={"_CH3": "C"},
-                box_0=["string", 5, 6],
-            )
-
-    def test_box_1_string_dims(self, two_propanol_ua):
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: Please enter float or integer values, which are all "
-            r"positive values for the box_1 dimensions.",
-        ):
-            Charmm(
-                two_propanol_ua,
-                "charmm_data_UA_box_0",
-                ff_filename="charmm_data_UA",
-                structure_box_1=two_propanol_ua,
-                filename_box_1="charmm_data_UA_box_1",
-                residues=[two_propanol_ua.name],
-                forcefield_selection="trappe-ua",
-                bead_to_atom_name_dict={"_CH3": "C"},
-                box_0=[4, 5, 6],
-                box_1=["string", 5, 6],
-            )
-
     def test_1_box_residues_not_all_listed_box_0(
         self, ethane_gomc, ethanol_gomc
     ):
@@ -2464,7 +2248,6 @@ class TestCharmmWriterData(BaseTest):
             residues=[two_propanol_ua.name],
             forcefield_selection="trappe-ua",
             bead_to_atom_name_dict={"_CH3": "C"},
-            box_0=[4, 5, 6],
         )
         charmm.write_pdb()
         charmm.write_psf()
@@ -2531,7 +2314,6 @@ class TestCharmmWriterData(BaseTest):
             residues=[two_propanol_ua.name],
             forcefield_selection="trappe-ua",
             bead_to_atom_name_dict={"_CH3": "C"},
-            box_0=[4, 5, 6],
         )
         charmm.write_pdb()
         charmm.write_psf()
@@ -2587,19 +2369,23 @@ class TestCharmmWriterData(BaseTest):
                     pass
 
     def test_box_1_empty_test_3(self, two_propanol_ua):
-        empty_compound = Box(lengths=[2, 2, 2])
+        empty_compound = Box(lengths=[4, 5, 6])
+
+        test_box_two_propanol_ua_gomc = mb.fill_box(
+            compound=[two_propanol_ua],
+            n_compounds=[1],
+            box=[3, 4, 5]
+        )
 
         charmm = Charmm(
             empty_compound,
             "charmm_empty_box",
-            structure_box_1=two_propanol_ua,
+            structure_box_1=test_box_two_propanol_ua_gomc,
             filename_box_1="charmm_filled_box",
             ff_filename="charmm_empty_box",
             residues=[two_propanol_ua.name],
             forcefield_selection="trappe-ua",
             bead_to_atom_name_dict={"_CH3": "C"},
-            box_0=[4, 5, 6],
-            box_1=[3, 4, 5],
         )
         charmm.write_pdb()
         charmm.write_psf()
@@ -2704,18 +2490,22 @@ class TestCharmmWriterData(BaseTest):
             r"If you are providing and empty box, please do so by specifying and "
             r"mbuild Box \({}\)".format(type(Box(lengths=[1, 1, 1]))),
         ):
+            test_box_two_propanol_ua_gomc = mb.fill_box(
+                compound=[two_propanol_ua],
+                n_compounds=[1],
+                box=[3, 4, 5]
+            )
+
             empty_compound = mb.Compound()
             Charmm(
                 empty_compound,
                 "charmm_empty_box",
-                structure_box_1=two_propanol_ua,
+                structure_box_1=test_box_two_propanol_ua_gomc,
                 filename_box_1="charmm_filled_box",
                 ff_filename="charmm_empty_box",
                 residues=[two_propanol_ua.name],
                 forcefield_selection="trappe-ua",
                 bead_to_atom_name_dict={"_CH3": "C"},
-                box_0=[4, 5, 6],
-                box_1=[3, 4, 5],
             )
 
     def test_structure_box_0_not_mb_compound(self, ethane_gomc):
@@ -2882,3 +2672,231 @@ class TestCharmmWriterData(BaseTest):
                         assert (
                             out_gomc[i + 1 + j].split()[4:5] == mass_type_2[j]
                         )
+
+    # test cif reader ETA psf writer outputs correct atom and residue numbering using non-orthoganol box
+    def test_save_non_othoganol_box_psf(self):
+        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
+        ETV_triclinic = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
+        ETV_triclinic.name = 'ETV'
+
+        charmm = Charmm(ETV_triclinic,
+                        'ETV_triclinic',
+                        ff_filename="ETV_triclinic_FF",
+                        forcefield_selection={
+                            ETV_triclinic.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
+                        residues=[ETV_triclinic.name],
+                        bead_to_atom_name_dict=None,
+                        fix_residue=[ETV_triclinic.name],
+                        )
+
+        charmm.write_psf()
+
+        with open("ETV_triclinic.psf", "r") as fp:
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if "42 !NATOM" in line:
+
+                    no_O_atoms = 28
+                    no_Si_atoms = 14
+                    atom_type_charge_etc_list = []
+                    for f_i in range(0, no_O_atoms):
+                        atom_type_charge_etc_list.append(
+                            [str(f_i + 1), "SYS", str(f_i + 1), "ETV", "O1", "A", "-0.400000", "15.9994"],
+                        )
+                    for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
+                        atom_type_charge_etc_list.append(
+                            [str(f_i + 1), "SYS", str(f_i + 1), "ETV", "Si1", "B", "0.800000", "28.0855"],
+                        )
+
+                    for j in range(0, len(atom_type_charge_etc_list)):
+                        assert (
+                            out_gomc[i + 1 + j].split()[0:8]
+                            == atom_type_charge_etc_list[j]
+                        )
+
+                else:
+                    pass
+
+    # test cif reader ETA pdb writer outputs correct atom and residue numbering using non-orthoganol box
+    def test_save_non_othoganol_box_pdb(self):
+        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
+        ETV_triclinic = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
+        ETV_triclinic.name = 'ETV'
+
+        charmm = Charmm(ETV_triclinic,
+                        'ETV_triclinic',
+                        ff_filename="ETV_triclinic_FF",
+                        forcefield_selection={
+                            ETV_triclinic.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
+                        residues=[ETV_triclinic.name],
+                        bead_to_atom_name_dict=None,
+                        fix_residue=[ETV_triclinic.name],
+                        )
+
+        charmm.write_pdb()
+
+        with open("ETV_triclinic.pdb", "r") as fp:
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+
+                if "CRYST1" in line:
+                    crystal_box_length_angles = [
+                        "CRYST1",
+                        "8.750",
+                        "9.648",
+                        "10.272",
+                        "105.72",
+                        "100.19",
+                        "97.02",
+                    ]
+
+                    no_O_atoms = 28
+                    no_Si_atoms = 14
+                    atom_type_res_part_1_list = []
+                    for f_i in range(0, no_O_atoms):
+                        atom_type_res_part_1_list.append(
+                            ["ATOM", str(f_i + 1), "O1", "ETV", "A", str(f_i + 1)]
+                        )
+                    for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
+                        atom_type_res_part_1_list.append(
+                            ["ATOM",  str(f_i + 1), "Si1", "ETV", "A",  str(f_i + 1)]
+                        )
+
+                    atom_type_res_part_2_list = []
+                    for f_i in range(0, no_O_atoms):
+                        atom_type_res_part_2_list.append(
+                            ["1.00", "1.00", "O"]
+                        )
+                    for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
+                        atom_type_res_part_2_list.append(
+                            ["1.00", "1.00", "SI"]
+                        )
+
+                    assert (
+                            out_gomc[i].split()[0:7]
+                            == crystal_box_length_angles
+                    )
+
+                    for j in range(0, len(atom_type_res_part_1_list)):
+                        assert (
+                            out_gomc[i + 1 + j].split()[0:6]
+                            == atom_type_res_part_1_list[j]
+                        )
+                        assert (
+                            out_gomc[i + 1 + j].split()[9:12]
+                            == atom_type_res_part_2_list[j]
+                        )
+
+                else:
+                    pass
+
+    # test methane UA psf writer outputs correct atom and residue numbering using orthoganol box
+    def test_save_othoganol_methane_ua_psf(self):
+        methane = mb.Compound(name="MET")
+        methane_child_bead = mb.Compound(name="_CH4")
+        methane.add(methane_child_bead, inherit_periodicity=False)
+
+        methane_box = mb.fill_box(compound=methane,
+            n_compounds=4,
+            box=[1, 1, 1]
+            )
+
+        charmm = Charmm(methane_box,
+                        'methane_box',
+                        ff_filename="methane_box_FF",
+                        forcefield_selection={
+                            methane.name: 'trappe-ua'},
+                        residues=[methane.name],
+                        bead_to_atom_name_dict={"_CH4":"C"},
+                        )
+
+        charmm.write_psf()
+
+        with open("methane_box.psf", "r") as fp:
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if "4 !NATOM" in line:
+
+                    no_methane_atoms = 4
+                    atom_type_charge_etc_list = []
+                    for f_i in range(0,  no_methane_atoms):
+                        atom_type_charge_etc_list.append(
+                            [str(f_i + 1), "SYS", str(f_i + 1), "MET", "C1", "A", "0.000000", "16.0430"],
+                        )
+
+                    for j in range(0, len(atom_type_charge_etc_list)):
+                        assert (
+                                out_gomc[i + 1 + j].split()[0:8]
+                                == atom_type_charge_etc_list[j]
+                        )
+
+                else:
+                    pass
+
+    # test methane UA pdb writer outputs correct atom and residue numbering using orthoganol box
+    def test_save_othoganol_methane_ua_pdb(self):
+        methane = mb.Compound(name="MET")
+        methane_child_bead = mb.Compound(name="_CH4")
+        methane.add(methane_child_bead, inherit_periodicity=False)
+
+        methane_box = mb.fill_box(compound=methane,
+                                  n_compounds=10,
+                                  box=[1, 2, 3]
+                                  )
+
+        charmm = Charmm(methane_box,
+                        'methane_box',
+                        ff_filename="methane_box_FF",
+                        forcefield_selection={
+                            methane.name: 'trappe-ua'},
+                        residues=[methane.name],
+                        bead_to_atom_name_dict={"_CH4":"C"},
+                        )
+
+        charmm.write_pdb()
+
+        with open("methane_box.pdb", "r") as fp:
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+
+                if "CRYST1" in line:
+                    crystal_box_length_angles = [
+                        "CRYST1",
+                        "10.000",
+                        "20.000",
+                        "30.000",
+                        "90.00",
+                        "90.00",
+                        "90.00",
+                    ]
+
+                    no_methane_atoms = 4
+                    atom_type_res_part_1_list = []
+                    for f_i in range(0, no_methane_atoms):
+                        atom_type_res_part_1_list.append(
+                            ["ATOM", str(f_i + 1), "C1", "MET", "A", str(f_i + 1)]
+                        )
+
+                    atom_type_res_part_2_list = []
+                    for f_i in range(0, no_methane_atoms):
+                        atom_type_res_part_2_list.append(
+                            ["1.00", "0.00", "EP"]
+                        )
+
+                    assert (
+                            out_gomc[i].split()[0:7]
+                            == crystal_box_length_angles
+                    )
+
+                    for j in range(0, len(atom_type_res_part_1_list)):
+                        assert (
+                                out_gomc[i + 1 + j].split()[0:6]
+                                == atom_type_res_part_1_list[j]
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split()[9:12]
+                                == atom_type_res_part_2_list[j]
+                        )
+
+                else:
+                    pass

--- a/mbuild/tests/test_charmm_writer.py
+++ b/mbuild/tests/test_charmm_writer.py
@@ -1274,9 +1274,9 @@ class TestCharmmWriterData(BaseTest):
         with pytest.raises(
             ValueError,
             match=r"Please make sure you are entering the correct foyer FF path, "
-                    "including the FF file name.xml "
-                    "If you are using the pre-build FF files in foyer, "
-                    "only use the string name without any extension.",
+            r"including the FF file name.xml "
+            r"If you are using the pre-build FF files in foyer, "
+            r"only use the string name without any extension.",
         ):
             test_box_ethane_gomc = mb.fill_box(
                 compound=[ethane_gomc],
@@ -1296,9 +1296,9 @@ class TestCharmmWriterData(BaseTest):
         with pytest.raises(
             ValueError,
             match=r"Please make sure you are entering the correct foyer FF path, "
-                    "including the FF file name.xml "
-                    "If you are using the pre-build FF files in foyer, "
-                    "only use the string name without any extension.",
+            r"including the FF file name.xml "
+            r"If you are using the pre-build FF files in foyer, "
+            r"only use the string name without any extension.",
         ):
             specific_ff_to_residue(
                 ethane_gomc,

--- a/mbuild/tests/test_charmm_writer.py
+++ b/mbuild/tests/test_charmm_writer.py
@@ -16,7 +16,7 @@ from mbuild.utils.conversion import (
     base10_to_base52_alph,
     base10_to_base62_alph_num,
 )
-from mbuild.utils.io import has_foyer, get_fn
+from mbuild.utils.io import get_fn, has_foyer
 from mbuild.utils.specific_ff_to_residue import specific_ff_to_residue
 
 
@@ -871,9 +871,7 @@ class TestCharmmWriterData(BaseTest):
         )
 
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc],
-            n_compounds=[1],
-            box=[4, 4, 4]
+            compound=[ethane_gomc], n_compounds=[1], box=[4, 4, 4]
         )
 
         charmm = Charmm(
@@ -1256,9 +1254,7 @@ class TestCharmmWriterData(BaseTest):
             match=r"Please enter boxes_for_simulation equal the integer 1 or 2.",
         ):
             test_box_ethane_gomc = mb.fill_box(
-                compound=[ethane_gomc],
-                n_compounds=[1],
-                box=[2, 3, 4]
+                compound=[ethane_gomc], n_compounds=[1], box=[2, 3, 4]
             )
 
             specific_ff_to_residue(
@@ -1278,9 +1274,7 @@ class TestCharmmWriterData(BaseTest):
             r"only use the string name without any extension.",
         ):
             test_box_ethane_gomc = mb.fill_box(
-                compound=[ethane_gomc],
-                n_compounds=[1],
-                box=[4, 5, 6]
+                compound=[ethane_gomc], n_compounds=[1], box=[4, 5, 6]
             )
 
             specific_ff_to_residue(
@@ -1382,9 +1376,7 @@ class TestCharmmWriterData(BaseTest):
 
     def test_specific_ff_to_residue_ffselection_run(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc],
-            n_compounds=[1],
-            box=[4, 5, 6]
+            compound=[ethane_gomc], n_compounds=[1], box=[4, 5, 6]
         )
 
         [
@@ -1841,7 +1833,10 @@ class TestCharmmWriterData(BaseTest):
         use_dihedrals_1 = True
         epsilon_conversion_factor = 1
         lj_unit = 1 / epsilon_conversion_factor
-        dihedral_types_1, unique_dihedral_types_1 = charmm_writer._get_dihedral_types(
+        (
+            dihedral_types_1,
+            unique_dihedral_types_1,
+        ) = charmm_writer._get_dihedral_types(
             structure_ff,
             use_rb_torsions_1,
             use_dihedrals_1,
@@ -1853,7 +1848,10 @@ class TestCharmmWriterData(BaseTest):
         use_rb_torsions_2 = True
         use_dihedrals_2 = False
 
-        dihedral_types_2, unique_dihedral_types_2 = charmm_writer._get_dihedral_types(
+        (
+            dihedral_types_2,
+            unique_dihedral_types_2,
+        ) = charmm_writer._get_dihedral_types(
             structure_ff,
             use_rb_torsions_2,
             use_dihedrals_2,
@@ -1904,7 +1902,10 @@ class TestCharmmWriterData(BaseTest):
         # ******** NOTE*************************
         # ******** NOTE*************************
         # ******** NOTE*************************
-        improper_types_1, unique_improper_types_1 = charmm_writer._get_impropers(
+        (
+            improper_types_1,
+            unique_improper_types_1,
+        ) = charmm_writer._get_impropers(
             structure_ff, epsilon_conversion_factor
         )
 
@@ -2370,9 +2371,7 @@ class TestCharmmWriterData(BaseTest):
         empty_compound = Box(lengths=[4, 5, 6])
 
         test_box_two_propanol_ua_gomc = mb.fill_box(
-            compound=[two_propanol_ua],
-            n_compounds=[1],
-            box=[3, 4, 5]
+            compound=[two_propanol_ua], n_compounds=[1], box=[3, 4, 5]
         )
 
         charmm = Charmm(
@@ -2489,9 +2488,7 @@ class TestCharmmWriterData(BaseTest):
             r"mbuild Box \({}\)".format(type(Box(lengths=[1, 1, 1]))),
         ):
             test_box_two_propanol_ua_gomc = mb.fill_box(
-                compound=[two_propanol_ua],
-                n_compounds=[1],
-                box=[3, 4, 5]
+                compound=[two_propanol_ua], n_compounds=[1], box=[3, 4, 5]
             )
 
             empty_compound = mb.Compound()
@@ -2673,19 +2670,25 @@ class TestCharmmWriterData(BaseTest):
 
     # test cif reader ETA psf writer outputs correct atom and residue numbering using non-orthoganol box
     def test_save_non_othoganol_box_psf(self):
-        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
+        lattice_cif_ETV_triclinic = load_cif(
+            file_or_path=get_fn("ETV_triclinic.cif")
+        )
         ETV_triclinic = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
-        ETV_triclinic.name = 'ETV'
+        ETV_triclinic.name = "ETV"
 
-        charmm = Charmm(ETV_triclinic,
-                        'ETV_triclinic',
-                        ff_filename="ETV_triclinic_FF",
-                        forcefield_selection={
-                            ETV_triclinic.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
-                        residues=[ETV_triclinic.name],
-                        bead_to_atom_name_dict=None,
-                        fix_residue=[ETV_triclinic.name],
-                        )
+        charmm = Charmm(
+            ETV_triclinic,
+            "ETV_triclinic",
+            ff_filename="ETV_triclinic_FF",
+            forcefield_selection={
+                ETV_triclinic.name: get_fn(
+                    "Charmm_writer_testing_only_zeolite.xml"
+                )
+            },
+            residues=[ETV_triclinic.name],
+            bead_to_atom_name_dict=None,
+            fix_residue=[ETV_triclinic.name],
+        )
 
         charmm.write_psf()
 
@@ -2699,11 +2702,29 @@ class TestCharmmWriterData(BaseTest):
                     atom_type_charge_etc_list = []
                     for f_i in range(0, no_O_atoms):
                         atom_type_charge_etc_list.append(
-                            [str(f_i + 1), "SYS", str(f_i + 1), "ETV", "O1", "A", "-0.400000", "15.9994"],
+                            [
+                                str(f_i + 1),
+                                "SYS",
+                                str(f_i + 1),
+                                "ETV",
+                                "O1",
+                                "A",
+                                "-0.400000",
+                                "15.9994",
+                            ],
                         )
                     for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
                         atom_type_charge_etc_list.append(
-                            [str(f_i + 1), "SYS", str(f_i + 1), "ETV", "Si1", "B", "0.800000", "28.0855"],
+                            [
+                                str(f_i + 1),
+                                "SYS",
+                                str(f_i + 1),
+                                "ETV",
+                                "Si1",
+                                "B",
+                                "0.800000",
+                                "28.0855",
+                            ],
                         )
 
                     for j in range(0, len(atom_type_charge_etc_list)):
@@ -2717,19 +2738,25 @@ class TestCharmmWriterData(BaseTest):
 
     # test cif reader ETA pdb writer outputs correct atom and residue numbering using non-orthoganol box
     def test_save_non_othoganol_box_pdb(self):
-        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
+        lattice_cif_ETV_triclinic = load_cif(
+            file_or_path=get_fn("ETV_triclinic.cif")
+        )
         ETV_triclinic = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
-        ETV_triclinic.name = 'ETV'
+        ETV_triclinic.name = "ETV"
 
-        charmm = Charmm(ETV_triclinic,
-                        'ETV_triclinic',
-                        ff_filename="ETV_triclinic_FF",
-                        forcefield_selection={
-                            ETV_triclinic.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
-                        residues=[ETV_triclinic.name],
-                        bead_to_atom_name_dict=None,
-                        fix_residue=[ETV_triclinic.name],
-                        )
+        charmm = Charmm(
+            ETV_triclinic,
+            "ETV_triclinic",
+            ff_filename="ETV_triclinic_FF",
+            forcefield_selection={
+                ETV_triclinic.name: get_fn(
+                    "Charmm_writer_testing_only_zeolite.xml"
+                )
+            },
+            residues=[ETV_triclinic.name],
+            bead_to_atom_name_dict=None,
+            fix_residue=[ETV_triclinic.name],
+        )
 
         charmm.write_pdb()
 
@@ -2753,27 +2780,34 @@ class TestCharmmWriterData(BaseTest):
                     atom_type_res_part_1_list = []
                     for f_i in range(0, no_O_atoms):
                         atom_type_res_part_1_list.append(
-                            ["ATOM", str(f_i + 1), "O1", "ETV", "A", str(f_i + 1)]
+                            [
+                                "ATOM",
+                                str(f_i + 1),
+                                "O1",
+                                "ETV",
+                                "A",
+                                str(f_i + 1),
+                            ]
                         )
                     for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
                         atom_type_res_part_1_list.append(
-                            ["ATOM",  str(f_i + 1), "Si1", "ETV", "A",  str(f_i + 1)]
+                            [
+                                "ATOM",
+                                str(f_i + 1),
+                                "Si1",
+                                "ETV",
+                                "A",
+                                str(f_i + 1),
+                            ]
                         )
 
                     atom_type_res_part_2_list = []
                     for f_i in range(0, no_O_atoms):
-                        atom_type_res_part_2_list.append(
-                            ["1.00", "1.00", "O"]
-                        )
+                        atom_type_res_part_2_list.append(["1.00", "1.00", "O"])
                     for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
-                        atom_type_res_part_2_list.append(
-                            ["1.00", "1.00", "SI"]
-                        )
+                        atom_type_res_part_2_list.append(["1.00", "1.00", "SI"])
 
-                    assert (
-                            out_gomc[i].split()[0:7]
-                            == crystal_box_length_angles
-                    )
+                    assert out_gomc[i].split()[0:7] == crystal_box_length_angles
 
                     for j in range(0, len(atom_type_res_part_1_list)):
                         assert (
@@ -2794,19 +2828,18 @@ class TestCharmmWriterData(BaseTest):
         methane_child_bead = mb.Compound(name="_CH4")
         methane.add(methane_child_bead, inherit_periodicity=False)
 
-        methane_box = mb.fill_box(compound=methane,
-            n_compounds=4,
-            box=[1, 1, 1]
-            )
+        methane_box = mb.fill_box(
+            compound=methane, n_compounds=4, box=[1, 1, 1]
+        )
 
-        charmm = Charmm(methane_box,
-                        'methane_box',
-                        ff_filename="methane_box_FF",
-                        forcefield_selection={
-                            methane.name: 'trappe-ua'},
-                        residues=[methane.name],
-                        bead_to_atom_name_dict={"_CH4":"C"},
-                        )
+        charmm = Charmm(
+            methane_box,
+            "methane_box",
+            ff_filename="methane_box_FF",
+            forcefield_selection={methane.name: "trappe-ua"},
+            residues=[methane.name],
+            bead_to_atom_name_dict={"_CH4": "C"},
+        )
 
         charmm.write_psf()
 
@@ -2817,15 +2850,24 @@ class TestCharmmWriterData(BaseTest):
 
                     no_methane_atoms = 4
                     atom_type_charge_etc_list = []
-                    for f_i in range(0,  no_methane_atoms):
+                    for f_i in range(0, no_methane_atoms):
                         atom_type_charge_etc_list.append(
-                            [str(f_i + 1), "SYS", str(f_i + 1), "MET", "C1", "A", "0.000000", "16.0430"],
+                            [
+                                str(f_i + 1),
+                                "SYS",
+                                str(f_i + 1),
+                                "MET",
+                                "C1",
+                                "A",
+                                "0.000000",
+                                "16.0430",
+                            ],
                         )
 
                     for j in range(0, len(atom_type_charge_etc_list)):
                         assert (
-                                out_gomc[i + 1 + j].split()[0:8]
-                                == atom_type_charge_etc_list[j]
+                            out_gomc[i + 1 + j].split()[0:8]
+                            == atom_type_charge_etc_list[j]
                         )
 
                 else:
@@ -2837,19 +2879,18 @@ class TestCharmmWriterData(BaseTest):
         methane_child_bead = mb.Compound(name="_CH4")
         methane.add(methane_child_bead, inherit_periodicity=False)
 
-        methane_box = mb.fill_box(compound=methane,
-                                  n_compounds=10,
-                                  box=[1, 2, 3]
-                                  )
+        methane_box = mb.fill_box(
+            compound=methane, n_compounds=10, box=[1, 2, 3]
+        )
 
-        charmm = Charmm(methane_box,
-                        'methane_box',
-                        ff_filename="methane_box_FF",
-                        forcefield_selection={
-                            methane.name: 'trappe-ua'},
-                        residues=[methane.name],
-                        bead_to_atom_name_dict={"_CH4":"C"},
-                        )
+        charmm = Charmm(
+            methane_box,
+            "methane_box",
+            ff_filename="methane_box_FF",
+            forcefield_selection={methane.name: "trappe-ua"},
+            residues=[methane.name],
+            bead_to_atom_name_dict={"_CH4": "C"},
+        )
 
         charmm.write_pdb()
 
@@ -2872,28 +2913,30 @@ class TestCharmmWriterData(BaseTest):
                     atom_type_res_part_1_list = []
                     for f_i in range(0, no_methane_atoms):
                         atom_type_res_part_1_list.append(
-                            ["ATOM", str(f_i + 1), "C1", "MET", "A", str(f_i + 1)]
+                            [
+                                "ATOM",
+                                str(f_i + 1),
+                                "C1",
+                                "MET",
+                                "A",
+                                str(f_i + 1),
+                            ]
                         )
 
                     atom_type_res_part_2_list = []
                     for f_i in range(0, no_methane_atoms):
-                        atom_type_res_part_2_list.append(
-                            ["1.00", "0.00", "EP"]
-                        )
+                        atom_type_res_part_2_list.append(["1.00", "0.00", "EP"])
 
-                    assert (
-                            out_gomc[i].split()[0:7]
-                            == crystal_box_length_angles
-                    )
+                    assert out_gomc[i].split()[0:7] == crystal_box_length_angles
 
                     for j in range(0, len(atom_type_res_part_1_list)):
                         assert (
-                                out_gomc[i + 1 + j].split()[0:6]
-                                == atom_type_res_part_1_list[j]
+                            out_gomc[i + 1 + j].split()[0:6]
+                            == atom_type_res_part_1_list[j]
                         )
                         assert (
-                                out_gomc[i + 1 + j].split()[9:12]
-                                == atom_type_res_part_2_list[j]
+                            out_gomc[i + 1 + j].split()[9:12]
+                            == atom_type_res_part_2_list[j]
                         )
 
                 else:

--- a/mbuild/tests/test_charmm_writer.py
+++ b/mbuild/tests/test_charmm_writer.py
@@ -16,7 +16,7 @@ from mbuild.utils.conversion import (
     base10_to_base52_alph,
     base10_to_base62_alph_num,
 )
-from mbuild.utils.io import get_fn, has_foyer
+from mbuild.utils.io import has_foyer, get_fn
 from mbuild.utils.specific_ff_to_residue import specific_ff_to_residue
 
 
@@ -871,7 +871,9 @@ class TestCharmmWriterData(BaseTest):
         )
 
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc], n_compounds=[1], box=[4, 4, 4]
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[4, 4, 4]
         )
 
         charmm = Charmm(
@@ -1254,7 +1256,9 @@ class TestCharmmWriterData(BaseTest):
             match=r"Please enter boxes_for_simulation equal the integer 1 or 2.",
         ):
             test_box_ethane_gomc = mb.fill_box(
-                compound=[ethane_gomc], n_compounds=[1], box=[2, 3, 4]
+                compound=[ethane_gomc],
+                n_compounds=[1],
+                box=[2, 3, 4]
             )
 
             specific_ff_to_residue(
@@ -1274,7 +1278,9 @@ class TestCharmmWriterData(BaseTest):
             r"only use the string name without any extension.",
         ):
             test_box_ethane_gomc = mb.fill_box(
-                compound=[ethane_gomc], n_compounds=[1], box=[4, 5, 6]
+                compound=[ethane_gomc],
+                n_compounds=[1],
+                box=[4, 5, 6]
             )
 
             specific_ff_to_residue(
@@ -1376,7 +1382,9 @@ class TestCharmmWriterData(BaseTest):
 
     def test_specific_ff_to_residue_ffselection_run(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc], n_compounds=[1], box=[4, 5, 6]
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[4, 5, 6]
         )
 
         [
@@ -1833,10 +1841,7 @@ class TestCharmmWriterData(BaseTest):
         use_dihedrals_1 = True
         epsilon_conversion_factor = 1
         lj_unit = 1 / epsilon_conversion_factor
-        (
-            dihedral_types_1,
-            unique_dihedral_types_1,
-        ) = charmm_writer._get_dihedral_types(
+        dihedral_types_1, unique_dihedral_types_1 = charmm_writer._get_dihedral_types(
             structure_ff,
             use_rb_torsions_1,
             use_dihedrals_1,
@@ -1848,10 +1853,7 @@ class TestCharmmWriterData(BaseTest):
         use_rb_torsions_2 = True
         use_dihedrals_2 = False
 
-        (
-            dihedral_types_2,
-            unique_dihedral_types_2,
-        ) = charmm_writer._get_dihedral_types(
+        dihedral_types_2, unique_dihedral_types_2 = charmm_writer._get_dihedral_types(
             structure_ff,
             use_rb_torsions_2,
             use_dihedrals_2,
@@ -1902,10 +1904,7 @@ class TestCharmmWriterData(BaseTest):
         # ******** NOTE*************************
         # ******** NOTE*************************
         # ******** NOTE*************************
-        (
-            improper_types_1,
-            unique_improper_types_1,
-        ) = charmm_writer._get_impropers(
+        improper_types_1, unique_improper_types_1 = charmm_writer._get_impropers(
             structure_ff, epsilon_conversion_factor
         )
 
@@ -2371,7 +2370,9 @@ class TestCharmmWriterData(BaseTest):
         empty_compound = Box(lengths=[4, 5, 6])
 
         test_box_two_propanol_ua_gomc = mb.fill_box(
-            compound=[two_propanol_ua], n_compounds=[1], box=[3, 4, 5]
+            compound=[two_propanol_ua],
+            n_compounds=[1],
+            box=[3, 4, 5]
         )
 
         charmm = Charmm(
@@ -2488,7 +2489,9 @@ class TestCharmmWriterData(BaseTest):
             r"mbuild Box \({}\)".format(type(Box(lengths=[1, 1, 1]))),
         ):
             test_box_two_propanol_ua_gomc = mb.fill_box(
-                compound=[two_propanol_ua], n_compounds=[1], box=[3, 4, 5]
+                compound=[two_propanol_ua],
+                n_compounds=[1],
+                box=[3, 4, 5]
             )
 
             empty_compound = mb.Compound()
@@ -2670,25 +2673,19 @@ class TestCharmmWriterData(BaseTest):
 
     # test cif reader ETA psf writer outputs correct atom and residue numbering using non-orthoganol box
     def test_save_non_othoganol_box_psf(self):
-        lattice_cif_ETV_triclinic = load_cif(
-            file_or_path=get_fn("ETV_triclinic.cif")
-        )
+        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
         ETV_triclinic = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
-        ETV_triclinic.name = "ETV"
+        ETV_triclinic.name = 'ETV'
 
-        charmm = Charmm(
-            ETV_triclinic,
-            "ETV_triclinic",
-            ff_filename="ETV_triclinic_FF",
-            forcefield_selection={
-                ETV_triclinic.name: get_fn(
-                    "Charmm_writer_testing_only_zeolite.xml"
-                )
-            },
-            residues=[ETV_triclinic.name],
-            bead_to_atom_name_dict=None,
-            fix_residue=[ETV_triclinic.name],
-        )
+        charmm = Charmm(ETV_triclinic,
+                        'ETV_triclinic',
+                        ff_filename="ETV_triclinic_FF",
+                        forcefield_selection={
+                            ETV_triclinic.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
+                        residues=[ETV_triclinic.name],
+                        bead_to_atom_name_dict=None,
+                        fix_residue=[ETV_triclinic.name],
+                        )
 
         charmm.write_psf()
 
@@ -2702,29 +2699,11 @@ class TestCharmmWriterData(BaseTest):
                     atom_type_charge_etc_list = []
                     for f_i in range(0, no_O_atoms):
                         atom_type_charge_etc_list.append(
-                            [
-                                str(f_i + 1),
-                                "SYS",
-                                str(f_i + 1),
-                                "ETV",
-                                "O1",
-                                "A",
-                                "-0.400000",
-                                "15.9994",
-                            ],
+                            [str(f_i + 1), "SYS", str(f_i + 1), "ETV", "O1", "A", "-0.400000", "15.9994"],
                         )
                     for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
                         atom_type_charge_etc_list.append(
-                            [
-                                str(f_i + 1),
-                                "SYS",
-                                str(f_i + 1),
-                                "ETV",
-                                "Si1",
-                                "B",
-                                "0.800000",
-                                "28.0855",
-                            ],
+                            [str(f_i + 1), "SYS", str(f_i + 1), "ETV", "Si1", "B", "0.800000", "28.0855"],
                         )
 
                     for j in range(0, len(atom_type_charge_etc_list)):
@@ -2738,25 +2717,19 @@ class TestCharmmWriterData(BaseTest):
 
     # test cif reader ETA pdb writer outputs correct atom and residue numbering using non-orthoganol box
     def test_save_non_othoganol_box_pdb(self):
-        lattice_cif_ETV_triclinic = load_cif(
-            file_or_path=get_fn("ETV_triclinic.cif")
-        )
+        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
         ETV_triclinic = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
-        ETV_triclinic.name = "ETV"
+        ETV_triclinic.name = 'ETV'
 
-        charmm = Charmm(
-            ETV_triclinic,
-            "ETV_triclinic",
-            ff_filename="ETV_triclinic_FF",
-            forcefield_selection={
-                ETV_triclinic.name: get_fn(
-                    "Charmm_writer_testing_only_zeolite.xml"
-                )
-            },
-            residues=[ETV_triclinic.name],
-            bead_to_atom_name_dict=None,
-            fix_residue=[ETV_triclinic.name],
-        )
+        charmm = Charmm(ETV_triclinic,
+                        'ETV_triclinic',
+                        ff_filename="ETV_triclinic_FF",
+                        forcefield_selection={
+                            ETV_triclinic.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
+                        residues=[ETV_triclinic.name],
+                        bead_to_atom_name_dict=None,
+                        fix_residue=[ETV_triclinic.name],
+                        )
 
         charmm.write_pdb()
 
@@ -2780,34 +2753,27 @@ class TestCharmmWriterData(BaseTest):
                     atom_type_res_part_1_list = []
                     for f_i in range(0, no_O_atoms):
                         atom_type_res_part_1_list.append(
-                            [
-                                "ATOM",
-                                str(f_i + 1),
-                                "O1",
-                                "ETV",
-                                "A",
-                                str(f_i + 1),
-                            ]
+                            ["ATOM", str(f_i + 1), "O1", "ETV", "A", str(f_i + 1)]
                         )
                     for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
                         atom_type_res_part_1_list.append(
-                            [
-                                "ATOM",
-                                str(f_i + 1),
-                                "Si1",
-                                "ETV",
-                                "A",
-                                str(f_i + 1),
-                            ]
+                            ["ATOM",  str(f_i + 1), "Si1", "ETV", "A",  str(f_i + 1)]
                         )
 
                     atom_type_res_part_2_list = []
                     for f_i in range(0, no_O_atoms):
-                        atom_type_res_part_2_list.append(["1.00", "1.00", "O"])
+                        atom_type_res_part_2_list.append(
+                            ["1.00", "1.00", "O"]
+                        )
                     for f_i in range(no_O_atoms, no_O_atoms + no_Si_atoms):
-                        atom_type_res_part_2_list.append(["1.00", "1.00", "SI"])
+                        atom_type_res_part_2_list.append(
+                            ["1.00", "1.00", "SI"]
+                        )
 
-                    assert out_gomc[i].split()[0:7] == crystal_box_length_angles
+                    assert (
+                            out_gomc[i].split()[0:7]
+                            == crystal_box_length_angles
+                    )
 
                     for j in range(0, len(atom_type_res_part_1_list)):
                         assert (
@@ -2828,18 +2794,19 @@ class TestCharmmWriterData(BaseTest):
         methane_child_bead = mb.Compound(name="_CH4")
         methane.add(methane_child_bead, inherit_periodicity=False)
 
-        methane_box = mb.fill_box(
-            compound=methane, n_compounds=4, box=[1, 1, 1]
-        )
+        methane_box = mb.fill_box(compound=methane,
+            n_compounds=4,
+            box=[1, 1, 1]
+            )
 
-        charmm = Charmm(
-            methane_box,
-            "methane_box",
-            ff_filename="methane_box_FF",
-            forcefield_selection={methane.name: "trappe-ua"},
-            residues=[methane.name],
-            bead_to_atom_name_dict={"_CH4": "C"},
-        )
+        charmm = Charmm(methane_box,
+                        'methane_box',
+                        ff_filename="methane_box_FF",
+                        forcefield_selection={
+                            methane.name: 'trappe-ua'},
+                        residues=[methane.name],
+                        bead_to_atom_name_dict={"_CH4":"C"},
+                        )
 
         charmm.write_psf()
 
@@ -2850,24 +2817,15 @@ class TestCharmmWriterData(BaseTest):
 
                     no_methane_atoms = 4
                     atom_type_charge_etc_list = []
-                    for f_i in range(0, no_methane_atoms):
+                    for f_i in range(0,  no_methane_atoms):
                         atom_type_charge_etc_list.append(
-                            [
-                                str(f_i + 1),
-                                "SYS",
-                                str(f_i + 1),
-                                "MET",
-                                "C1",
-                                "A",
-                                "0.000000",
-                                "16.0430",
-                            ],
+                            [str(f_i + 1), "SYS", str(f_i + 1), "MET", "C1", "A", "0.000000", "16.0430"],
                         )
 
                     for j in range(0, len(atom_type_charge_etc_list)):
                         assert (
-                            out_gomc[i + 1 + j].split()[0:8]
-                            == atom_type_charge_etc_list[j]
+                                out_gomc[i + 1 + j].split()[0:8]
+                                == atom_type_charge_etc_list[j]
                         )
 
                 else:
@@ -2879,18 +2837,19 @@ class TestCharmmWriterData(BaseTest):
         methane_child_bead = mb.Compound(name="_CH4")
         methane.add(methane_child_bead, inherit_periodicity=False)
 
-        methane_box = mb.fill_box(
-            compound=methane, n_compounds=10, box=[1, 2, 3]
-        )
+        methane_box = mb.fill_box(compound=methane,
+                                  n_compounds=10,
+                                  box=[1, 2, 3]
+                                  )
 
-        charmm = Charmm(
-            methane_box,
-            "methane_box",
-            ff_filename="methane_box_FF",
-            forcefield_selection={methane.name: "trappe-ua"},
-            residues=[methane.name],
-            bead_to_atom_name_dict={"_CH4": "C"},
-        )
+        charmm = Charmm(methane_box,
+                        'methane_box',
+                        ff_filename="methane_box_FF",
+                        forcefield_selection={
+                            methane.name: 'trappe-ua'},
+                        residues=[methane.name],
+                        bead_to_atom_name_dict={"_CH4":"C"},
+                        )
 
         charmm.write_pdb()
 
@@ -2913,30 +2872,28 @@ class TestCharmmWriterData(BaseTest):
                     atom_type_res_part_1_list = []
                     for f_i in range(0, no_methane_atoms):
                         atom_type_res_part_1_list.append(
-                            [
-                                "ATOM",
-                                str(f_i + 1),
-                                "C1",
-                                "MET",
-                                "A",
-                                str(f_i + 1),
-                            ]
+                            ["ATOM", str(f_i + 1), "C1", "MET", "A", str(f_i + 1)]
                         )
 
                     atom_type_res_part_2_list = []
                     for f_i in range(0, no_methane_atoms):
-                        atom_type_res_part_2_list.append(["1.00", "0.00", "EP"])
+                        atom_type_res_part_2_list.append(
+                            ["1.00", "0.00", "EP"]
+                        )
 
-                    assert out_gomc[i].split()[0:7] == crystal_box_length_angles
+                    assert (
+                            out_gomc[i].split()[0:7]
+                            == crystal_box_length_angles
+                    )
 
                     for j in range(0, len(atom_type_res_part_1_list)):
                         assert (
-                            out_gomc[i + 1 + j].split()[0:6]
-                            == atom_type_res_part_1_list[j]
+                                out_gomc[i + 1 + j].split()[0:6]
+                                == atom_type_res_part_1_list[j]
                         )
                         assert (
-                            out_gomc[i + 1 + j].split()[9:12]
-                            == atom_type_res_part_2_list[j]
+                                out_gomc[i + 1 + j].split()[9:12]
+                                == atom_type_res_part_2_list[j]
                         )
 
                 else:

--- a/mbuild/tests/test_charmm_writer.py
+++ b/mbuild/tests/test_charmm_writer.py
@@ -524,7 +524,6 @@ class TestCharmmWriterData(BaseTest):
                     pass
 
     def test_save_charmm_ua_psf(self, two_propanol_ua):
-
         charmm = Charmm(
             two_propanol_ua,
             "charmm_data_UA",
@@ -1303,7 +1302,7 @@ class TestCharmmWriterData(BaseTest):
         ):
             specific_ff_to_residue(
                 ethane_gomc,
-                forcefield_selection={ethane_gomc.name: "/home/oplsaa.xml"},
+                forcefield_selection={ethane_gomc.name: "oplsaa.xml"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,
                 boxes_for_simulation=1,

--- a/mbuild/tests/test_charmm_writer.py
+++ b/mbuild/tests/test_charmm_writer.py
@@ -6,7 +6,6 @@ from foyer.forcefields import forcefields
 
 import mbuild as mb
 from mbuild import Box, Compound
-from mbuild.exceptions import MBuildError
 from mbuild.formats import charmm_writer
 from mbuild.formats.charmm_writer import Charmm
 from mbuild.lattice import load_cif
@@ -1285,7 +1284,7 @@ class TestCharmmWriterData(BaseTest):
             )
 
             specific_ff_to_residue(
-                ethane_gomc,
+                test_box_ethane_gomc,
                 forcefield_selection={ethane_gomc.name: "oplsaa.xml"},
                 residues=[ethane_gomc.name],
                 reorder_res_in_pdb_psf=False,

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -5,14 +5,12 @@ import mbuild.formats.gomc_conf_writer as gomc_control
 from mbuild.formats.charmm_writer import Charmm
 from mbuild.lattice import load_cif
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import get_fn, has_foyer
+from mbuild.utils.io import has_foyer, get_fn
 
 
 @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
 class TestGOMCControlFileWriter(BaseTest):
-    def test_dict_keys_to_list(
-        self,
-    ):
+    def test_dict_keys_to_list(self,):
         dict = {"a": "1", "b": "2", "c": "3"}
         keys = gomc_control.dict_keys_to_list(dict)
 
@@ -349,7 +347,9 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_NVT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[1, 1, 1]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -639,7 +639,9 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_NPT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[2, 2, 2]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -804,7 +806,9 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_GCMC(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[2, 2, 2]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -1021,7 +1025,9 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_GEMC_NVT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[2, 2, 2]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -1100,7 +1106,9 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_GEMC_NPT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[2, 2, 2]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -1637,12 +1645,12 @@ class TestGOMCControlFileWriter(BaseTest):
                     "InitialState": 3,
                     "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
                     "LambdaCoulomb": [0.1, 0.3, 0.8, 0.9],
-                },
+                }
             )
 
         with pytest.raises(
-            ValueError,
-            match=r"ERROR: The last value in the LambdaVDW variable list must be a 1.0",
+                ValueError,
+                match=r"ERROR: The last value in the LambdaVDW variable list must be a 1.0",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -1655,7 +1663,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 3,
                     "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                },
+                }
             )
 
     def test_save_NVT_bad_variables_part_1(self, ethane_gomc, ethanol_gomc):
@@ -7568,7 +7576,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]],
-                        [1, "ETH", ["C1", "C2"], "ETO", ["C1", "O1"]],
+                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "O1"]]
                     ],
                     "ChEmPot": {"ETH": -4000, "ETO": -8000},
                     "DisFreQ": 0.05,
@@ -7705,85 +7713,75 @@ class TestGOMCControlFileWriter(BaseTest):
             )
 
     def test_save_non_othoganol_writer(self):
-        lattice_cif_ETV_triclinic = load_cif(
-            file_or_path=get_fn("ETV_triclinic.cif")
-        )
+        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
         ETV_triclinic_1_cell = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
-        ETV_triclinic_1_cell.name = "ETV_1"
+        ETV_triclinic_1_cell.name = 'ETV_1'
         ETV_triclinic_3_cell = lattice_cif_ETV_triclinic.populate(x=3, y=3, z=3)
-        ETV_triclinic_3_cell.name = "ETV_3"
+        ETV_triclinic_3_cell.name = 'ETV_3'
 
-        charmm = Charmm(
-            ETV_triclinic_1_cell,
-            "ETV_triclinic_1_cell_box_0",
-            structure_box_1=ETV_triclinic_3_cell,
-            filename_box_1="ETV_triclinic_3_cell_box_1",
-            ff_filename="ETV_triclinic_FF",
-            forcefield_selection={
-                ETV_triclinic_1_cell.name: get_fn(
-                    "Charmm_writer_testing_only_zeolite.xml"
-                ),
-                ETV_triclinic_3_cell.name: get_fn(
-                    "Charmm_writer_testing_only_zeolite.xml"
-                ),
-            },
-            residues=[ETV_triclinic_1_cell.name, ETV_triclinic_3_cell.name],
-            bead_to_atom_name_dict=None,
-            fix_residue=[ETV_triclinic_1_cell.name, ETV_triclinic_3_cell.name],
-        )
+        charmm = Charmm(ETV_triclinic_1_cell,
+                        'ETV_triclinic_1_cell_box_0',
+                        structure_box_1=ETV_triclinic_3_cell,
+                        filename_box_1="ETV_triclinic_3_cell_box_1",
+                        ff_filename="ETV_triclinic_FF",
+                        forcefield_selection={
+                            ETV_triclinic_1_cell.name: get_fn("Charmm_writer_testing_only_zeolite.xml"),
+                            ETV_triclinic_3_cell.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
+                        residues=[ETV_triclinic_1_cell.name,
+                                  ETV_triclinic_3_cell.name],
+                        bead_to_atom_name_dict=None,
+                        fix_residue=[ETV_triclinic_1_cell.name,
+                                     ETV_triclinic_3_cell.name],
+                        )
 
-        gomc_control.write_gomc_control_file(
-            charmm,
-            "test_save_non_othoganol_writer.conf",
-            "GEMC_NVT",
-            100000,
-            300,
-        )
+        gomc_control.write_gomc_control_file(charmm, 'test_save_non_othoganol_writer.conf',
+                                             'GEMC_NVT', 100000, 300,
+                                             )
 
-        with open("test_save_non_othoganol_writer.conf", "r") as fp:
+        with open('test_save_non_othoganol_writer.conf', 'r') as fp:
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
-                if line.startswith("CellBasisVector1 0"):
+                if line.startswith('CellBasisVector1 0'):
                     split_line = line.split()
-                    assert split_line[1] == "0"
-                    assert split_line[2] == "8.7503"
-                    assert split_line[3] == "0.0"
-                    assert split_line[4] == "0.0"
+                    assert split_line[1] == '0'
+                    assert split_line[2] == '8.7503'
+                    assert split_line[3] == '0.0'
+                    assert split_line[4] == '0.0'
 
-                elif line.startswith("CellBasisVector2 0"):
+                elif line.startswith('CellBasisVector2 0'):
                     split_line = line.split()
-                    assert split_line[1] == "0"
-                    assert split_line[2] == "-1.179131"
-                    assert split_line[3] == "9.575585"
-                    assert split_line[4] == "0.0"
+                    assert split_line[1] == '0'
+                    assert split_line[2] == '-1.179131'
+                    assert split_line[3] == '9.575585'
+                    assert split_line[4] == '0.0'
 
-                elif line.startswith("CellBasisVector3 0"):
+                elif line.startswith('CellBasisVector3 0'):
                     split_line = line.split()
-                    assert split_line[1] == "0"
-                    assert split_line[2] == "-1.817231"
-                    assert split_line[3] == "-3.027821"
-                    assert split_line[4] == "9.645823"
+                    assert split_line[1] == '0'
+                    assert split_line[2] == '-1.817231'
+                    assert split_line[3] == '-3.027821'
+                    assert split_line[4] == '9.645823'
 
-                if line.startswith("CellBasisVector1 1"):
+                if line.startswith('CellBasisVector1 1'):
                     split_line = line.split()
-                    assert split_line[1] == "1"
-                    assert split_line[2] == "26.2509"
-                    assert split_line[3] == "0.0"
-                    assert split_line[4] == "0.0"
+                    assert split_line[1] == '1'
+                    assert split_line[2] == '26.2509'
+                    assert split_line[3] == '0.0'
+                    assert split_line[4] == '0.0'
 
-                elif line.startswith("CellBasisVector2 1"):
+                elif line.startswith('CellBasisVector2 1'):
                     split_line = line.split()
-                    assert split_line[1] == "1"
-                    assert split_line[2] == "-3.537381"
-                    assert split_line[3] == "28.726735"
-                    assert split_line[4] == "0.0"
+                    assert split_line[1] == '1'
+                    assert split_line[2] == '-3.537381'
+                    assert split_line[3] == '28.726735'
+                    assert split_line[4] == '0.0'
 
-                elif line.startswith("CellBasisVector3 1"):
+                elif line.startswith('CellBasisVector3 1'):
                     split_line = line.split()
-                    assert split_line[1] == "1"
-                    assert split_line[2] == "-5.451699"
-                    assert split_line[3] == "-9.083469"
-                    assert split_line[4] == "28.937455"
+                    assert split_line[1] == '1'
+                    assert split_line[2] == '-5.451699'
+                    assert split_line[3] == '-9.083469'
+                    assert split_line[4] == '28.937455'
 
                 else:
                     pass
@@ -7794,16 +7792,17 @@ class TestGOMCControlFileWriter(BaseTest):
         methane_child_bead = mb.Compound(name="_CH4")
         methane.add(methane_child_bead, inherit_periodicity=False)
 
-        methane_box_orth = mb.fill_box(
-            compound=methane, n_compounds=10, box=[1, 2, 3]
-        )
+        methane_box_orth = mb.fill_box(compound=methane,
+                                       n_compounds=10,
+                                       box=[1, 2, 3]
+                                       )
 
         charmm_bad_box_0 = Charmm(
             methane_box_orth,
             "methane_box_0_orth",
             ff_filename="methane_box_orth_bad_box_0_non_orth",
             residues=[methane.name],
-            forcefield_selection="trappe-ua",
+            forcefield_selection="trappe-ua"
         )
 
         # set the vectors all too long
@@ -7824,7 +7823,7 @@ class TestGOMCControlFileWriter(BaseTest):
             filename_box_1="methane_box_1_orth",
             ff_filename="methane_box_orth_bad_box_1_non_orth",
             residues=[methane.name],
-            forcefield_selection="trappe-ua",
+            forcefield_selection="trappe-ua"
         )
 
         # set the vectors all too long
@@ -7842,8 +7841,8 @@ class TestGOMCControlFileWriter(BaseTest):
         with pytest.raises(
             ValueError,
             match=r"ERROR: At lease one of the individual box {} vectors are too large "
-            "or greater than {} characters."
-            "".format(0, 16),
+                  "or greater than {} characters."
+                  "".format(0, 16)
         ):
 
             gomc_control.write_gomc_control_file(
@@ -7857,9 +7856,9 @@ class TestGOMCControlFileWriter(BaseTest):
         # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
         with pytest.raises(
             ValueError,
-            match=r"ERROR: At lease one of the individual box {} vectors are too large "
-            "or greater than {} characters."
-            "".format(1, 16),
+                match=r"ERROR: At lease one of the individual box {} vectors are too large "
+                      "or greater than {} characters."
+                      "".format(1, 16)
         ):
 
             gomc_control.write_gomc_control_file(

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -7785,3 +7785,86 @@ class TestGOMCControlFileWriter(BaseTest):
 
                 else:
                     pass
+
+    def test_box_vector_too_many_char(self):
+
+        methane = mb.Compound(name="MET")
+        methane_child_bead = mb.Compound(name="_CH4")
+        methane.add(methane_child_bead, inherit_periodicity=False)
+
+        methane_box_orth = mb.fill_box(compound=methane,
+                                       n_compounds=10,
+                                       box=[1, 2, 3]
+                                       )
+
+        charmm_bad_box_0 = Charmm(
+            methane_box_orth,
+            "methane_box_0_orth",
+            ff_filename="methane_box_orth_bad_box_0_non_orth",
+            residues=[methane.name],
+            forcefield_selection="trappe-ua"
+        )
+
+        # set the vectors all too long
+        charmm_bad_box_0.box_0_vectors[0][0] = -0.45678901234561
+        charmm_bad_box_0.box_0_vectors[0][1] = -0.45678901234562
+        charmm_bad_box_0.box_0_vectors[0][2] = -0.45678901234563
+        charmm_bad_box_0.box_0_vectors[1][0] = -0.45678901234564
+        charmm_bad_box_0.box_0_vectors[1][1] = -0.45678901234565
+        charmm_bad_box_0.box_0_vectors[1][2] = -0.45678901234566
+        charmm_bad_box_0.box_0_vectors[2][0] = -0.45678901234567
+        charmm_bad_box_0.box_0_vectors[2][1] = -0.45678901234568
+        charmm_bad_box_0.box_0_vectors[2][2] = -0.45678901234569
+
+        charmm_bad_box_1 = Charmm(
+            methane_box_orth,
+            "methane_box_0_orth",
+            structure_box_1=methane_box_orth,
+            filename_box_1="methane_box_1_orth",
+            ff_filename="methane_box_orth_bad_box_1_non_orth",
+            residues=[methane.name],
+            forcefield_selection="trappe-ua"
+        )
+
+        # set the vectors all too long
+        charmm_bad_box_1.box_1_vectors[0][0] = -0.45678901234561
+        charmm_bad_box_1.box_1_vectors[0][1] = -0.45678901234562
+        charmm_bad_box_1.box_1_vectors[0][2] = -0.45678901234563
+        charmm_bad_box_1.box_1_vectors[1][0] = -0.45678901234564
+        charmm_bad_box_1.box_1_vectors[1][1] = -0.45678901234565
+        charmm_bad_box_1.box_1_vectors[1][2] = -0.45678901234566
+        charmm_bad_box_1.box_1_vectors[2][0] = -0.45678901234567
+        charmm_bad_box_1.box_1_vectors[2][1] = -0.45678901234568
+        charmm_bad_box_1.box_1_vectors[2][2] = -0.45678901234569
+
+        # test that it fails with the GEMC_NVT with only 1 box in the Charmm object
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: At lease one of the individual box {} vectors are too large "
+                  "or greater than {} characters."
+                  "".format(0, 16)
+        ):
+
+            gomc_control.write_gomc_control_file(
+                charmm_bad_box_0,
+                "test_box_vector_too_many_char_box_0",
+                "NVT",
+                100,
+                300,
+            )
+
+        # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
+        with pytest.raises(
+            ValueError,
+                match=r"ERROR: At lease one of the individual box {} vectors are too large "
+                      "or greater than {} characters."
+                      "".format(1, 16)
+        ):
+
+            gomc_control.write_gomc_control_file(
+                charmm_bad_box_1,
+                "test_box_vector_too_many_char_box_1",
+                "GCMC",
+                100,
+                300,
+            )

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -7751,16 +7751,16 @@ class TestGOMCControlFileWriter(BaseTest):
                 elif line.startswith('CellBasisVector2 0'):
                     split_line = line.split()
                     assert split_line[1] == '0'
-                    assert split_line[2] == '-1.179126'
-                    assert split_line[3] == '9.575575'
+                    assert split_line[2] == '-1.179131'
+                    assert split_line[3] == '9.575585'
                     assert split_line[4] == '0.0'
 
                 elif line.startswith('CellBasisVector3 0'):
                     split_line = line.split()
                     assert split_line[1] == '0'
-                    assert split_line[2] == '-1.817232'
-                    assert split_line[3] == '-3.027825'
-                    assert split_line[4] == '9.645822'
+                    assert split_line[2] == '-1.817231'
+                    assert split_line[3] == '-3.027821'
+                    assert split_line[4] == '9.645823'
 
                 if line.startswith('CellBasisVector1 1'):
                     split_line = line.split()
@@ -7772,100 +7772,16 @@ class TestGOMCControlFileWriter(BaseTest):
                 elif line.startswith('CellBasisVector2 1'):
                     split_line = line.split()
                     assert split_line[1] == '1'
-                    assert split_line[2] == '-3.537377'
-                    assert split_line[3] == '28.726725'
+                    assert split_line[2] == '-3.537381'
+                    assert split_line[3] == '28.726735'
                     assert split_line[4] == '0.0'
 
                 elif line.startswith('CellBasisVector3 1'):
                     split_line = line.split()
                     assert split_line[1] == '1'
-                    assert split_line[2] == '-5.451697'
-                    assert split_line[3] == '-9.083474'
-                    assert split_line[4] == '28.937465'
+                    assert split_line[2] == '-5.451699'
+                    assert split_line[3] == '-9.083469'
+                    assert split_line[4] == '28.937455'
 
                 else:
                     pass
-
-    def test_box_vector_too_many_char(self):
-
-        methane = mb.Compound(name="MET")
-        methane_child_bead = mb.Compound(name="_CH4")
-        methane.add(methane_child_bead, inherit_periodicity=False)
-
-        methane_box_orth = mb.fill_box(compound=methane,
-                                       n_compounds=10,
-                                       box=[1, 2, 3]
-                                       )
-
-        charmm_bad_box_0 = Charmm(
-            methane_box_orth,
-            "methane_box_0_orth",
-            ff_filename="methane_box_orth_bad_box_0_non_orth",
-            residues=[methane.name],
-            forcefield_selection="trappe-ua"
-        )
-
-        # set the vectors all too long
-        charmm_bad_box_0.box_0_vectors[0][0] = -0.45678901234561
-        charmm_bad_box_0.box_0_vectors[0][1] = -0.45678901234562
-        charmm_bad_box_0.box_0_vectors[0][2] = -0.45678901234563
-        charmm_bad_box_0.box_0_vectors[1][0] = -0.45678901234564
-        charmm_bad_box_0.box_0_vectors[1][1] = -0.45678901234565
-        charmm_bad_box_0.box_0_vectors[1][2] = -0.45678901234566
-        charmm_bad_box_0.box_0_vectors[2][0] = -0.45678901234567
-        charmm_bad_box_0.box_0_vectors[2][1] = -0.45678901234568
-        charmm_bad_box_0.box_0_vectors[2][2] = -0.45678901234569
-
-        charmm_bad_box_1 = Charmm(
-            methane_box_orth,
-            "methane_box_0_orth",
-            structure_box_1=methane_box_orth,
-            filename_box_1="methane_box_1_orth",
-            ff_filename="methane_box_orth_bad_box_1_non_orth",
-            residues=[methane.name],
-            forcefield_selection="trappe-ua"
-        )
-
-        # set the vectors all too long
-        charmm_bad_box_1.box_1_vectors[0][0] = -0.45678901234561
-        charmm_bad_box_1.box_1_vectors[0][1] = -0.45678901234562
-        charmm_bad_box_1.box_1_vectors[0][2] = -0.45678901234563
-        charmm_bad_box_1.box_1_vectors[1][0] = -0.45678901234564
-        charmm_bad_box_1.box_1_vectors[1][1] = -0.45678901234565
-        charmm_bad_box_1.box_1_vectors[1][2] = -0.45678901234566
-        charmm_bad_box_1.box_1_vectors[2][0] = -0.45678901234567
-        charmm_bad_box_1.box_1_vectors[2][1] = -0.45678901234568
-        charmm_bad_box_1.box_1_vectors[2][2] = -0.45678901234569
-
-        # test that it fails with the GEMC_NVT with only 1 box in the Charmm object
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: At lease one of the individual box {} vectors are too large "
-                  "or greater than {} characters."
-                  "".format(0, 16)
-        ):
-
-            gomc_control.write_gomc_control_file(
-                charmm_bad_box_0,
-                "test_box_vector_too_many_char_box_0",
-                "NVT",
-                100,
-                300,
-            )
-
-        # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
-        with pytest.raises(
-            ValueError,
-                match=r"ERROR: At lease one of the individual box {} vectors are too large "
-                      "or greater than {} characters."
-                      "".format(1, 16)
-        ):
-
-            gomc_control.write_gomc_control_file(
-                charmm_bad_box_1,
-                "test_box_vector_too_many_char_box_1",
-                "GCMC",
-                100,
-                300,
-            )
-

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -3,15 +3,14 @@ import pytest
 import mbuild as mb
 import mbuild.formats.gomc_conf_writer as gomc_control
 from mbuild.formats.charmm_writer import Charmm
+from mbuild.lattice import load_cif
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import has_foyer
+from mbuild.utils.io import has_foyer, get_fn
 
 
 @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
 class TestGOMCControlFileWriter(BaseTest):
-    def test_dict_keys_to_list(
-        self,
-    ):
+    def test_dict_keys_to_list(self,):
         dict = {"a": "1", "b": "2", "c": "3"}
         keys = gomc_control.dict_keys_to_list(dict)
 
@@ -347,13 +346,17 @@ class TestGOMCControlFileWriter(BaseTest):
         assert test_status == "PASSED"
 
     def test_save_basic_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[1, 1, 1]
+        )
         charmm = Charmm(
-            ethane_gomc,
+            test_box_ethane_gomc,
             "ethane",
             ff_filename="ethane",
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[1, 1, 1],
         )
         gomc_control.write_gomc_control_file(
             charmm, "test_save_basic_NVT.conf", "NVT", 10, 300
@@ -430,7 +433,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
                 elif line.startswith("Tolerance "):
                     split_line = line.split()
-                    assert split_line[1] == "0.000010000000"
+                    assert split_line[1] == "1e-05"
 
                 elif line.startswith("1-4scaling "):
                     split_line = line.split()
@@ -514,21 +517,21 @@ class TestGOMCControlFileWriter(BaseTest):
                     assert split_line[1] == "0"
                     print("split_line[2] = " + str(split_line[2]))
                     assert split_line[2] == "10.0"
-                    assert split_line[3] == "0.00"
-                    assert split_line[4] == "0.00"
+                    assert split_line[3] == "0.0"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector2 "):
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "0.00"
+                    assert split_line[2] == "0.0"
                     assert split_line[3] == "10.0"
-                    assert split_line[4] == "0.00"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector3 "):
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "0.00"
-                    assert split_line[3] == "0.00"
+                    assert split_line[2] == "0.0"
+                    assert split_line[3] == "0.0"
                     assert split_line[4] == "10.0"
 
                 elif line.startswith("CBMC_First "):
@@ -635,13 +638,17 @@ class TestGOMCControlFileWriter(BaseTest):
                     pass
 
     def test_save_basic_NPT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[2, 2, 2]
+        )
         charmm = Charmm(
-            ethane_gomc,
+            test_box_ethane_gomc,
             "ethane",
             ff_filename="ethane",
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[2, 2, 2],
         )
         gomc_control.write_gomc_control_file(
             charmm, "test_save_basic_NPT.conf", "NPT", 1000, 500
@@ -735,21 +742,21 @@ class TestGOMCControlFileWriter(BaseTest):
                     split_line = line.split()
                     assert split_line[1] == "0"
                     assert split_line[2] == "20.0"
-                    assert split_line[3] == "0.00"
-                    assert split_line[4] == "0.00"
+                    assert split_line[3] == "0.0"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector2 "):
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "0.00"
+                    assert split_line[2] == "0.0"
                     assert split_line[3] == "20.0"
-                    assert split_line[4] == "0.00"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector3 "):
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "0.00"
-                    assert split_line[3] == "0.00"
+                    assert split_line[2] == "0.0"
+                    assert split_line[3] == "0.0"
                     assert split_line[4] == "20.0"
 
                 elif line.startswith("RestartFreq "):
@@ -798,16 +805,19 @@ class TestGOMCControlFileWriter(BaseTest):
                     pass
 
     def test_save_basic_GCMC(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[2, 2, 2]
+        )
         charmm = Charmm(
-            ethane_gomc,
+            test_box_ethane_gomc,
             "ethane_box_0",
-            structure_box_1=ethane_gomc,
+            structure_box_1=test_box_ethane_gomc,
             filename_box_1="ethane_box_1",
             ff_filename="ethane_FF",
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[2, 2, 2],
-            box_1=[2, 2, 2],
         )
         gomc_control.write_gomc_control_file(
             charmm,
@@ -934,42 +944,42 @@ class TestGOMCControlFileWriter(BaseTest):
                     split_line = line.split()
                     assert split_line[1] == "0"
                     assert split_line[2] == "20.0"
-                    assert split_line[3] == "0.00"
-                    assert split_line[4] == "0.00"
+                    assert split_line[3] == "0.0"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector2 0"):
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "0.00"
+                    assert split_line[2] == "0.0"
                     assert split_line[3] == "20.0"
-                    assert split_line[4] == "0.00"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector3 0"):
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "0.00"
-                    assert split_line[3] == "0.00"
+                    assert split_line[2] == "0.0"
+                    assert split_line[3] == "0.0"
                     assert split_line[4] == "20.0"
 
                 elif line.startswith("CellBasisVector1 1"):
                     split_line = line.split()
                     assert split_line[1] == "1"
                     assert split_line[2] == "20.0"
-                    assert split_line[3] == "0.00"
-                    assert split_line[4] == "0.00"
+                    assert split_line[3] == "0.0"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector2 1"):
                     split_line = line.split()
                     assert split_line[1] == "1"
-                    assert split_line[2] == "0.00"
+                    assert split_line[2] == "0.0"
                     assert split_line[3] == "20.0"
-                    assert split_line[4] == "0.00"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector3 1"):
                     split_line = line.split()
                     assert split_line[1] == "1"
-                    assert split_line[2] == "0.00"
-                    assert split_line[3] == "0.00"
+                    assert split_line[2] == "0.0"
+                    assert split_line[3] == "0.0"
                     assert split_line[4] == "20.0"
 
                 elif line.startswith("RestartFreq "):
@@ -1014,16 +1024,19 @@ class TestGOMCControlFileWriter(BaseTest):
                     pass
 
     def test_save_basic_GEMC_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[2, 2, 2]
+        )
         charmm = Charmm(
-            ethane_gomc,
+            test_box_ethane_gomc,
             "ethane_box_0",
-            structure_box_1=ethane_gomc,
+            structure_box_1=test_box_ethane_gomc,
             filename_box_1="ethane_box_1",
             ff_filename="ethane_FF",
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[2, 2, 2],
-            box_1=[2, 2, 2],
         )
         gomc_control.write_gomc_control_file(
             charmm, "test_save_basic_GEMC_NVT.conf", "GEMC_NVT", 1000000, 500
@@ -1092,16 +1105,19 @@ class TestGOMCControlFileWriter(BaseTest):
                     pass
 
     def test_save_basic_GEMC_NPT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc],
+            n_compounds=[1],
+            box=[2, 2, 2]
+        )
         charmm = Charmm(
-            ethane_gomc,
+            test_box_ethane_gomc,
             "ethane_box_0",
-            structure_box_1=ethane_gomc,
+            structure_box_1=test_box_ethane_gomc,
             filename_box_1="ethane_box_1",
             ff_filename="ethane_FF",
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[2, 2, 2],
-            box_1=[2, 2, 2],
         )
         gomc_control.write_gomc_control_file(
             charmm,
@@ -1254,8 +1270,8 @@ class TestGOMCControlFileWriter(BaseTest):
                 "FreeEnergyCalc": [True, 50],
                 "MoleculeType": ["ETH", 1],
                 "InitialState": 3,
-                "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 "MEMC_DataInput": [
                     [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
                 ],
@@ -1339,7 +1355,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
                 elif line.startswith("Tolerance "):
                     split_line = line.split()
-                    assert split_line[1] == "0.010000000000"
+                    assert split_line[1] == "0.01"
 
                 elif line.startswith("1-4scaling "):
                     split_line = line.split()
@@ -1427,21 +1443,21 @@ class TestGOMCControlFileWriter(BaseTest):
                     split_line = line.split()
                     assert split_line[1] == "0"
                     assert split_line[2] == "40.0"
-                    assert split_line[3] == "0.00"
-                    assert split_line[4] == "0.00"
+                    assert split_line[3] == "0.0"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector2 "):
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "0.00"
+                    assert split_line[2] == "0.0"
                     assert split_line[3] == "40.0"
-                    assert split_line[4] == "0.00"
+                    assert split_line[4] == "0.0"
 
                 elif line.startswith("CellBasisVector3 "):
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "0.00"
-                    assert split_line[3] == "0.00"
+                    assert split_line[2] == "0.0"
+                    assert split_line[3] == "0.0"
                     assert split_line[4] == "40.0"
 
                 elif line.startswith("FreeEnergyCalc "):
@@ -1486,14 +1502,14 @@ class TestGOMCControlFileWriter(BaseTest):
                     assert split_line[1] == "0.1"
                     assert split_line[2] == "0.2"
                     assert split_line[3] == "0.4"
-                    assert split_line[4] == "0.9"
+                    assert split_line[4] == "1.0"
 
                 elif line.startswith("LambdaCoulomb "):
                     split_line = line.split()
                     assert split_line[1] == "0.1"
                     assert split_line[2] == "0.3"
                     assert split_line[3] == "0.8"
-                    assert split_line[4] == "0.8"
+                    assert split_line[4] == "1.0"
 
                 elif line.startswith("CBMC_First "):
                     split_line = line.split()
@@ -1598,11 +1614,11 @@ class TestGOMCControlFileWriter(BaseTest):
                 else:
                     pass
 
-    def test_save_NVT_bad_variables_part_1(self, ethane_gomc, ethanol_gomc):
+    def test_save_NVT_bad_lamda_value(self, ethane_gomc, ethanol_gomc):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
-            box=[4.0, 4.0, 4.0],
+            box=[1, 1, 1],
         )
 
         charmm = Charmm(
@@ -1611,7 +1627,58 @@ class TestGOMCControlFileWriter(BaseTest):
             ff_filename="ethane_ethanol",
             residues=[ethane_gomc.name, ethanol_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[1, 1, 1],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: The last value in the LambdaCoulomb variable list must be a 1.0",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_NVT_bad_variables_part_1.conf",
+                "NVT",
+                100,
+                300,
+                input_variables_dict={
+                    "FreeEnergyCalc": [True, 10],
+                    "MoleculeType": ["ETH", 1],
+                    "InitialState": 3,
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.9],
+                }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match=r"ERROR: The last value in the LambdaVDW variable list must be a 1.0",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_NVT_bad_variables_part_1.conf",
+                "NVT",
+                100,
+                300,
+                input_variables_dict={
+                    "FreeEnergyCalc": [True, 10],
+                    "MoleculeType": ["ETH", 1],
+                    "InitialState": 3,
+                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
+                }
+            )
+
+    def test_save_NVT_bad_variables_part_1(self, ethane_gomc, ethanol_gomc):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[1, 1, 1],
+        )
+
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol",
+            ff_filename="ethane_ethanol",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
         )
 
         with pytest.raises(
@@ -2405,8 +2472,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": "s",
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -2427,8 +2494,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", "s"],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -2449,8 +2516,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [["ETH"], 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -2471,8 +2538,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"ETH": "1"}, 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -2493,8 +2560,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
                     "InitialState": "s",
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -2516,7 +2583,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 1,
                     "LambdaVDW": "s",
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -2537,7 +2604,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
                     "LambdaCoulomb": "s",
                 },
             )
@@ -2899,7 +2966,7 @@ class TestGOMCControlFileWriter(BaseTest):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
-            box=[4.0, 4.0, 4.0],
+            box=[1, 1, 1],
         )
 
         charmm = Charmm(
@@ -2908,7 +2975,6 @@ class TestGOMCControlFileWriter(BaseTest):
             ff_filename="ethane_ethanol",
             residues=[ethane_gomc.name, ethanol_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[1, 1, 1],
         )
 
         with pytest.raises(
@@ -3720,8 +3786,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [],
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -3742,8 +3808,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", []],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -3764,8 +3830,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [["ETH"], 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -3786,8 +3852,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"ETH": "1"}, 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -3808,8 +3874,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
                     "InitialState": [],
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -3831,7 +3897,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 1,
                     "LambdaVDW": [],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -3852,7 +3918,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
                     "LambdaCoulomb": [],
                 },
             )
@@ -4214,7 +4280,7 @@ class TestGOMCControlFileWriter(BaseTest):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
-            box=[4.0, 4.0, 4.0],
+            box=[1, 1, 1],
         )
 
         charmm = Charmm(
@@ -4223,7 +4289,6 @@ class TestGOMCControlFileWriter(BaseTest):
             ff_filename="ethane_ethanol",
             residues=[ethane_gomc.name, ethanol_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[1, 1, 1],
         )
 
         try:
@@ -4446,7 +4511,7 @@ class TestGOMCControlFileWriter(BaseTest):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
-            box=[4.0, 4.0, 4.0],
+            box=[1, 1, 1],
         )
 
         charmm = Charmm(
@@ -4455,7 +4520,6 @@ class TestGOMCControlFileWriter(BaseTest):
             ff_filename="ethane_ethanol",
             residues=[ethane_gomc.name, ethanol_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[1, 1, 1],
         )
 
         try:
@@ -4674,7 +4738,7 @@ class TestGOMCControlFileWriter(BaseTest):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
-            box=[4.0, 4.0, 4.0],
+            box=[1, 1, 1],
         )
 
         charmm = Charmm(
@@ -4683,7 +4747,6 @@ class TestGOMCControlFileWriter(BaseTest):
             ff_filename="ethane_ethanol",
             residues=[ethane_gomc.name, ethanol_gomc.name],
             forcefield_selection="oplsaa",
-            box_0=[1, 1, 1],
         )
 
         try:
@@ -4697,8 +4760,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4718,8 +4781,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9, 0.99],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8, 0.99],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8, 1.0],
                 },
             )
         except:
@@ -4738,8 +4801,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4759,8 +4822,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
         except:
@@ -4783,8 +4846,8 @@ class TestGOMCControlFileWriter(BaseTest):
                 input_variables_dict={
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4803,8 +4866,8 @@ class TestGOMCControlFileWriter(BaseTest):
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4823,8 +4886,8 @@ class TestGOMCControlFileWriter(BaseTest):
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4844,7 +4907,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4859,7 +4922,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
                 },
             )
         except:
@@ -4885,8 +4948,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [1, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4907,8 +4970,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": ["1", 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4929,8 +4992,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [["1"], 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4951,8 +5014,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [{"a": "1"}, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -4967,7 +5030,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
                 },
             )
         except:
@@ -4993,8 +5056,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 1.0],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5015,8 +5078,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, "1"],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5037,8 +5100,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, ["1"]],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5059,8 +5122,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, {"a": "1"}],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5081,8 +5144,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000, "s"],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5104,8 +5167,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [1, 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5126,8 +5189,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [[1], 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5148,8 +5211,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"a": "1"}, 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5170,8 +5233,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", "1"],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5192,8 +5255,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", ["1"]],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5214,8 +5277,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", {"a": "1"}],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5236,8 +5299,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETOa", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5259,8 +5322,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": "s",
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5281,8 +5344,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": ["s"],
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5303,8 +5366,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": {"a": "1"},
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5325,8 +5388,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1.0,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5348,8 +5411,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": ["x", 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": ["x", 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5370,8 +5433,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [[0.1], 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [[0.1], 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5392,8 +5455,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [{"a": "1"}, 0.2, 0.4],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8],
+                    "LambdaVDW": [{"a": "1"}, 0.2, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 1.0],
                 },
             )
 
@@ -5415,8 +5478,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": ["x", 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": ["x", 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5437,8 +5500,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [[0.1], 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [[0.1], 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5459,8 +5522,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4],
-                    "LambdaCoulomb": [{"a": "1"}, 0.3, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 1.0],
+                    "LambdaCoulomb": [{"a": "1"}, 0.3, 1.0],
                 },
             )
 
@@ -5479,8 +5542,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.1, 0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.1, 0.3, 0.8, 1.0],
                 },
             )
 
@@ -5498,8 +5561,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
-                    "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                    "LambdaCoulomb": [0.3, 0.8, 0.8],
+                    "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
+                    "LambdaCoulomb": [0.3, 0.8, 1.0],
                 },
             )
 
@@ -7512,7 +7575,8 @@ class TestGOMCControlFileWriter(BaseTest):
                 300,
                 input_variables_dict={
                     "MEMC_DataInput": [
-                        [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
+                        [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]],
+                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "O1"]]
                     ],
                     "ChEmPot": {"ETH": -4000, "ETO": -8000},
                     "DisFreQ": 0.05,
@@ -7647,3 +7711,161 @@ class TestGOMCControlFileWriter(BaseTest):
                 100,
                 300,
             )
+
+    def test_save_non_othoganol_writer(self):
+        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
+        ETV_triclinic_1_cell = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
+        ETV_triclinic_1_cell.name = 'ETV_1'
+        ETV_triclinic_3_cell = lattice_cif_ETV_triclinic.populate(x=3, y=3, z=3)
+        ETV_triclinic_3_cell.name = 'ETV_3'
+
+        charmm = Charmm(ETV_triclinic_1_cell,
+                        'ETV_triclinic_1_cell_box_0',
+                        structure_box_1=ETV_triclinic_3_cell,
+                        filename_box_1="ETV_triclinic_3_cell_box_1",
+                        ff_filename="ETV_triclinic_FF",
+                        forcefield_selection={
+                            ETV_triclinic_1_cell.name: get_fn("Charmm_writer_testing_only_zeolite.xml"),
+                            ETV_triclinic_3_cell.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
+                        residues=[ETV_triclinic_1_cell.name,
+                                  ETV_triclinic_3_cell.name],
+                        bead_to_atom_name_dict=None,
+                        fix_residue=[ETV_triclinic_1_cell.name,
+                                     ETV_triclinic_3_cell.name],
+                        )
+
+        gomc_control.write_gomc_control_file(charmm, 'test_save_non_othoganol_writer.conf',
+                                             'GEMC_NVT', 100000, 300,
+                                             )
+
+        with open('test_save_non_othoganol_writer.conf', 'r') as fp:
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith('CellBasisVector1 0'):
+                    split_line = line.split()
+                    assert split_line[1] == '0'
+                    assert split_line[2] == '8.7503'
+                    assert split_line[3] == '0.0'
+                    assert split_line[4] == '0.0'
+
+                elif line.startswith('CellBasisVector2 0'):
+                    split_line = line.split()
+                    assert split_line[1] == '0'
+                    assert split_line[2] == '-1.179126'
+                    assert split_line[3] == '9.575575'
+                    assert split_line[4] == '0.0'
+
+                elif line.startswith('CellBasisVector3 0'):
+                    split_line = line.split()
+                    assert split_line[1] == '0'
+                    assert split_line[2] == '-1.817232'
+                    assert split_line[3] == '-3.027825'
+                    assert split_line[4] == '9.645822'
+
+                if line.startswith('CellBasisVector1 1'):
+                    split_line = line.split()
+                    assert split_line[1] == '1'
+                    assert split_line[2] == '26.2509'
+                    assert split_line[3] == '0.0'
+                    assert split_line[4] == '0.0'
+
+                elif line.startswith('CellBasisVector2 1'):
+                    split_line = line.split()
+                    assert split_line[1] == '1'
+                    assert split_line[2] == '-3.537377'
+                    assert split_line[3] == '28.726725'
+                    assert split_line[4] == '0.0'
+
+                elif line.startswith('CellBasisVector3 1'):
+                    split_line = line.split()
+                    assert split_line[1] == '1'
+                    assert split_line[2] == '-5.451697'
+                    assert split_line[3] == '-9.083474'
+                    assert split_line[4] == '28.937465'
+
+                else:
+                    pass
+
+    def test_box_vector_too_many_char(self):
+
+        methane = mb.Compound(name="MET")
+        methane_child_bead = mb.Compound(name="_CH4")
+        methane.add(methane_child_bead, inherit_periodicity=False)
+
+        methane_box_orth = mb.fill_box(compound=methane,
+                                       n_compounds=10,
+                                       box=[1, 2, 3]
+                                       )
+
+        charmm_bad_box_0 = Charmm(
+            methane_box_orth,
+            "methane_box_0_orth",
+            ff_filename="methane_box_orth_bad_box_0_non_orth",
+            residues=[methane.name],
+            forcefield_selection="trappe-ua"
+        )
+
+        # set the vectors all too long
+        charmm_bad_box_0.box_0_vectors[0][0] = -0.45678901234561
+        charmm_bad_box_0.box_0_vectors[0][1] = -0.45678901234562
+        charmm_bad_box_0.box_0_vectors[0][2] = -0.45678901234563
+        charmm_bad_box_0.box_0_vectors[1][0] = -0.45678901234564
+        charmm_bad_box_0.box_0_vectors[1][1] = -0.45678901234565
+        charmm_bad_box_0.box_0_vectors[1][2] = -0.45678901234566
+        charmm_bad_box_0.box_0_vectors[2][0] = -0.45678901234567
+        charmm_bad_box_0.box_0_vectors[2][1] = -0.45678901234568
+        charmm_bad_box_0.box_0_vectors[2][2] = -0.45678901234569
+
+        charmm_bad_box_1 = Charmm(
+            methane_box_orth,
+            "methane_box_0_orth",
+            structure_box_1=methane_box_orth,
+            filename_box_1="methane_box_1_orth",
+            ff_filename="methane_box_orth_bad_box_1_non_orth",
+            residues=[methane.name],
+            forcefield_selection="trappe-ua"
+        )
+
+        # set the vectors all too long
+        charmm_bad_box_1.box_1_vectors[0][0] = -0.45678901234561
+        charmm_bad_box_1.box_1_vectors[0][1] = -0.45678901234562
+        charmm_bad_box_1.box_1_vectors[0][2] = -0.45678901234563
+        charmm_bad_box_1.box_1_vectors[1][0] = -0.45678901234564
+        charmm_bad_box_1.box_1_vectors[1][1] = -0.45678901234565
+        charmm_bad_box_1.box_1_vectors[1][2] = -0.45678901234566
+        charmm_bad_box_1.box_1_vectors[2][0] = -0.45678901234567
+        charmm_bad_box_1.box_1_vectors[2][1] = -0.45678901234568
+        charmm_bad_box_1.box_1_vectors[2][2] = -0.45678901234569
+
+        # test that it fails with the GEMC_NVT with only 1 box in the Charmm object
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: At lease one of the individual box {} vectors are too large "
+                  "or greater than {} characters."
+                  "".format(0, 16)
+        ):
+
+            gomc_control.write_gomc_control_file(
+                charmm_bad_box_0,
+                "test_box_vector_too_many_char_box_0",
+                "NVT",
+                100,
+                300,
+            )
+
+        # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
+        with pytest.raises(
+            ValueError,
+                match=r"ERROR: At lease one of the individual box {} vectors are too large "
+                      "or greater than {} characters."
+                      "".format(1, 16)
+        ):
+
+            gomc_control.write_gomc_control_file(
+                charmm_bad_box_1,
+                "test_box_vector_too_many_char_box_1",
+                "GCMC",
+                100,
+                300,
+            )
+

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -5,12 +5,14 @@ import mbuild.formats.gomc_conf_writer as gomc_control
 from mbuild.formats.charmm_writer import Charmm
 from mbuild.lattice import load_cif
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import has_foyer, get_fn
+from mbuild.utils.io import get_fn, has_foyer
 
 
 @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
 class TestGOMCControlFileWriter(BaseTest):
-    def test_dict_keys_to_list(self,):
+    def test_dict_keys_to_list(
+        self,
+    ):
         dict = {"a": "1", "b": "2", "c": "3"}
         keys = gomc_control.dict_keys_to_list(dict)
 
@@ -347,9 +349,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_NVT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc],
-            n_compounds=[1],
-            box=[1, 1, 1]
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -639,9 +639,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_NPT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc],
-            n_compounds=[1],
-            box=[2, 2, 2]
+            compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -806,9 +804,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_GCMC(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc],
-            n_compounds=[1],
-            box=[2, 2, 2]
+            compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -1025,9 +1021,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_GEMC_NVT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc],
-            n_compounds=[1],
-            box=[2, 2, 2]
+            compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -1106,9 +1100,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_save_basic_GEMC_NPT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
-            compound=[ethane_gomc],
-            n_compounds=[1],
-            box=[2, 2, 2]
+            compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
         )
         charmm = Charmm(
             test_box_ethane_gomc,
@@ -1645,12 +1637,12 @@ class TestGOMCControlFileWriter(BaseTest):
                     "InitialState": 3,
                     "LambdaVDW": [0.1, 0.2, 0.4, 1.0],
                     "LambdaCoulomb": [0.1, 0.3, 0.8, 0.9],
-                }
+                },
             )
 
         with pytest.raises(
-                ValueError,
-                match=r"ERROR: The last value in the LambdaVDW variable list must be a 1.0",
+            ValueError,
+            match=r"ERROR: The last value in the LambdaVDW variable list must be a 1.0",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -1663,7 +1655,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     "MoleculeType": ["ETH", 1],
                     "InitialState": 3,
                     "LambdaVDW": [0.1, 0.2, 0.4, 0.9],
-                }
+                },
             )
 
     def test_save_NVT_bad_variables_part_1(self, ethane_gomc, ethanol_gomc):
@@ -7576,7 +7568,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]],
-                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "O1"]]
+                        [1, "ETH", ["C1", "C2"], "ETO", ["C1", "O1"]],
                     ],
                     "ChEmPot": {"ETH": -4000, "ETO": -8000},
                     "DisFreQ": 0.05,
@@ -7713,75 +7705,85 @@ class TestGOMCControlFileWriter(BaseTest):
             )
 
     def test_save_non_othoganol_writer(self):
-        lattice_cif_ETV_triclinic = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
+        lattice_cif_ETV_triclinic = load_cif(
+            file_or_path=get_fn("ETV_triclinic.cif")
+        )
         ETV_triclinic_1_cell = lattice_cif_ETV_triclinic.populate(x=1, y=1, z=1)
-        ETV_triclinic_1_cell.name = 'ETV_1'
+        ETV_triclinic_1_cell.name = "ETV_1"
         ETV_triclinic_3_cell = lattice_cif_ETV_triclinic.populate(x=3, y=3, z=3)
-        ETV_triclinic_3_cell.name = 'ETV_3'
+        ETV_triclinic_3_cell.name = "ETV_3"
 
-        charmm = Charmm(ETV_triclinic_1_cell,
-                        'ETV_triclinic_1_cell_box_0',
-                        structure_box_1=ETV_triclinic_3_cell,
-                        filename_box_1="ETV_triclinic_3_cell_box_1",
-                        ff_filename="ETV_triclinic_FF",
-                        forcefield_selection={
-                            ETV_triclinic_1_cell.name: get_fn("Charmm_writer_testing_only_zeolite.xml"),
-                            ETV_triclinic_3_cell.name: get_fn("Charmm_writer_testing_only_zeolite.xml")},
-                        residues=[ETV_triclinic_1_cell.name,
-                                  ETV_triclinic_3_cell.name],
-                        bead_to_atom_name_dict=None,
-                        fix_residue=[ETV_triclinic_1_cell.name,
-                                     ETV_triclinic_3_cell.name],
-                        )
+        charmm = Charmm(
+            ETV_triclinic_1_cell,
+            "ETV_triclinic_1_cell_box_0",
+            structure_box_1=ETV_triclinic_3_cell,
+            filename_box_1="ETV_triclinic_3_cell_box_1",
+            ff_filename="ETV_triclinic_FF",
+            forcefield_selection={
+                ETV_triclinic_1_cell.name: get_fn(
+                    "Charmm_writer_testing_only_zeolite.xml"
+                ),
+                ETV_triclinic_3_cell.name: get_fn(
+                    "Charmm_writer_testing_only_zeolite.xml"
+                ),
+            },
+            residues=[ETV_triclinic_1_cell.name, ETV_triclinic_3_cell.name],
+            bead_to_atom_name_dict=None,
+            fix_residue=[ETV_triclinic_1_cell.name, ETV_triclinic_3_cell.name],
+        )
 
-        gomc_control.write_gomc_control_file(charmm, 'test_save_non_othoganol_writer.conf',
-                                             'GEMC_NVT', 100000, 300,
-                                             )
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_save_non_othoganol_writer.conf",
+            "GEMC_NVT",
+            100000,
+            300,
+        )
 
-        with open('test_save_non_othoganol_writer.conf', 'r') as fp:
+        with open("test_save_non_othoganol_writer.conf", "r") as fp:
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
-                if line.startswith('CellBasisVector1 0'):
+                if line.startswith("CellBasisVector1 0"):
                     split_line = line.split()
-                    assert split_line[1] == '0'
-                    assert split_line[2] == '8.7503'
-                    assert split_line[3] == '0.0'
-                    assert split_line[4] == '0.0'
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "8.7503"
+                    assert split_line[3] == "0.0"
+                    assert split_line[4] == "0.0"
 
-                elif line.startswith('CellBasisVector2 0'):
+                elif line.startswith("CellBasisVector2 0"):
                     split_line = line.split()
-                    assert split_line[1] == '0'
-                    assert split_line[2] == '-1.179131'
-                    assert split_line[3] == '9.575585'
-                    assert split_line[4] == '0.0'
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "-1.179131"
+                    assert split_line[3] == "9.575585"
+                    assert split_line[4] == "0.0"
 
-                elif line.startswith('CellBasisVector3 0'):
+                elif line.startswith("CellBasisVector3 0"):
                     split_line = line.split()
-                    assert split_line[1] == '0'
-                    assert split_line[2] == '-1.817231'
-                    assert split_line[3] == '-3.027821'
-                    assert split_line[4] == '9.645823'
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "-1.817231"
+                    assert split_line[3] == "-3.027821"
+                    assert split_line[4] == "9.645823"
 
-                if line.startswith('CellBasisVector1 1'):
+                if line.startswith("CellBasisVector1 1"):
                     split_line = line.split()
-                    assert split_line[1] == '1'
-                    assert split_line[2] == '26.2509'
-                    assert split_line[3] == '0.0'
-                    assert split_line[4] == '0.0'
+                    assert split_line[1] == "1"
+                    assert split_line[2] == "26.2509"
+                    assert split_line[3] == "0.0"
+                    assert split_line[4] == "0.0"
 
-                elif line.startswith('CellBasisVector2 1'):
+                elif line.startswith("CellBasisVector2 1"):
                     split_line = line.split()
-                    assert split_line[1] == '1'
-                    assert split_line[2] == '-3.537381'
-                    assert split_line[3] == '28.726735'
-                    assert split_line[4] == '0.0'
+                    assert split_line[1] == "1"
+                    assert split_line[2] == "-3.537381"
+                    assert split_line[3] == "28.726735"
+                    assert split_line[4] == "0.0"
 
-                elif line.startswith('CellBasisVector3 1'):
+                elif line.startswith("CellBasisVector3 1"):
                     split_line = line.split()
-                    assert split_line[1] == '1'
-                    assert split_line[2] == '-5.451699'
-                    assert split_line[3] == '-9.083469'
-                    assert split_line[4] == '28.937455'
+                    assert split_line[1] == "1"
+                    assert split_line[2] == "-5.451699"
+                    assert split_line[3] == "-9.083469"
+                    assert split_line[4] == "28.937455"
 
                 else:
                     pass
@@ -7792,17 +7794,16 @@ class TestGOMCControlFileWriter(BaseTest):
         methane_child_bead = mb.Compound(name="_CH4")
         methane.add(methane_child_bead, inherit_periodicity=False)
 
-        methane_box_orth = mb.fill_box(compound=methane,
-                                       n_compounds=10,
-                                       box=[1, 2, 3]
-                                       )
+        methane_box_orth = mb.fill_box(
+            compound=methane, n_compounds=10, box=[1, 2, 3]
+        )
 
         charmm_bad_box_0 = Charmm(
             methane_box_orth,
             "methane_box_0_orth",
             ff_filename="methane_box_orth_bad_box_0_non_orth",
             residues=[methane.name],
-            forcefield_selection="trappe-ua"
+            forcefield_selection="trappe-ua",
         )
 
         # set the vectors all too long
@@ -7823,7 +7824,7 @@ class TestGOMCControlFileWriter(BaseTest):
             filename_box_1="methane_box_1_orth",
             ff_filename="methane_box_orth_bad_box_1_non_orth",
             residues=[methane.name],
-            forcefield_selection="trappe-ua"
+            forcefield_selection="trappe-ua",
         )
 
         # set the vectors all too long
@@ -7841,8 +7842,8 @@ class TestGOMCControlFileWriter(BaseTest):
         with pytest.raises(
             ValueError,
             match=r"ERROR: At lease one of the individual box {} vectors are too large "
-                  "or greater than {} characters."
-                  "".format(0, 16)
+            "or greater than {} characters."
+            "".format(0, 16),
         ):
 
             gomc_control.write_gomc_control_file(
@@ -7856,9 +7857,9 @@ class TestGOMCControlFileWriter(BaseTest):
         # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
         with pytest.raises(
             ValueError,
-                match=r"ERROR: At lease one of the individual box {} vectors are too large "
-                      "or greater than {} characters."
-                      "".format(1, 16)
+            match=r"ERROR: At lease one of the individual box {} vectors are too large "
+            "or greater than {} characters."
+            "".format(1, 16),
         ):
 
             gomc_control.write_gomc_control_file(

--- a/mbuild/utils/reference/Charmm_writer_testing_only_zeolite.xml
+++ b/mbuild/utils/reference/Charmm_writer_testing_only_zeolite.xml
@@ -1,0 +1,10 @@
+<ForceField>
+ <AtomTypes>
+  <Type name="Si" class="Si" element="Si" mass="12.011"   def="Si" desc="Si, faked for testing" doi="Physic are wrong, for testing only"/>
+  <Type name="O" class="O" element="O" mass="16.04300" def="O" desc="O, faked for testing" doi="Physic are wrong, for testing only"/>
+ </AtomTypes>
+ <NonbondedForce coulomb14scale="0" lj14scale="0">
+  <Atom type="Si"    charge="0.80"    sigma="0.34"   epsilon="0.232805"/>
+  <Atom type="O" charge="-0.4" sigma="0.373" epsilon="1.23054"/>
+  </NonbondedForce>
+</ForceField>

--- a/mbuild/utils/specific_ff_to_residue.py
+++ b/mbuild/utils/specific_ff_to_residue.py
@@ -204,7 +204,6 @@ def specific_ff_to_residue(
 
     coulomb14scalar_dict = {}
     lj14_scalar_dict = {}
-
     for j in range(0, len(forcefield_keys_list)):
         residue_iteration = forcefield_keys_list[j]
         if user_entered_ff_with_path_dict[residue_iteration]:

--- a/mbuild/utils/specific_ff_to_residue.py
+++ b/mbuild/utils/specific_ff_to_residue.py
@@ -14,7 +14,6 @@ def specific_ff_to_residue(
     forcefield_selection=None,
     residues=None,
     reorder_res_in_pdb_psf=False,
-    box=None,
     boxes_for_simulation=1,
 ):
 
@@ -46,10 +45,6 @@ def specific_ff_to_residue(
         This option provides the ability to reorder the residues/molecules from the original
         structure's order.  If True, the residues will be reordered as they appear in the residues
         variable.  If False, the order will be the same as entered in the original structure.
-    box: list, default=None
-        list of 3 positive float or integer values or the dimensions [x, y ,z]
-        for structure in nanometers (nm). This is to add/override or change the structures dimensions.
-        Ex: [1,2,3]
     boxes_for_simulation: int [1, 2], default = 1
         Gibbs (GEMC) or grand canonical (GCMC) ensembles are examples of where the boxes_for_simulation would be 2.
         Canonical (NVT) or isothermal–isobaric (NPT) ensembles are example with the boxes_for_simulation equal to 1.
@@ -147,25 +142,6 @@ def specific_ff_to_residue(
         )
         raise TypeError(print_error_message)
 
-    if box is not None:
-        box_ang = []
-        box_length = len(box)
-        if box_length != 3:
-            print_error_message = "Please enter all 3 values, and only 3 values for the box dimensions."
-            raise ValueError(print_error_message)
-        print_error_message_box_positive_values = (
-            "Please enter positive ( > 0) integers for the box dimensions."
-        )
-        for box_iter in box:
-            if not isinstance(box_iter, int) and not isinstance(
-                box_iter, float
-            ):
-                raise TypeError(print_error_message_box_positive_values)
-            if box_iter < 0:
-                raise ValueError(print_error_message_box_positive_values)
-            # change from nm to Angstroms
-            box_ang.append(box_iter * 10)
-
     print_error_message_for_boxes_for_simulatiion = (
         "ERROR: Please enter boxes_for_simulation equal " "the integer 1 or 2."
     )
@@ -228,11 +204,11 @@ def specific_ff_to_residue(
 
     coulomb14scalar_dict = {}
     lj14_scalar_dict = {}
+
     for j in range(0, len(forcefield_keys_list)):
         residue_iteration = forcefield_keys_list[j]
         if user_entered_ff_with_path_dict[residue_iteration]:
             ff_for_residue_iteration = ff_data[residue_iteration]
-
             try:
                 read_xlm_iteration = minidom.parse(ff_for_residue_iteration)
 
@@ -241,7 +217,7 @@ def specific_ff_to_residue(
                     "Please make sure you are entering the correct foyer FF path, "
                     "including the FF file name.xml "
                     "If you are using the pre-build FF files in foyer, "
-                    "please us the forcefield_names variable."
+                    "only use the string name without any extension."
                 )
                 raise ValueError(print_error_message)
         elif not user_entered_ff_with_path_dict[residue_iteration]:
@@ -296,16 +272,6 @@ def specific_ff_to_residue(
         lengths = structure.lengths
         angles = structure.angles
 
-        if (
-            structure.angles[0] != 90
-            or structure.angles[1] != 90
-            or structure.angles[2] != 90
-        ):
-            print_error_message = (
-                "This writer only currently supports orthogonal boxes "
-                "(i.e., boxes with all 90 degree angles)."
-            )
-            raise ValueError(print_error_message)
         structure = mb.Compound()
         structure.box = mb.Box(lengths=lengths, angles=angles)
         initial_no_atoms = 0
@@ -429,11 +395,6 @@ def specific_ff_to_residue(
                 new_compound_iteration, residues=[residues[i]]
             )
             new_structure = new_structure + new_structure_iteration
-
-    if box is not None:
-        new_structure.box[0] = box_ang[0]
-        new_structure.box[1] = box_ang[1]
-        new_structure.box[2] = box_ang[2]
 
     structure = new_structure
 


### PR DESCRIPTION
### PR Summary:
Addition of the non-orthogonal box and CIF reader capability for GOMC. Also, better formatting for the GOMC control file writer, a check to ensure the last free energy lambda value is 1, and a faked FF for zeolite testing for the test code.

Lastly, the removal of the box size changing from the specific_ff_to_residue.py and charmm_writer.py writers as this is more complicated and cumbersome with the non-orthogonal boxes, so it was removed.

This also changed:
- Formatting in the gomc_conf_file_writer to be cleaner. 
- PSF and PDB writer to write individual atoms for a fixed crystal structure with no bonds, which allows proper atom wrapping on GOMC. Previously, if it was listed as an atom if it was had the same residue name.
- Removed allowing box size changes in the Charmm object and the specific_ff_to_residue.py file, as this is difficult and confusing with non-orthogonal boxes. 
- Added restraint to only allow 1 for the last lambda value for the free energy calcs in the GOMC writer.

There are not a lot of technical changes, mostly formating.

### PR Checklist
------------
 - [X] Includes appropriate unit test(s)
 - [X] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
