### PR TITLE
Fix function calls in axis transform functions

### DIFF
--- a/mbuild/coordinate_transform.py
+++ b/mbuild/coordinate_transform.py
@@ -551,7 +551,7 @@ def rotate_around_x(compound, theta):
         The angle by which to rotate the compound.
     """
     raise RemovedFuncError(
-        "rotate_around_x()", "Compound.rotate_around_x()", "0.7.0", "0.11.0"
+        "rotate_around_x()", "Compound.rotate()", "0.7.0", "0.11.0"
     )
 
 
@@ -566,7 +566,7 @@ def rotate_around_y(compound, theta):
         The angle by which to rotate the compound.
     """
     raise RemovedFuncError(
-        "rotate_around_y()", "Compound.rotate_around_y()", "0.7.0", "0.11.0"
+        "rotate_around_y()", "Compound.rotate()", "0.7.0", "0.11.0"
     )
 
 
@@ -581,7 +581,7 @@ def rotate_around_z(compound, theta):
         The angle by which to rotate the compound.
     """
     raise RemovedFuncError(
-        "rotate_around_z()", "Compound.rotate_around_z()", "0.7.0", "0.11.0"
+        "rotate_around_z()", "Compound.rotate()", "0.7.0", "0.11.0"
     )
 
 

--- a/mbuild/coordinate_transform.py
+++ b/mbuild/coordinate_transform.py
@@ -750,7 +750,7 @@ def y_axis_transform(
         point_on_x_axis=point_on_y_axis,
         point_on_xy_plane=point_on_xy_plane,
     )
-    rotate_around_z(compound, np.pi / 2)
+    compound.rotate(theta=np.pi/2, around=(0,0,1))
 
 
 def z_axis_transform(
@@ -775,4 +775,4 @@ def z_axis_transform(
         point_on_x_axis=point_on_z_axis,
         point_on_xy_plane=point_on_zx_plane,
     )
-    rotate_around_y(compound, np.pi * 3 / 2)
+    compound.rotate(theta=np.pi*1.5, around=(0, 1, 0))

--- a/mbuild/coordinate_transform.py
+++ b/mbuild/coordinate_transform.py
@@ -750,7 +750,7 @@ def y_axis_transform(
         point_on_x_axis=point_on_y_axis,
         point_on_xy_plane=point_on_xy_plane,
     )
-    compound.rotate(theta=np.pi/2, around=(0,0,1))
+    compound.rotate(theta=np.pi / 2, around=(0, 0, 1))
 
 
 def z_axis_transform(
@@ -775,4 +775,4 @@ def z_axis_transform(
         point_on_x_axis=point_on_z_axis,
         point_on_xy_plane=point_on_zx_plane,
     )
-    compound.rotate(theta=np.pi*1.5, around=(0, 1, 0))
+    compound.rotate(theta=np.pi * 1.5, around=(0, 1, 0))

--- a/mbuild/tests/test_coordinate_transform.py
+++ b/mbuild/tests/test_coordinate_transform.py
@@ -421,7 +421,7 @@ class TestCoordinateTransform(BaseTest):
         spun_points = _spin(points, np.pi / 2, [0, 0, 1])
         assert np.allclose(spun_points, new_points_should_be, atol=1e-15)
 
-    def test_xyz_axis_transform(self):
+    def test_x_axis_transform(self):
         rot_by_compound = mb.Compound(name="rot_by_compound")
         b = mb.Compound(name="b")
         c = mb.Compound(name="c")
@@ -436,3 +436,15 @@ class TestCoordinateTransform(BaseTest):
         x_axis_transform(rot_by_compound, b, c, d)
         x_axis_transform(rot_by_array, array1, array2, array3)
         assert np.array_equal(rot_by_compound.pos, rot_by_array.pos)
+
+    def test_y_axis_transform(self, h2o):
+        init_xyz = h2o.xyz
+        for i in range(4):
+            y_axis_transform(h2o)
+        assert np.allclose(h2o.xyz, init_xyz, atol=1e-4)
+
+    def test_z_axis_transform(self, h2o):
+        init_xyz = h2o.xyz
+        for i in range(4):
+            z_axis_transform(h2o)
+        assert np.allclose(h2o.xyz, init_xyz, atol=1e-4)


### PR DESCRIPTION
### PR Summary:
If you were to try and run the following, you'd get a `RemovedFuncError`

```
import mbuild as mb
from mbuild.coordinate_transform import x_axis_transform, y_axis_transform, z_axis_transform

comp = mb.load("CCCCCC", smiles=True)
z_axis_transform(comp)
```

```
RemovedFuncError: 
        rotate_around_y() has been removed. Please use Compound.rotate_around_y().
        Deprecated since mBuild version 0.7.0 and removed
        in version 0.11.0.
```

The `y_axis_transform` and `z_axis_transform` functions within `coordinate_transform.py` were still calling deprecated functions. They now call the `Compound.rotate()` function and specify the correct axis to rotate around
### PR Checklist

I'll work on adding unit tests that probably should have caught this error earlier.

------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
