### PR TITLE
Added the path to the FF, psf, and pdb file to be selected by the user.  Moved restart variables to the required variables, and added the ability to use new restart input files.

### DIFF
--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -946,7 +946,7 @@ def unique_atom_naming(
             elif len(str(atom.name)) > 2:
                 if len(str(atom.name)) == 3:
                     no_digits_atom_name = 1
-                    tom_name_value = atom.name
+                    atom_name_value = atom.name
                 else:
                     text_to_write = (
                         "ERROR: atom numbering will not work propery at"

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -946,6 +946,7 @@ def unique_atom_naming(
             elif len(str(atom.name)) > 2:
                 if len(str(atom.name)) == 3:
                     no_digits_atom_name = 1
+                    tom_name_value = atom.name
                 else:
                     text_to_write = (
                         "ERROR: atom numbering will not work propery at"

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -49,7 +49,6 @@ def _get_bond_type_key(
         bond_atom_2_residue_name : str
             The residue name for atom 2 in the bond.
     """
-
     bond_k_constant = round(
         bond.type.k
         * (sigma_conversion_factor ** 2 / epsilon_conversion_factor),

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -1799,7 +1799,7 @@ class Charmm:
                 boxes_for_simulation=self.boxes_for_simulation,
             )
 
-            self.residue_id_list = (
+            self.structure_box_0_and_1_ff = (
                 self.structure_box_0_ff + self.structure_box_1_ff
             )
             self.combined_1_4_lj_dict_per_residue.update(
@@ -1864,7 +1864,7 @@ class Charmm:
                     "Total charge is {}.".format(total_charge)
                 )
 
-            total_charge = sum([atom.charge for atom in self.residue_id_list])
+            total_charge = sum([atom.charge for atom in self.structure_box_0_and_1_ff])
             if round(total_charge, 4) != 0.0:
                 warn(
                     "System is not charge neutral for structure_0_and_1. "
@@ -1961,7 +1961,7 @@ class Charmm:
             self.types = np.array(
                 [
                     atom.type + "_" + str(atom.residue.name)
-                    for atom in self.residue_id_list.atoms
+                    for atom in self.structure_box_0_and_1_ff.atoms
                 ]
             )
 
@@ -1978,7 +1978,7 @@ class Charmm:
 
         if self.structure_box_1:
             self.masses = (
-                np.array([atom.mass for atom in self.residue_id_list.atoms])
+                np.array([atom.mass for atom in self.structure_box_0_and_1_ff.atoms])
                 / self.mass_conversion_factor
             )
             self.mass_dict = dict(
@@ -2059,7 +2059,7 @@ class Charmm:
 
         # if self.structure_box_1 != None:
         if self.structure_box_1:
-            self.structure_selection = self.residue_id_list
+            self.structure_selection = self.structure_box_0_and_1_ff
         else:
             self.structure_selection = self.structure_box_0_ff
 

--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -1864,7 +1864,9 @@ class Charmm:
                     "Total charge is {}.".format(total_charge)
                 )
 
-            total_charge = sum([atom.charge for atom in self.structure_box_0_and_1_ff])
+            total_charge = sum(
+                [atom.charge for atom in self.structure_box_0_and_1_ff]
+            )
             if round(total_charge, 4) != 0.0:
                 warn(
                     "System is not charge neutral for structure_0_and_1. "
@@ -1978,7 +1980,9 @@ class Charmm:
 
         if self.structure_box_1:
             self.masses = (
-                np.array([atom.mass for atom in self.structure_box_0_and_1_ff.atoms])
+                np.array(
+                    [atom.mass for atom in self.structure_box_0_and_1_ff.atoms]
+                )
                 / self.mass_conversion_factor
             )
             self.mass_dict = dict(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2677,17 +2677,23 @@ class GOMCControl:
 
         # auto calculate the best RestartFreq  for the number of self.RunSteps
         self.RestartFreq = _scale_gen_freq_for_run_steps_list_bool_int(
-            "RestartFreq", default_input_variables_dict["RestartFreq"], self.RunSteps
+            "RestartFreq",
+            default_input_variables_dict["RestartFreq"],
+            self.RunSteps,
         )
 
         # auto calculate the best CheckpointFreq  for the number of self.RunSteps
         self.CheckpointFreq = _scale_gen_freq_for_run_steps_list_bool_int(
-            "CheckpointFreq", default_input_variables_dict["CheckpointFreq"], self.RunSteps
+            "CheckpointFreq",
+            default_input_variables_dict["CheckpointFreq"],
+            self.RunSteps,
         )
 
         # auto calculate the best CoordinatesFreq  for the number of self.RunSteps
         self.CoordinatesFreq = _scale_gen_freq_for_run_steps_list_bool_int(
-            "CoordinatesFreq", default_input_variables_dict["CoordinatesFreq"], self.RunSteps
+            "CoordinatesFreq",
+            default_input_variables_dict["CoordinatesFreq"],
+            self.RunSteps,
         )
 
         # auto calculate the best DCDFreq for the number of self.RunSteps
@@ -2697,27 +2703,37 @@ class GOMCControl:
 
         # auto calculate the best ConsoleFreq  for the number of self.RunSteps
         self.ConsoleFreq = _scale_gen_freq_for_run_steps_list_bool_int(
-            "ConsoleFreq", default_input_variables_dict["ConsoleFreq"], self.RunSteps
+            "ConsoleFreq",
+            default_input_variables_dict["ConsoleFreq"],
+            self.RunSteps,
         )
 
         # auto calculate the best PressureCalc  for the number of self.RunSteps
         self.PressureCalc = _scale_gen_freq_for_run_steps_list_bool_int(
-            "PressureCalc", default_input_variables_dict["PressureCalc"], self.RunSteps
+            "PressureCalc",
+            default_input_variables_dict["PressureCalc"],
+            self.RunSteps,
         )
 
         # auto calculate the best BlockAverageFreq  for the number of self.RunSteps
         self.BlockAverageFreq = _scale_gen_freq_for_run_steps_list_bool_int(
-            "BlockAverageFreq", default_input_variables_dict["BlockAverageFreq"], self.RunSteps
+            "BlockAverageFreq",
+            default_input_variables_dict["BlockAverageFreq"],
+            self.RunSteps,
         )
 
         # auto calculate the best HistogramFreq  for the number of self.RunSteps
         self.HistogramFreq = _scale_gen_freq_for_run_steps_list_bool_int(
-            "HistogramFreq", default_input_variables_dict["HistogramFreq"], self.RunSteps
+            "HistogramFreq",
+            default_input_variables_dict["HistogramFreq"],
+            self.RunSteps,
         )
 
         # auto calculate the best SampleFreq  for the number of self.RunSteps
         self.SampleFreq = _scale_gen_freq_for_run_steps_int(
-            "SampleFreq", default_input_variables_dict["SampleFreq"], self.RunSteps
+            "SampleFreq",
+            default_input_variables_dict["SampleFreq"],
+            self.RunSteps,
         )
 
         if input_variables_dict is None:
@@ -6271,7 +6287,9 @@ class GOMCControl:
             bad_input_variables_values_list.append(key)
 
 
-def _scale_gen_freq_for_run_steps_list_bool_int(variable_name, charmm_variable, run_steps):
+def _scale_gen_freq_for_run_steps_list_bool_int(
+    variable_name, charmm_variable, run_steps
+):
     """
     Scales the frequency of the output to a a more realistic value,
     if the output frequency does not make sense based on the
@@ -6294,20 +6312,32 @@ def _scale_gen_freq_for_run_steps_list_bool_int(variable_name, charmm_variable, 
         GOMCControl object, based on the RunSteps in the simulation.
     """
     if not isinstance(charmm_variable, list):
-        print_error_message = "ERROR: The {} variable is not a list.".format(variable_name)
+        print_error_message = "ERROR: The {} variable is not a list.".format(
+            variable_name
+        )
         raise ValueError(print_error_message)
 
         if len(charmm_variable) != 2:
-            print_error_message = "ERROR: The {} variable list length is not 2.".format(variable_name)
+            print_error_message = (
+                "ERROR: The {} variable list length is not 2.".format(
+                    variable_name
+                )
+            )
             raise ValueError(print_error_message)
 
         else:
             if not isinstance(charmm_variable[0], bool):
-                print_error_message = "ERROR: The {} variable is not a boolean.".format(variable_name)
+                print_error_message = (
+                    "ERROR: The {} variable is not a boolean.".format(
+                        variable_name
+                    )
+                )
                 raise ValueError(print_error_message)
 
             if not isinstance(charmm_variable[1], int):
-                print_error_message = "ERROR: The {} variable is not a int.".format(variable_name)
+                print_error_message = (
+                    "ERROR: The {} variable is not a int.".format(variable_name)
+                )
                 raise ValueError(print_error_message)
 
     set_max_steps_charmm_variable = charmm_variable[1]
@@ -6322,7 +6352,9 @@ def _scale_gen_freq_for_run_steps_list_bool_int(variable_name, charmm_variable, 
     return charmm_variable
 
 
-def _scale_gen_freq_for_run_steps_int(variable_name, charmm_variable, run_steps):
+def _scale_gen_freq_for_run_steps_int(
+    variable_name, charmm_variable, run_steps
+):
     """
     Scales the frequency of the output to a a more realistic value,
     if the output frequency does not make sense based on the
@@ -6345,7 +6377,9 @@ def _scale_gen_freq_for_run_steps_int(variable_name, charmm_variable, run_steps)
         GOMCControl object, based on the RunSteps in the simulation.
     """
     if not isinstance(charmm_variable, int):
-        print_error_message = "ERROR: The {} variable is not an interger.".format(variable_name)
+        print_error_message = (
+            "ERROR: The {} variable is not an interger.".format(variable_name)
+        )
         raise ValueError(print_error_message)
 
     set_max_steps_charmm_variable = charmm_variable

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2132,7 +2132,7 @@ class GOMCControl:
         # set and check valid inputs for the Restart attribute
         _check_if_bool("Restart", Restart)
         self.Restart = Restart
-        
+
         # set and check valid inputs for the RestartCheckpoint attribute
         _check_if_bool("RestartCheckpoint", RestartCheckpoint)
         self.RestartCheckpoint = RestartCheckpoint

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -4572,7 +4572,7 @@ class GOMCControl:
             raise ValueError(print_error_message)
 
         # Check that RunSteps >= EqSteps >= AdjSteps
-        print('self.RunSteps = ' +str(self.RunSteps))
+        print("self.RunSteps = " + str(self.RunSteps))
         if (
             self.RunSteps < self.EqSteps
             or self.RunSteps < self.AdjSteps

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2667,57 +2667,57 @@ class GOMCControl:
         self.MEMC_DataInput = default_input_variables_dict["MEMC_DataInput"]
 
         # auto calculate the best EqSteps (number of Equilbrium Steps) and Adj_Steps (number of AdjSteps Steps)
-        self.EqSteps = scale_gen_freq_for_run_steps_int(
-            default_input_variables_dict["EqSteps"], self.RunSteps
+        self.EqSteps = _scale_gen_freq_for_run_steps_int(
+            "EqSteps", default_input_variables_dict["EqSteps"], self.RunSteps
         )
 
-        self.AdjSteps = scale_gen_freq_for_run_steps_int(
-            default_input_variables_dict["AdjSteps"], self.RunSteps
+        self.AdjSteps = _scale_gen_freq_for_run_steps_int(
+            "AdjSteps", default_input_variables_dict["AdjSteps"], self.RunSteps
         )
 
         # auto calculate the best RestartFreq  for the number of self.RunSteps
-        self.RestartFreq = scale_gen_freq_for_run_steps_list_bool_int(
-            default_input_variables_dict["RestartFreq"], self.RunSteps
+        self.RestartFreq = _scale_gen_freq_for_run_steps_list_bool_int(
+            "RestartFreq", default_input_variables_dict["RestartFreq"], self.RunSteps
         )
 
         # auto calculate the best CheckpointFreq  for the number of self.RunSteps
-        self.CheckpointFreq = scale_gen_freq_for_run_steps_list_bool_int(
-            default_input_variables_dict["CheckpointFreq"], self.RunSteps
+        self.CheckpointFreq = _scale_gen_freq_for_run_steps_list_bool_int(
+            "CheckpointFreq", default_input_variables_dict["CheckpointFreq"], self.RunSteps
         )
 
         # auto calculate the best CoordinatesFreq  for the number of self.RunSteps
-        self.CoordinatesFreq = scale_gen_freq_for_run_steps_list_bool_int(
-            default_input_variables_dict["CoordinatesFreq"], self.RunSteps
+        self.CoordinatesFreq = _scale_gen_freq_for_run_steps_list_bool_int(
+            "CoordinatesFreq", default_input_variables_dict["CoordinatesFreq"], self.RunSteps
         )
 
         # auto calculate the best DCDFreq for the number of self.RunSteps
-        self.DCDFreq = scale_gen_freq_for_run_steps_list_bool_int(
-            default_input_variables_dict["DCDFreq"], self.RunSteps
+        self.DCDFreq = _scale_gen_freq_for_run_steps_list_bool_int(
+            "DCDFreq", default_input_variables_dict["DCDFreq"], self.RunSteps
         )
 
         # auto calculate the best ConsoleFreq  for the number of self.RunSteps
-        self.ConsoleFreq = scale_gen_freq_for_run_steps_list_bool_int(
-            default_input_variables_dict["ConsoleFreq"], self.RunSteps
+        self.ConsoleFreq = _scale_gen_freq_for_run_steps_list_bool_int(
+            "ConsoleFreq", default_input_variables_dict["ConsoleFreq"], self.RunSteps
         )
 
         # auto calculate the best PressureCalc  for the number of self.RunSteps
-        self.PressureCalc = scale_gen_freq_for_run_steps_list_bool_int(
-            default_input_variables_dict["PressureCalc"], self.RunSteps
+        self.PressureCalc = _scale_gen_freq_for_run_steps_list_bool_int(
+            "PressureCalc", default_input_variables_dict["PressureCalc"], self.RunSteps
         )
 
         # auto calculate the best BlockAverageFreq  for the number of self.RunSteps
-        self.BlockAverageFreq = scale_gen_freq_for_run_steps_list_bool_int(
-            default_input_variables_dict["BlockAverageFreq"], self.RunSteps
+        self.BlockAverageFreq = _scale_gen_freq_for_run_steps_list_bool_int(
+            "BlockAverageFreq", default_input_variables_dict["BlockAverageFreq"], self.RunSteps
         )
 
         # auto calculate the best HistogramFreq  for the number of self.RunSteps
-        self.HistogramFreq = scale_gen_freq_for_run_steps_list_bool_int(
-            default_input_variables_dict["HistogramFreq"], self.RunSteps
+        self.HistogramFreq = _scale_gen_freq_for_run_steps_list_bool_int(
+            "HistogramFreq", default_input_variables_dict["HistogramFreq"], self.RunSteps
         )
 
         # auto calculate the best SampleFreq  for the number of self.RunSteps
-        self.SampleFreq = scale_gen_freq_for_run_steps_int(
-            default_input_variables_dict["SampleFreq"], self.RunSteps
+        self.SampleFreq = _scale_gen_freq_for_run_steps_int(
+            "SampleFreq", default_input_variables_dict["SampleFreq"], self.RunSteps
         )
 
         if input_variables_dict is None:
@@ -2879,7 +2879,12 @@ class GOMCControl:
             raise ValueError(print_error_message)
 
         # verify all input variable values are valid, for their keys
-        input_var_keys_list = dict_keys_to_list(self.input_variables_dict)
+        input_var_all_keys_list = dict_keys_to_list(self.input_variables_dict)
+        # sort to only values that are not None
+        input_var_keys_list = []
+        for all_keys_i in input_var_all_keys_list:
+            if self.input_variables_dict[all_keys_i] is not None:
+                input_var_keys_list.append(all_keys_i)
 
         possible_ensemble_variables_list = (
             _get_possible_ensemble_input_variables(self.ensemble_type)
@@ -6266,7 +6271,7 @@ class GOMCControl:
             bad_input_variables_values_list.append(key)
 
 
-def scale_gen_freq_for_run_steps_list_bool_int(charmm_variable, run_steps):
+def _scale_gen_freq_for_run_steps_list_bool_int(variable_name, charmm_variable, run_steps):
     """
     Scales the frequency of the output to a a more realistic value,
     if the output frequency does not make sense based on the
@@ -6274,6 +6279,8 @@ def scale_gen_freq_for_run_steps_list_bool_int(charmm_variable, run_steps):
 
     Parameters
     ----------
+    variable_name, str
+        The variable name as a sting, which is used for printing error outputs.
     charmm_variable : GOMCControl object variable list, [bool, int]
         This only for the frequency output variables of the GOMCControl object
     run_steps : int (>0), must be an integer greater than zero.
@@ -6286,6 +6293,22 @@ def scale_gen_freq_for_run_steps_list_bool_int(charmm_variable, run_steps):
         A rescaled and appropriate value for the frequency output variables of the
         GOMCControl object, based on the RunSteps in the simulation.
     """
+    if not isinstance(charmm_variable, list):
+        print_error_message = "ERROR: The {} variable is not a list.".format(variable_name)
+        raise ValueError(print_error_message)
+
+        if len(charmm_variable) != 2:
+            print_error_message = "ERROR: The {} variable list length is not 2.".format(variable_name)
+            raise ValueError(print_error_message)
+
+        else:
+            if not isinstance(charmm_variable[0], bool):
+                print_error_message = "ERROR: The {} variable is not a boolean.".format(variable_name)
+                raise ValueError(print_error_message)
+
+            if not isinstance(charmm_variable[1], int):
+                print_error_message = "ERROR: The {} variable is not a int.".format(variable_name)
+                raise ValueError(print_error_message)
 
     set_max_steps_charmm_variable = charmm_variable[1]
 
@@ -6299,7 +6322,7 @@ def scale_gen_freq_for_run_steps_list_bool_int(charmm_variable, run_steps):
     return charmm_variable
 
 
-def scale_gen_freq_for_run_steps_int(charmm_variable, run_steps):
+def _scale_gen_freq_for_run_steps_int(variable_name, charmm_variable, run_steps):
     """
     Scales the frequency of the output to a a more realistic value,
     if the output frequency does not make sense based on the
@@ -6307,6 +6330,8 @@ def scale_gen_freq_for_run_steps_int(charmm_variable, run_steps):
 
     Parameters
     ----------
+    variable_name, str
+        The variable name as a sting, which is used for printing error outputs.
     charmm_variable : GOMCControl object variable, int
         This only for the frequency output variables of the GOMCControl object
     run_steps : int (>0), must be an integer greater than zero.
@@ -6319,6 +6344,9 @@ def scale_gen_freq_for_run_steps_int(charmm_variable, run_steps):
         A rescaled and appropriate value for the frequency output variables of the
         GOMCControl object, based on the RunSteps in the simulation.
     """
+    if not isinstance(charmm_variable, int):
+        print_error_message = "ERROR: The {} variable is not an interger.".format(variable_name)
+        raise ValueError(print_error_message)
 
     set_max_steps_charmm_variable = charmm_variable
 

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -520,11 +520,11 @@ def _get_all_possible_input_variables(description=False):
         "The list provides the booleans to [block_averages_bool, console_output_bool]. "
         "This outputs the pressure data into the block averages and console output/log files."
         "".format(_get_default_variables_dict()["OutPressure"]),
-        "OutMolNumber": "Output Data (all ensembles): [bool, bool], default = {}.   "
+        "OutMolNum": "Output Data (all ensembles): [bool, bool], default = {}.   "
         "The list provides the booleans to [block_averages_bool, console_output_bool]. "
         "This outputs the number of molecules data into the block averages and console "
         "output/log files."
-        "".format(_get_default_variables_dict()["OutMolNumber"]),
+        "".format(_get_default_variables_dict()["OutMolNum"]),
         "OutDensity": "Output Data (all ensembles): [bool, bool], default = {}.   "
         "The list provides the booleans to [block_averages_bool, console_output_bool]. "
         "This outputs the density data into the block averages and console output/log files."
@@ -901,7 +901,7 @@ def _get_default_variables_dict():
         # Data output for the console and bulk properties calculations
         "OutEnergy": [True, True],
         "OutPressure": [True, True],
-        "OutMolNumber": [True, True],
+        "OutMolNum": [True, True],
         "OutDensity": [True, True],
         "OutVolume": [True, True],
         "OutSurfaceTension": [False, False],
@@ -1201,7 +1201,7 @@ def _get_possible_ensemble_input_variables(ensemble_type):
     output_data_variables_list = [
         "OutEnergy",
         "OutPressure",
-        "OutMolNumber",
+        "OutMolNum",
         "OutDensity",
         "OutVolume",
         "OutSurfaceTension",
@@ -1672,7 +1672,7 @@ class GOMCControl:
     OutPressure : [bool, bool], default = [True, True]
         The list provides the booleans to [block_averages_bool, console_output_bool].
         This outputs the pressure data into the block averages and console output/log files.
-    OutMolNumber : [bool, bool], default = [True, True]
+    OutMolNum : [bool, bool], default = [True, True]
         The list provides the booleans to [block_averages_bool, console_output_bool].
         This outputs the number of molecules data into the block averages and console
         output/log files.
@@ -2592,7 +2592,7 @@ class GOMCControl:
         self.RunLetter = default_input_variables_dict["RunLetter"]
         self.OutEnergy = default_input_variables_dict["OutEnergy"]
         self.OutPressure = default_input_variables_dict["OutPressure"]
-        self.OutMolNumber = default_input_variables_dict["OutMolNumber"]
+        self.OutMolNum = default_input_variables_dict["OutMolNum"]
         self.OutDensity = default_input_variables_dict["OutDensity"]
         self.OutVolume = default_input_variables_dict["OutVolume"]
         self.OutSurfaceTension = default_input_variables_dict[
@@ -3636,7 +3636,7 @@ class GOMCControl:
                 ):
                     self.OutPressure = self.input_variables_dict[key]
 
-            key = "OutMolNumber"
+            key = "OutMolNum"
             if input_var_keys_list[var_iter] == key:
                 self.ck_input_variable_list_bool_bool(
                     self.input_variables_dict,
@@ -3647,7 +3647,7 @@ class GOMCControl:
                     input_var_keys_list[var_iter] == key
                     and key in possible_ensemble_variables_list
                 ):
-                    self.OutMolNumber = self.input_variables_dict[key]
+                    self.OutMolNum = self.input_variables_dict[key]
 
             key = "OutDensity"
             if input_var_keys_list[var_iter] == key:
@@ -4572,6 +4572,7 @@ class GOMCControl:
             raise ValueError(print_error_message)
 
         # Check that RunSteps >= EqSteps >= AdjSteps
+        print('self.RunSteps = ' +str(self.RunSteps))
         if (
             self.RunSteps < self.EqSteps
             or self.RunSteps < self.AdjSteps
@@ -5470,9 +5471,9 @@ class GOMCControl:
         )
         data_control_file.write(
             "{:25s} {:10s} {:10s}\n".format(
-                "OutMolNumber",
-                str(self.OutMolNumber[0]),
-                str(self.OutMolNumber[1]),
+                "OutMolNum",
+                str(self.OutMolNum[0]),
+                str(self.OutMolNum[1]),
             )
         )
         data_control_file.write(
@@ -6929,7 +6930,7 @@ def write_gomc_control_file(
     OutPressure : [bool, bool], default = [True, True]
         The list provides the booleans to [block_averages_bool, console_output_bool].
         This outputs the pressure data into the block averages and console output/log files.
-    OutMolNumber : [bool, bool], default = [True, True]
+    OutMolNum : [bool, bool], default = [True, True]
         The list provides the booleans to [block_averages_bool, console_output_bool].
         This outputs the number of molecules data into the block averages and console
         output/log files.

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1381,7 +1381,7 @@ class GOMCControl:
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
         The details of the acceptable input variables for the selected
-        ensembles can be found by running this python workbook,
+        ensembles can be found by running the code below in python,
         >>> print_valid_ensemble_input_variables('GCMC', description = True)
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
@@ -2000,7 +2000,7 @@ class GOMCControl:
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
         The details of the acceptable input variables for the selected
-        ensembles can be found by running this python workbook,
+        ensembles can be found by running the code below in python,
         >>> print_valid_ensemble_input_variables('GCMC', description = True)
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
@@ -2127,16 +2127,15 @@ class GOMCControl:
             raise ValueError(print_error_message)
 
         # check if check_input_files_exist is a boolean
-        if check_input_files_exist is not None:
-            _check_if_bool("check_input_files_exist", check_input_files_exist)
+        _check_if_bool("check_input_files_exist", check_input_files_exist)
 
-        # set the restart attributes:
-        if Restart is not None:
-            _check_if_bool("Restart", Restart)
-            self.Restart = Restart
-        if RestartCheckpoint is not None:
-            _check_if_bool("RestartCheckpoint", RestartCheckpoint)
-            self.RestartCheckpoint = RestartCheckpoint
+        # set and check valid inputs for the Restart attribute
+        _check_if_bool("Restart", Restart)
+        self.Restart = Restart
+        
+        # set and check valid inputs for the RestartCheckpoint attribute
+        _check_if_bool("RestartCheckpoint", RestartCheckpoint)
+        self.RestartCheckpoint = RestartCheckpoint
 
         self.binCoordinates_box_0 = binCoordinates_box_0
         self.extendedSystem_box_0 = extendedSystem_box_0
@@ -2146,7 +2145,7 @@ class GOMCControl:
         self.binVelocities_box_1 = binVelocities_box_1
 
         # check if the binary restart files are provided correctly
-        if self.Restart is True and self.ensemble_type in ["NVT", "NPT"]:
+        if self.Restart and self.ensemble_type in ["NVT", "NPT"]:
             if (
                 self.binCoordinates_box_0 is not None
                 or self.extendedSystem_box_0 is not None
@@ -6639,7 +6638,7 @@ def write_gomc_control_file(
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
         The details of the acceptable input variables for the selected
-        ensembles can be found by running this python workbook,
+        ensembles can be found by running the code below in python,
         >>>print_valid_ensemble_input_variables('GCMC', description = True)
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
@@ -7257,7 +7256,7 @@ def write_gomc_control_file(
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
         The details of the acceptable input variables for the selected
-        ensembles can be found by running this python workbook,
+        ensembles can be found by running the code below in python,
         >>> print_valid_ensemble_input_variables('GCMC', description = True)
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -71,9 +71,9 @@ def _get_required_data(description=False):
         "charmm_object": "Charmm object, "
         "A Charmm object, which by definition has been parameterized "
         "from the selected force field.",
-        "ensemble_type": "Required files or System Info (all ensembles): str. "
+        "ensemble_type": "Required files or System Info (all ensembles): str, "
         "(valid strings are 'NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', or 'GCMC'), "
-        "the ensemble type for the simulation,",
+        "the ensemble type for the simulation.",
         "RunSteps": "Required files or System Info (all ensembles): int (> 0), "
         "The number or run steps for the simulation.",
         "Temperature": "Required files or System Info (all ensembles): float or integer (> 0), "

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -81,8 +81,8 @@ def _get_required_data(description=False):
         "ff_psf_pdb_file_directory": "str (optional), default=None (i.e., the current directory)."
         "The full or relative directory added to the force field, psf, and pdb"
         "file names, created via the Charmm object.",
-        "override_check_input_files_exist" : "bool (default = False) " 
-        "Override the check to see if the force field, psf, and pdb files exist. " 
+        "override_check_input_files_exist": "bool (default = False) "
+        "Override the check to see if the force field, psf, and pdb files exist. "
         "If the files are checked and do not exist, the writer will throw a ValueError."
         "True, check if the force field, psf, and pdb files exist."
         "False, do not check if the force field, psf, and pdb files exist.",
@@ -2047,11 +2047,16 @@ class GOMCControl:
         self.RunSteps = RunSteps
         self.Temperature = Temperature
         self.ff_psf_pdb_file_directory = ff_psf_pdb_file_directory
-        if not isinstance(self.ff_psf_pdb_file_directory, str) and self.ff_psf_pdb_file_directory is not None:
+        if (
+            not isinstance(self.ff_psf_pdb_file_directory, str)
+            and self.ff_psf_pdb_file_directory is not None
+        ):
             self.input_error = True
             print_error_message = (
                 r"ERROR: The ff_psf_pdb_file_directory variable for modifying the FF, pdb, "
-                r"and psf file directories is a {} and not a string.".format(type(self.ff_psf_pdb_file_directory))
+                r"and psf file directories is a {} and not a string.".format(
+                    type(self.ff_psf_pdb_file_directory)
+                )
             )
             raise TypeError(print_error_message)
 
@@ -2062,14 +2067,16 @@ class GOMCControl:
             if self.ff_psf_pdb_file_directory is None:
                 self.ff_filename = charmm_object.ff_filename
             else:
-                self.ff_filename = "{}/{}".format(self.ff_psf_pdb_file_directory,
-                                                  charmm_object.ff_filename,
-                                                  )
+                self.ff_filename = "{}/{}".format(
+                    self.ff_psf_pdb_file_directory,
+                    charmm_object.ff_filename,
+                )
             # check if the FF file exist:
-            _check_if_input_files_exist(self.ff_filename,
-                                        "force field file or parameter file",
-                                        override_check_input_files_exist=override_check_input_files_exist,
-                                        )
+            _check_if_input_files_exist(
+                self.ff_filename,
+                "force field file or parameter file",
+                override_check_input_files_exist=override_check_input_files_exist,
+            )
         elif (
             charmm_object.ff_filename is None
             or isinstance(charmm_object.ff_filename, str) is False
@@ -2090,44 +2097,60 @@ class GOMCControl:
             and isinstance(charmm_object.filename_box_0, str) is True
         ):
             if self.ff_psf_pdb_file_directory is None:
-                self.Coordinates_box_0 = "{}.pdb".format(charmm_object.filename_box_0)
-                self.Structures_box_0 = "{}.psf".format(charmm_object.filename_box_0)
+                self.Coordinates_box_0 = "{}.pdb".format(
+                    charmm_object.filename_box_0
+                )
+                self.Structures_box_0 = "{}.psf".format(
+                    charmm_object.filename_box_0
+                )
             else:
-                self.Coordinates_box_0 = "{}/{}.pdb".format(self.ff_psf_pdb_file_directory,
-                                                            charmm_object.filename_box_0)
-                self.Structures_box_0 = "{}/{}.psf".format(self.ff_psf_pdb_file_directory,
-                                                           charmm_object.filename_box_0)
+                self.Coordinates_box_0 = "{}/{}.pdb".format(
+                    self.ff_psf_pdb_file_directory, charmm_object.filename_box_0
+                )
+                self.Structures_box_0 = "{}/{}.psf".format(
+                    self.ff_psf_pdb_file_directory, charmm_object.filename_box_0
+                )
 
-            _check_if_input_files_exist(self.Coordinates_box_0,
-                                        "box 0 pdb file",
-                                        override_check_input_files_exist=override_check_input_files_exist,
-                                        )
-            _check_if_input_files_exist(self.Structures_box_0,
-                                        "box 0 psf file",
-                                        override_check_input_files_exist=override_check_input_files_exist,
-                                        )
+            _check_if_input_files_exist(
+                self.Coordinates_box_0,
+                "box 0 pdb file",
+                override_check_input_files_exist=override_check_input_files_exist,
+            )
+            _check_if_input_files_exist(
+                self.Structures_box_0,
+                "box 0 psf file",
+                override_check_input_files_exist=override_check_input_files_exist,
+            )
 
         if (
             charmm_object.filename_box_1 is not None
             and isinstance(charmm_object.filename_box_1, str) is True
         ):
             if self.ff_psf_pdb_file_directory is None:
-                self.Coordinates_box_1 = "{}.pdb".format(charmm_object.filename_box_1)
-                self.Structures_box_1 = "{}.psf".format(charmm_object.filename_box_1)
+                self.Coordinates_box_1 = "{}.pdb".format(
+                    charmm_object.filename_box_1
+                )
+                self.Structures_box_1 = "{}.psf".format(
+                    charmm_object.filename_box_1
+                )
             else:
-                self.Coordinates_box_1 = "{}/{}.pdb".format(self.ff_psf_pdb_file_directory,
-                                                            charmm_object.filename_box_1)
-                self.Structures_box_1 = "{}/{}.psf".format(self.ff_psf_pdb_file_directory,
-                                                           charmm_object.filename_box_1)
+                self.Coordinates_box_1 = "{}/{}.pdb".format(
+                    self.ff_psf_pdb_file_directory, charmm_object.filename_box_1
+                )
+                self.Structures_box_1 = "{}/{}.psf".format(
+                    self.ff_psf_pdb_file_directory, charmm_object.filename_box_1
+                )
 
-            _check_if_input_files_exist(self.Coordinates_box_1,
-                                        "box 1 pdb file",
-                                        override_check_input_files_exist=override_check_input_files_exist,
-                                        )
-            _check_if_input_files_exist(self.Structures_box_1,
-                                        "box 1 psf file",
-                                        override_check_input_files_exist=override_check_input_files_exist,
-                                        )
+            _check_if_input_files_exist(
+                self.Coordinates_box_1,
+                "box 1 pdb file",
+                override_check_input_files_exist=override_check_input_files_exist,
+            )
+            _check_if_input_files_exist(
+                self.Structures_box_1,
+                "box 1 psf file",
+                override_check_input_files_exist=override_check_input_files_exist,
+            )
 
         else:
             self.Coordinates_box_1 = None
@@ -6011,6 +6034,7 @@ def ck_box_dim_is_float_or_int_greater_0(
 
     return None
 
+
 def _check_box_vectors_char_limit(vectors, char_limit):
     """
     Checks to see if the vectors exceed the specified character limit
@@ -6036,9 +6060,12 @@ def _check_box_vectors_char_limit(vectors, char_limit):
                 return False
     return True
 
-def _check_if_input_files_exist(file_directory_and_name,
-                                type_of_file,
-                                override_check_input_files_exist=False):
+
+def _check_if_input_files_exist(
+    file_directory_and_name,
+    type_of_file,
+    override_check_input_files_exist=False,
+):
     """
     Checks to see if the vectors exceed the specified character limit
 
@@ -6059,12 +6086,16 @@ def _check_if_input_files_exist(file_directory_and_name,
     If the file exists : None
     If the file does not exist : raise ValueError
     """
-    if os.path.isfile(file_directory_and_name) is False and override_check_input_files_exist is False:
-        print_error_message = ("The {} with the file directory and name {}, "
-                               "does not exist.".format(type_of_file,
-                                                       file_directory_and_name)
-                               )
+    if (
+        os.path.isfile(file_directory_and_name) is False
+        and override_check_input_files_exist is False
+    ):
+        print_error_message = (
+            "The {} with the file directory and name {}, "
+            "does not exist.".format(type_of_file, file_directory_and_name)
+        )
         raise ValueError(print_error_message)
+
 
 # user callable function to write the GOMC control file
 def write_gomc_control_file(
@@ -6793,7 +6824,6 @@ def write_gomc_control_file(
         ff_psf_pdb_file_directory=ff_psf_pdb_file_directory,
         override_check_input_files_exist=override_check_input_files_exist,
         input_variables_dict=input_variables_dict,
-
     )
     test_gomc_control_write_conf_file = gomc_control.write_conf_file(
         conf_filename

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2795,7 +2795,7 @@ class GOMCControl:
         if self.ensemble_type in ["NVT", "NPT"]:
             if (
                 len(required_data_list) != 3
-                or os.path.splitext(self.ff_filename)[1] != ".inp"
+                or os.path.splitext(self.ff_filename)[1] not in [".inp", ".par"]
                 or os.path.splitext(self.Coordinates_box_0)[1] != ".pdb"
                 or os.path.splitext(self.Structure_box_0)[1] != ".psf"
             ):
@@ -2803,7 +2803,7 @@ class GOMCControl:
                 print_error_message = (
                     "ERROR: The proper force field, PDB, and psf files were not provided, "
                     "or at least their extentions are not correct "
-                    "(i.e., not .inp, .pdb, or .psf). Or box 1 PSF and PDB files were "
+                    "(i.e., not .inp, .par, .pdb, or .psf). Or box 1 PSF and PDB files were "
                     "provided for the NVT or NPT simulations, which is not allowed"
                 )
                 raise ValueError(print_error_message)
@@ -2817,25 +2817,20 @@ class GOMCControl:
         if self.ensemble_type in ["GEMC_NVT", "GEMC_NPT", "GCMC"]:
             if (
                 len(required_data_list) != 5
-                or os.path.splitext(self.ff_filename)[1] != ".inp"
+                or os.path.splitext(self.ff_filename)[1] not in [".inp", ".par"]
                 or os.path.splitext(self.Coordinates_box_0)[1] != ".pdb"
                 or os.path.splitext(self.Structure_box_0)[1] != ".psf"
                 or os.path.splitext(self.Coordinates_box_1)[1] != ".pdb"
                 or os.path.splitext(self.Structure_box_1)[1] != ".psf"
             ):
-                warn(
-                    "ERROR: The proper force field, PDB, and psf files were not provided, "
-                    "or at least their extentions are not correct "
-                    "(i.e., not .inp, .pdb, or .psf). Or box 1 PSF and PDB files were not provided "
-                    "for the GEMC_NVT, GEMC_NPT or GCMC simulations, which is not allowed"
-                )
-                self.input_error = True
                 print_error_message = (
                     "ERROR: The proper force field, PDB, and psf files were not provided, "
                     "or at least their extentions are not correct "
-                    "(i.e., not .inp, .pdb, or .psf). Or box 1 PSF and PDB files were not provided "
+                    "(i.e., not .inp, .par, .pdb, or .psf). Or box 1 PSF and PDB files were not provided "
                     "for the GEMC_NVT, GEMC_NPT or GCMC simulations, which is not allowed"
                 )
+                self.input_error = True
+                print_error_message = (print_error_message)
                 raise ValueError(print_error_message)
         else:
             print(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2192,11 +2192,14 @@ class GOMCControl:
                 )
                 raise ValueError(print_error_message)
 
-            if (
-                self.binCoordinates_box_0 is None
-                or self.extendedSystem_box_0 is None
-                or self.binCoordinates_box_1 is None
-                or self.extendedSystem_box_1 is None
+            elif (
+                    self.binVelocities_box_0 is not None
+                    or self.binVelocities_box_1 is not None
+            ) and (
+                    self.binCoordinates_box_0 is None
+                    or self.extendedSystem_box_0 is None
+                    or self.binCoordinates_box_1 is None
+                    or self.extendedSystem_box_1 is None
             ):
                 print_error_message = (
                     'ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the '
@@ -2270,26 +2273,30 @@ class GOMCControl:
                     "pdb",
                     expected_file_extension=[".pdb"],
                 )
-                _check_if_string_and_extension(
-                    "Structure_box_0",
-                    Structure_box_0,
-                    "psf",
-                    expected_file_extension=[".psf"],
-                )
                 self.Coordinates_box_0 = Coordinates_box_0
-                self.Structures_box_0 = Structure_box_0
             elif self.ff_psf_pdb_file_directory is None:
                 self.Coordinates_box_0 = "{}.pdb".format(
-                    charmm_object.filename_box_0
-                )
-                self.Structures_box_0 = "{}.psf".format(
                     charmm_object.filename_box_0
                 )
             else:
                 self.Coordinates_box_0 = "{}/{}.pdb".format(
                     self.ff_psf_pdb_file_directory, charmm_object.filename_box_0
                 )
-                self.Structures_box_0 = "{}/{}.psf".format(
+
+            if Structure_box_0 is not None:
+                _check_if_string_and_extension(
+                    "Structure_box_0",
+                    Structure_box_0,
+                    "psf",
+                    expected_file_extension=[".psf"],
+                )
+                self.Structure_box_0 = Structure_box_0
+            elif self.ff_psf_pdb_file_directory is None:
+                self.Structure_box_0 = "{}.psf".format(
+                    charmm_object.filename_box_0
+                )
+            else:
+                self.Structure_box_0 = "{}/{}.psf".format(
                     self.ff_psf_pdb_file_directory, charmm_object.filename_box_0
                 )
 
@@ -2299,7 +2306,7 @@ class GOMCControl:
                 check_input_files_exist=check_input_files_exist,
             )
             _check_if_input_files_exist(
-                self.Structures_box_0,
+                self.Structure_box_0,
                 "box 0 psf file",
                 check_input_files_exist=check_input_files_exist,
             )
@@ -2316,7 +2323,7 @@ class GOMCControl:
                     expected_file_extension=[".coor"],
                 )
                 _check_if_string_and_extension(
-                    "Structure_box_0",
+                    "extendedSystem_box_0",
                     self.extendedSystem_box_0,
                     "xsc",
                     expected_file_extension=[".xsc"],
@@ -2356,26 +2363,32 @@ class GOMCControl:
                     "pdb",
                     expected_file_extension=[".pdb"],
                 )
+                self.Coordinates_box_1 = Coordinates_box_1
+
+            elif self.ff_psf_pdb_file_directory is None:
+                self.Coordinates_box_1 = "{}.pdb".format(
+                    charmm_object.filename_box_1
+                )
+
+            else:
+                self.Coordinates_box_1 = "{}/{}.pdb".format(
+                    self.ff_psf_pdb_file_directory, charmm_object.filename_box_1
+                )
+
+            if Structure_box_1 is not None:
                 _check_if_string_and_extension(
                     "Structure_box_1",
                     Structure_box_1,
                     "psf",
                     expected_file_extension=[".psf"],
                 )
-                self.Coordinates_box_1 = Coordinates_box_1
-                self.Structures_box_1 = Structure_box_1
+                self.Structure_box_1 = Structure_box_1
             elif self.ff_psf_pdb_file_directory is None:
-                self.Coordinates_box_1 = "{}.pdb".format(
-                    charmm_object.filename_box_1
-                )
-                self.Structures_box_1 = "{}.psf".format(
+                self.Structure_box_1 = "{}.psf".format(
                     charmm_object.filename_box_1
                 )
             else:
-                self.Coordinates_box_1 = "{}/{}.pdb".format(
-                    self.ff_psf_pdb_file_directory, charmm_object.filename_box_1
-                )
-                self.Structures_box_1 = "{}/{}.psf".format(
+                self.Structure_box_1 = "{}/{}.psf".format(
                     self.ff_psf_pdb_file_directory, charmm_object.filename_box_1
                 )
 
@@ -2385,7 +2398,7 @@ class GOMCControl:
                 check_input_files_exist=check_input_files_exist,
             )
             _check_if_input_files_exist(
-                self.Structures_box_1,
+                self.Structure_box_1,
                 "box 1 psf file",
                 check_input_files_exist=check_input_files_exist,
             )
@@ -2402,7 +2415,7 @@ class GOMCControl:
                     expected_file_extension=[".coor"],
                 )
                 _check_if_string_and_extension(
-                    "Structure_box_1",
+                    "extendedSystem_box_1",
                     self.extendedSystem_box_1,
                     "xsc",
                     expected_file_extension=[".xsc"],
@@ -2433,7 +2446,7 @@ class GOMCControl:
 
         else:
             self.Coordinates_box_1 = None
-            self.Structures_box_1 = None
+            self.Structure_box_1 = None
 
         self.coul_1_4 = charmm_object.coul_1_4
         self.input_variables_dict = input_variables_dict
@@ -2490,7 +2503,7 @@ class GOMCControl:
         if (
             self.ensemble_type in ["NVT", "NPT"]
             and self.Coordinates_box_1 is not None
-            and self.Structures_box_1 is not None
+            and self.Structure_box_1 is not None
         ):
             self.input_error = True
             print_error_message = (
@@ -2504,7 +2517,7 @@ class GOMCControl:
         if (
             self.ensemble_type in ["GEMC_NVT", "GEMC_NPT", "GCMC"]
             and self.Coordinates_box_1 is None
-            and self.Structures_box_1 is None
+            and self.Structure_box_1 is None
         ):
             self.input_error = True
             print_error_message = (
@@ -2771,20 +2784,20 @@ class GOMCControl:
         required_data_list = [
             self.ff_filename,
             self.Coordinates_box_0,
-            self.Structures_box_0,
+            self.Structure_box_0,
         ]
 
         if self.Coordinates_box_1 is not None:
             required_data_list.append(self.Coordinates_box_1)
-        if self.Structures_box_1 is not None:
-            required_data_list.append(self.Structures_box_1)
+        if self.Structure_box_1 is not None:
+            required_data_list.append(self.Structure_box_1)
 
         if self.ensemble_type in ["NVT", "NPT"]:
             if (
                 len(required_data_list) != 3
                 or os.path.splitext(self.ff_filename)[1] != ".inp"
                 or os.path.splitext(self.Coordinates_box_0)[1] != ".pdb"
-                or os.path.splitext(self.Structures_box_0)[1] != ".psf"
+                or os.path.splitext(self.Structure_box_0)[1] != ".psf"
             ):
                 self.input_error = True
                 print_error_message = (
@@ -2806,9 +2819,9 @@ class GOMCControl:
                 len(required_data_list) != 5
                 or os.path.splitext(self.ff_filename)[1] != ".inp"
                 or os.path.splitext(self.Coordinates_box_0)[1] != ".pdb"
-                or os.path.splitext(self.Structures_box_0)[1] != ".psf"
+                or os.path.splitext(self.Structure_box_0)[1] != ".psf"
                 or os.path.splitext(self.Coordinates_box_1)[1] != ".pdb"
-                or os.path.splitext(self.Structures_box_1)[1] != ".psf"
+                or os.path.splitext(self.Structure_box_1)[1] != ".psf"
             ):
                 warn(
                     "ERROR: The proper force field, PDB, and psf files were not provided, "
@@ -4871,11 +4884,11 @@ class GOMCControl:
         data_control_file.write("####################################\n")
         if self.ensemble_type in ["NVT", "NPT", "GEMC_NPT", "GEMC_NVT", "GCMC"]:
             data_control_file.write(
-                "{:25s} {}\n".format("Structure 0", self.Structures_box_0)
+                "{:25s} {}\n".format("Structure 0", self.Structure_box_0)
             )
         if self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]:
             data_control_file.write(
-                "{:25s} {}\n".format("Structure 1", self.Structures_box_1)
+                "{:25s} {}\n".format("Structure 1", self.Structure_box_1)
             )
 
         if (

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -6472,11 +6472,14 @@ def _check_if_string_and_extension(
             file_directory_and_name_variable
         )[-1]
         if acutal_file_extension not in expected_file_extension:
-            print_error_message = r'ERROR: The {} variable expects a file extension of {}, ' \
-                                  r'but the actual file extension is "{}". ' r"".format(
-                file_directory_and_name,
-                expected_file_extension,
-                acutal_file_extension,
+            print_error_message = (
+                r"ERROR: The {} variable expects a file extension of {}, "
+                r'but the actual file extension is "{}". '
+                r"".format(
+                    file_directory_and_name,
+                    expected_file_extension,
+                    acutal_file_extension,
+                )
             )
             raise TypeError(print_error_message)
 

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1742,7 +1742,7 @@ class GOMCControl:
         rotated or displaced simultaneously, along the calculated torque or force
         respectively (i.e., fraction of multi-particle moves).
     IntraMEMC_1Freq : int or float (0 <= value <= 1), default are specific for each ensemble
-    {'NVT': 0.0, 'NPT': 0.0, 'GEMC_NVT': 0.0, 'GEMC_NPT': 0.0, 'GCMC': 0.0}
+        {'NVT': 0.0, 'NPT': 0.0, 'GEMC_NVT': 0.0, 'GEMC_NPT': 0.0, 'GCMC': 0.0}
         Fractional percentage at which specified number of small molecule kind will be
         exchanged with a specified large molecule kind in defined sub-volume within
         same simulation box.  This move need additional information such as
@@ -1894,7 +1894,9 @@ class GOMCControl:
         This error is typically incurred from an error in the user input values.
         However, it could also be due to a bug, provided the user is inputting
         the data as this Class intends.
-    all_failed_input_List
+    all_failed_input_List : list
+        A list of all the inputs that failed, but there may be some inputs that
+        are not possible to put on this list.
     ensemble_typ : str, ['NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', 'GCMC']
         The ensemble type of the simulation.
     RunSteps : int (>0), must be an integer greater than zero.
@@ -1936,7 +1938,7 @@ class GOMCControl:
         GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
         simulation, the value will be None.
     Structures_box_1 : str or None
-    The structure file or PSF file for box 1 in the simulation.  This is only for
+        The structure file or PSF file for box 1 in the simulation.  This is only for
         GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
         simulation, the value will be None.
     box_0_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
@@ -1962,7 +1964,6 @@ class GOMCControl:
         Any of the input variables keys is also an Attribute and can be called
         the same way.  Please see the input_variables_dict keys in the
         Parameters section above for all the available attributes.
-
 
     Notes
     -------
@@ -6552,7 +6553,7 @@ def write_gomc_control_file(
         rotated or displaced simultaneously, along the calculated torque or force
         respectively (i.e., fraction of multi-particle moves).
     IntraMEMC_1Freq : int or float (0 <= value <= 1), default are specific for each ensemble
-    {'NVT': 0.0, 'NPT': 0.0, 'GEMC_NVT': 0.0, 'GEMC_NPT': 0.0, 'GCMC': 0.0}
+        {'NVT': 0.0, 'NPT': 0.0, 'GEMC_NVT': 0.0, 'GEMC_NPT': 0.0, 'GCMC': 0.0}
         Fractional percentage at which specified number of small molecule kind will be
         exchanged with a specified large molecule kind in defined sub-volume within
         same simulation box.  This move need additional information such as
@@ -6704,7 +6705,8 @@ def write_gomc_control_file(
             This error is typically incurred from an error in the user input values.
             However, it could also be due to a bug, provided the user is inputting
             the data as this Class intends.
-        all_failed_input_List
+        all_failed_input_List : list
+            A list of all the inputs that failed, but there may be some inputs that
         ensemble_typ : str, ['NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', 'GCMC']
             The ensemble type of the simulation.
         RunSteps : int (>0), must be an integer greater than zero.
@@ -6746,7 +6748,7 @@ def write_gomc_control_file(
             GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
             simulation, the value will be None.
         Structures_box_1 : str or None
-        The structure file or PSF file for box 1 in the simulation.  This is only for
+            The structure file or PSF file for box 1 in the simulation.  This is only for
             GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
             simulation, the value will be None.
         box_0_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
@@ -6772,7 +6774,6 @@ def write_gomc_control_file(
             Any of the input variables keys is also an Attribute and can be called
             the same way.  Please see the input_variables_dict keys in the
             Parameters section above for all the available attributes.
-
 
     Notes
     -------

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -981,7 +981,7 @@ def _get_default_variables_dict():
 def check_valid_ensemble_files(ensemble_type, testing_ensemble_files_list):
     """
     Checks if all the required ensemble inputs are provided,
-        and provides a list of the bad variables in the printed output.
+    and provides a list of the bad variables in the printed output.
 
     Parameters
     ----------
@@ -1066,7 +1066,7 @@ def check_valid_ensemble_input_variables(
 ):
     """
     Checks if all the input variables (user optional) inputs are valid for the given
-        ensemble, and provides a list of the bad variables in the printed output.
+    ensemble, and provides a list of the bad variables in the printed output.
 
     Parameters
     ----------

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2830,7 +2830,7 @@ class GOMCControl:
                     "for the GEMC_NVT, GEMC_NPT or GCMC simulations, which is not allowed"
                 )
                 self.input_error = True
-                print_error_message = (print_error_message)
+                print_error_message = print_error_message
                 raise ValueError(print_error_message)
         else:
             print(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -6700,79 +6700,79 @@ def write_gomc_control_file(
 
     Attributes
     ----------
-        input_error : bool
-            This error is typically incurred from an error in the user input values.
-            However, it could also be due to a bug, provided the user is inputting
-            the data as this Class intends.
-        all_failed_input_List : list
-            A list of all the inputs that failed, but there may be some inputs that
-        ensemble_typ : str, ['NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', 'GCMC']
-            The ensemble type of the simulation.
-        RunSteps : int (>0), must be an integer greater than zero.
-            Sets the total number of simulation steps.
-        Temperature : float or int (>0), must be an integer greater than zero.
-            Temperature of system in Kelvin (K)
-        ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
-            The full or relative directory added to the force field, psf, and pdb
-            file names, created via the Charmm object.
-        override_check_input_files_exist : bool (default = False)
-            Override the check to see if the force field, psf, and pdb files exist.
-            If the files are checked and do not exist, the writer will throw a ValueError.
-            True, check if the force field, psf, and pdb files exist.
-            False, do not check if the force field, psf, and pdb files exist.
-        input_variables_dict: dict, default = None
-            These input variables are optional and override the default settings.
-            Changing these variables likely required for more advanced systems.
-            The details of the acceptable input variables for the selected
-            ensembles can be found by running this python workbook,
-            >>> print_valid_ensemble_input_variables('GCMC', description = True)
-            which prints the input_variables with their subsection description
-            for the selected 'GCMC' ensemble (other ensembles can be set as well).
-            Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,
-            'ParaTypeCHARMM' : True }
-        conf_filename : str
-            The name of the GOMC contol file, which will be created.  The extension
-            of the GOMC control file can be .conf, or no extension can be provided.
-            If no extension is provided, this writer will automatically add the
-            .conf extension to the provided string.
-        Coordinates_box_0 : str
-            The coordinate or PDB file for box 0 in the simulation.
-        Coordinates_box_1 : str or None
-            The coordinate or PDB file for box 1 in the simulation.  This is only for
-            GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-            simulation, the value will be None.
-        Structures_box_0 : str
-            The structure file or PSF file for box 0 in the simulation.
-            The coordinate or PDB file for box 1 in the simulation.  This is only for
-            GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-            simulation, the value will be None.
-        Structures_box_1 : str or None
-            The structure file or PSF file for box 1 in the simulation.  This is only for
-            GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-            simulation, the value will be None.
-        box_0_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
-            Three (3) sets vectors for box 0 each with 3 float values, which represent
-            the vectors for the Charmm-style systems (units in Angstroms (Ang))
-        box_1_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
-            Three (3) sets vectors for box 1 each with 3 float values, which represent
-            the vectors for the Charmm-style systems (units in Angstroms (Ang))
-        coul_1_4 : float or int
-            The non-bonded 1-4 coulombic scaling factor, which is the
-            same for all the residues/molecules, regardless if
-            differenct force fields are utilized.
-        residues : list, [str, ..., str]
-            Labels of unique residues in the Compound. Residues are assigned by
-            checking against Compound.name.  Only supply residue names as 4 character
-            strings, as the residue names are truncated to 4 characters to fit in the
-            psf and pdb file.
-        all_res_unique_atom_name_dict : dict, {str : [str, ..., str]}
-            A dictionary that provides the residue names (keys) and a list
-            of the unique atom names in the residue (value), for the
-            combined structures (box 0 and box 1 (if supplied)).
-        any input_variables_dict key : varies (see each input_variables_dict key and value)
-            Any of the input variables keys is also an Attribute and can be called
-            the same way.  Please see the input_variables_dict keys in the
-            Parameters section above for all the available attributes.
+    input_error : bool
+        This error is typically incurred from an error in the user input values.
+        However, it could also be due to a bug, provided the user is inputting
+        the data as this Class intends.
+    all_failed_input_List : list
+        A list of all the inputs that failed, but there may be some inputs that
+    ensemble_typ : str, ['NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', 'GCMC']
+        The ensemble type of the simulation.
+    RunSteps : int (>0), must be an integer greater than zero.
+        Sets the total number of simulation steps.
+    Temperature : float or int (>0), must be an integer greater than zero.
+        Temperature of system in Kelvin (K)
+    ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
+        The full or relative directory added to the force field, psf, and pdb
+        file names, created via the Charmm object.
+    override_check_input_files_exist : bool (default = False)
+        Override the check to see if the force field, psf, and pdb files exist.
+        If the files are checked and do not exist, the writer will throw a ValueError.
+        True, check if the force field, psf, and pdb files exist.
+        False, do not check if the force field, psf, and pdb files exist.
+    input_variables_dict: dict, default = None
+        These input variables are optional and override the default settings.
+        Changing these variables likely required for more advanced systems.
+        The details of the acceptable input variables for the selected
+        ensembles can be found by running this python workbook,
+        >>> print_valid_ensemble_input_variables('GCMC', description = True)
+        which prints the input_variables with their subsection description
+        for the selected 'GCMC' ensemble (other ensembles can be set as well).
+        Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,
+        'ParaTypeCHARMM' : True }
+    conf_filename : str
+        The name of the GOMC contol file, which will be created.  The extension
+        of the GOMC control file can be .conf, or no extension can be provided.
+        If no extension is provided, this writer will automatically add the
+        .conf extension to the provided string.
+    Coordinates_box_0 : str
+        The coordinate or PDB file for box 0 in the simulation.
+    Coordinates_box_1 : str or None
+        The coordinate or PDB file for box 1 in the simulation.  This is only for
+        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
+        simulation, the value will be None.
+    Structures_box_0 : str
+        The structure file or PSF file for box 0 in the simulation.
+        The coordinate or PDB file for box 1 in the simulation.  This is only for
+        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
+        simulation, the value will be None.
+    Structures_box_1 : str or None
+        The structure file or PSF file for box 1 in the simulation.  This is only for
+        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
+        simulation, the value will be None.
+    box_0_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
+        Three (3) sets vectors for box 0 each with 3 float values, which represent
+        the vectors for the Charmm-style systems (units in Angstroms (Ang))
+    box_1_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
+        Three (3) sets vectors for box 1 each with 3 float values, which represent
+        the vectors for the Charmm-style systems (units in Angstroms (Ang))
+    coul_1_4 : float or int
+        The non-bonded 1-4 coulombic scaling factor, which is the
+        same for all the residues/molecules, regardless if
+        differenct force fields are utilized.
+    residues : list, [str, ..., str]
+        Labels of unique residues in the Compound. Residues are assigned by
+        checking against Compound.name.  Only supply residue names as 4 character
+        strings, as the residue names are truncated to 4 characters to fit in the
+        psf and pdb file.
+    all_res_unique_atom_name_dict : dict, {str : [str, ..., str]}
+        A dictionary that provides the residue names (keys) and a list
+        of the unique atom names in the residue (value), for the
+        combined structures (box 0 and box 1 (if supplied)).
+    any input_variables_dict key : varies (see each input_variables_dict key and value)
+        Any of the input variables keys is also an Attribute and can be called
+        the same way.  Please see the input_variables_dict keys in the
+        Parameters section above for all the available attributes.
 
     Notes
     -------

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -86,6 +86,16 @@ def _get_required_data(description=False):
         "If the files are checked and do not exist, the writer will throw a ValueError."
         "True, check if the force field, psf, and pdb files exist."
         "False, do not check if the force field, psf, and pdb files exist.",
+        "override_ff_directory_filename": "str, (default = None)"
+        "Override all other force field directory and filename inputs.",
+        "override_box_0_pdb_directory_filename": "str, (default = None)"
+        "Override all other box 0 pdb directory and filename inputs.",
+        "override_box_0_psf_directory_filename": "str, (default = None)"
+        "Override all other box 0 psf directory and filename inputs.",
+        "override_box_1_pdb_directory_filename": "str, (default = None)"
+        "Override all other box 1 pdb directory and filename inputs.",
+        "override_box_1_psf_directory_filename": "str, (default = None)"
+        "Override all other box 1 psf directory and filename inputs.",
     }
 
     if description:
@@ -1326,11 +1336,21 @@ class GOMCControl:
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_files_exist : bool, (default = False)
+    override_check_files_inputs_exist : bool, (default = False)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
+    override_ff_directory_filename : str, (default = None)
+        Override all other force field directory and filename inputs.
+    override_box_0_pdb_directory_filename : str, (default = None)
+        Override all other box 0 pdb directory and filename inputs.
+    override_box_0_psf_directory_filename : str, (default = None)
+        Override all other box 0 psf directory and filename inputs.
+    override_box_1_pdb_directory_filename : str, (default = None)
+        Override all other box 1 pdb directory and filename inputs.
+    override_box_1_psf_directory_filename : str, (default = None)
+        Override all other box 1  psf directory and filename inputs.
     input_variables_dict: dict, default = None
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
@@ -1906,11 +1926,21 @@ class GOMCControl:
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_files_exist : bool, (default = False)
+    override_check_files_inputs_exist : bool, (default = False)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
+    override_ff_directory_filename : str, (default = None)
+        Override all other force field directory and filename inputs.
+    override_box_0_pdb_directory_filename : str, (default = None)
+        Override all other box 0 pdb directory and filename inputs.
+    override_box_0_psf_directory_filename : str, (default = None)
+        Override all other box 0 psf directory and filename inputs.
+    override_box_1_pdb_directory_filename : str, (default = None)
+        Override all other box 1 pdb directory and filename inputs.
+    override_box_1_psf_directory_filename : str, (default = None)
+        Override all other box 1  psf directory and filename inputs.
     input_variables_dict: dict, default = None
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
@@ -2009,6 +2039,11 @@ class GOMCControl:
         Temperature,
         ff_psf_pdb_file_directory=None,
         override_check_input_files_exist=False,
+        override_ff_directory_filename=None,
+        override_box_0_pdb_directory_filename=None,
+        override_box_0_psf_directory_filename=None,
+        override_box_1_pdb_directory_filename=None,
+        override_box_1_psf_directory_filename=None,
         input_variables_dict=None,
     ):
 
@@ -2052,20 +2087,20 @@ class GOMCControl:
             not isinstance(self.ff_psf_pdb_file_directory, str)
             and self.ff_psf_pdb_file_directory is not None
         ):
-            self.input_error = True
-            print_error_message = (
-                r"ERROR: The ff_psf_pdb_file_directory variable for modifying the FF, pdb, "
-                r"and psf file directories is a {} and not a string.".format(
-                    type(self.ff_psf_pdb_file_directory)
-                )
-            )
-            raise TypeError(print_error_message)
+            _check_if_string('ff_psf_pdb_file_directory',
+                             self.ff_psf_pdb_file_directory,
+                             'force field, pdb, and psf')
 
         if (
             charmm_object.ff_filename is not None
             and isinstance(charmm_object.ff_filename, str) is True
         ):
-            if self.ff_psf_pdb_file_directory is None:
+            if override_ff_directory_filename is not None:
+                _check_if_string('override_ff_directory_filename',
+                                 override_ff_directory_filename,
+                                 'force field')
+                self.ff_filename = override_ff_directory_filename
+            elif self.ff_psf_pdb_file_directory is None:
                 self.ff_filename = charmm_object.ff_filename
             else:
                 self.ff_filename = "{}/{}".format(
@@ -2097,7 +2132,16 @@ class GOMCControl:
             charmm_object.filename_box_0 is not None
             and isinstance(charmm_object.filename_box_0, str) is True
         ):
-            if self.ff_psf_pdb_file_directory is None:
+            if override_box_0_pdb_directory_filename is not None:
+                _check_if_string('override_box_0_pdb_directory_filename',
+                                 override_box_0_pdb_directory_filename,
+                                 'pdb')
+                _check_if_string('override_box_0_psf_directory_filename',
+                                 override_box_0_psf_directory_filename,
+                                 'psf')
+                self.Coordinates_box_0 = override_box_0_pdb_directory_filename
+                self.Structures_box_0 = override_box_0_psf_directory_filename
+            elif self.ff_psf_pdb_file_directory is None:
                 self.Coordinates_box_0 = "{}.pdb".format(
                     charmm_object.filename_box_0
                 )
@@ -2127,7 +2171,16 @@ class GOMCControl:
             charmm_object.filename_box_1 is not None
             and isinstance(charmm_object.filename_box_1, str) is True
         ):
-            if self.ff_psf_pdb_file_directory is None:
+            if override_box_1_pdb_directory_filename is not None:
+                _check_if_string('override_box_1_pdb_directory_filename',
+                                 override_box_1_pdb_directory_filename,
+                                 'pdb')
+                _check_if_string('override_box_1_psf_directory_filename',
+                                 override_box_1_psf_directory_filename,
+                                 'psf')
+                self.Coordinates_box_1 = override_box_1_pdb_directory_filename
+                self.Structures_box_1 = override_box_1_psf_directory_filename
+            elif self.ff_psf_pdb_file_directory is None:
                 self.Coordinates_box_1 = "{}.pdb".format(
                     charmm_object.filename_box_1
                 )
@@ -6074,7 +6127,7 @@ def _check_if_input_files_exist(
         The file directory and name of the file.
     type_of_file : str
         A brief description of the file which is evaluated.
-    override_check_input_files_exist : bool (default = False)
+    override_check_input_files_exist: bool (default = False)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
@@ -6085,17 +6138,52 @@ def _check_if_input_files_exist(
     If the file exists : None
     If the file does not exist : raise ValueError
     """
-
     if (
         os.path.isfile(file_directory_and_name) is False
         and override_check_input_files_exist is False
     ):
+
         print_error_message = (
             "The {} with the file directory and name {}, "
             "does not exist.".format(type_of_file, file_directory_and_name)
         )
         raise ValueError(print_error_message)
 
+def _check_if_string(
+        file_directory_and_name,
+        file_directory_and_name_variable,
+        type_of_file,
+):
+    """
+    Checks to see GOMC FF, pdb, and psf files exist
+
+    Parameters
+    ----------
+    file_directory_and_name : str
+        The file directory and name of the file.
+    file_directory_and_name_variable : variable
+        The variable for the file directory and name of the file.
+    type_of_file : str
+        A brief description of the file which is evaluated (force file, psf, pdb).
+
+    Returns
+    -------
+    If the variable is a string : None
+    If the variable is not a string : raise TypeError
+    """
+    if (
+            not isinstance(file_directory_and_name_variable, str)
+            and file_directory_and_name_variable is not None
+    ):
+        print_error_message = (
+            r"ERROR: The {} variable for directly entering the "
+            r"{} file directory and name is a {} and not a string.".format(
+                file_directory_and_name,
+                type_of_file,
+                type(file_directory_and_name_variable),
+            )
+        )
+        raise TypeError(print_error_message)
 
 # user callable function to write the GOMC control file
 def write_gomc_control_file(
@@ -6106,6 +6194,11 @@ def write_gomc_control_file(
     Temperature,
     ff_psf_pdb_file_directory=None,
     override_check_input_files_exist=False,
+    override_ff_directory_filename=None,
+    override_box_0_pdb_directory_filename=None,
+    override_box_0_psf_directory_filename=None,
+    override_box_1_pdb_directory_filename=None,
+    override_box_1_psf_directory_filename=None,
     input_variables_dict=None,
 ):
     """
@@ -6136,11 +6229,21 @@ def write_gomc_control_file(
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_input_files_exist : bool (default = False)
+    override_check_files_inputs_exist : bool, (default = False)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
+    override_ff_directory_filename : str, (default = None)
+        Override all other force field directory and filename inputs.
+    override_box_0_pdb_directory_filename : str, (default = None)
+        Override all other box 0 pdb directory and filename inputs.
+    override_box_0_psf_directory_filename : str, (default = None)
+        Override all other box 0 psf directory and filename inputs.
+    override_box_1_pdb_directory_filename : str, (default = None)
+        Override all other box 1 pdb directory and filename inputs.
+    override_box_1_psf_directory_filename : str, (default = None)
+        Override all other box 1  psf directory and filename inputs.
     input_variables_dict: dict, default=None
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
@@ -6715,11 +6818,21 @@ def write_gomc_control_file(
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_input_files_exist : bool (default = False)
+    override_check_input_files_exist: bool (default = False)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
+    override_ff_directory_filename : str, (default = None)
+        Override all other force field directory and filename inputs.
+    override_box_0_pdb_directory_filename : str, (default = None)
+        Override all other box 0 pdb directory and filename inputs.
+    override_box_0_psf_directory_filename : str, (default = None)
+        Override all other box 0 psf directory and filename inputs.
+    override_box_1_pdb_directory_filename : str, (default = None)
+        Override all other box 1 pdb directory and filename inputs.
+    override_box_1_psf_directory_filename : str, (default = None)
+        Override all other box 1  psf directory and filename inputs.
     input_variables_dict: dict, default = None
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
@@ -6823,6 +6936,11 @@ def write_gomc_control_file(
         Temperature,
         ff_psf_pdb_file_directory=ff_psf_pdb_file_directory,
         override_check_input_files_exist=override_check_input_files_exist,
+        override_ff_directory_filename=override_ff_directory_filename,
+        override_box_0_pdb_directory_filename=override_box_0_pdb_directory_filename,
+        override_box_0_psf_directory_filename=override_box_0_psf_directory_filename,
+        override_box_1_pdb_directory_filename=override_box_1_pdb_directory_filename,
+        override_box_1_psf_directory_filename=override_box_1_psf_directory_filename,
         input_variables_dict=input_variables_dict,
     )
     test_gomc_control_write_conf_file = gomc_control.write_conf_file(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1014,6 +1014,7 @@ def _get_default_variables_dict():
 
     return default_input_variables_dict
 
+
 def print_required_input(description=False):
     """
     Prints the required ensemble arguments with an optional description based on the ensemble type
@@ -2087,10 +2088,7 @@ class GOMCControl:
             self.input_error = True
             print_error_message = (
                 "ERROR: The variable supplied is a ({}), not a charmm_object ({})"
-                "".format(
-                    type(charmm_object),
-                    type(mf_charmm.Charmm)
-                )
+                "".format(type(charmm_object), type(mf_charmm.Charmm))
             )
             raise TypeError(print_error_message)
 
@@ -2253,7 +2251,8 @@ class GOMCControl:
                 "Therefore, the force field file (.inp) can not be written, and thus, the "
                 "GOMC control file (.conf) can not be created. Please use the force field file "
                 "name when building the Charmm object".format(
-                    type(mf_charmm.Charmm))
+                    type(mf_charmm.Charmm)
+                )
             )
             raise ValueError(print_error_message)
 

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -6472,7 +6472,8 @@ def _check_if_string_and_extension(
             file_directory_and_name_variable
         )[-1]
         if acutal_file_extension not in expected_file_extension:
-            print_error_message = r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". ' r"".format(
+            print_error_message = r'ERROR: The {} variable expects a file extension of {}, ' \
+                                  r'but the actual file extension is "{}". ' r"".format(
                 file_directory_and_name,
                 expected_file_extension,
                 acutal_file_extension,

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -82,7 +82,7 @@ def _get_required_data(description=False):
         "The full or relative directory added to the force field, psf, and pdb "
         "file names, created via the Charmm object.",
         "check_input_files_exist": "Required to check if files exist (all ensembles): bool (default=True), "
-        "Override the check to see if the force field, psf, and pdb files exist. "
+        "Check if the force field, psf, and pdb files exist. "
         "If the files are checked and do not exist, the writer will throw "
         "a ValueError. "
         "True, check if the force field, psf, and pdb files exist. "
@@ -95,43 +95,46 @@ def _get_required_data(description=False):
         "checkpoint file (checkpoint.dat) or not. Restarting the "
         "simulation with checkpoint.dat would result in an identical outcome, "
         "as if previous simulation was continued.",
+        "Parameters": "Required for alternate force field file (all ensembles): "
+        "str, (default=None), "
+        "Override all other force field directory and filename input with the correct extension (.inp or .par).",
         "Coordinates_box_0": "Required for alternate box 0 .pdb file (all ensembles): "
-        "str, (default = None), "
+        "str, (default=None), "
         "Override all other box 0 pdb directory and filename inputs.",
         "Structure_box_0": "Required for alternate box 0 .psf file (all ensembles): "
-        "str, (default = None), "
+        "str, (default=None), "
         "Override all other box 0 psf directory and filename inputs.",
         "Coordinates_box_1": "Required for alternate box 1 .pdb file (all ensembles): "
-        "str, (default = None), "
+        "str, (default=None), "
         "Override all other box 1 pdb directory and filename inputs.",
         "Structure_box_1": "Required for alternate box 1 .psf file  (all ensembles): "
-        "str, (default = None), "
+        "str, (default=None), "
         "Override all other box 1 psf directory and filename inputs.",
         "binCoordinates_box_0": "Required for alternate box 0 .coor file (all ensembles): "
-        "str, (default = None), "
+        "str, (default=None), "
         "The box 0 binary coordinate file is used only for restarting "
         "a GOMC simulation, which provides increased numerical accuracy.",
         "extendedSystem_box_0": "Required for alternate box 0 .xsc file (all ensembles): "
-        "str, (default = None), "
-        "The box 0 vectors origin file is used only for restarting a "
+        "str, (default=None), "
+        "The box 0 vectors and origin file is used only for restarting a "
         "GOMC simulation. ",
         "binVelocities_box_0": "Required for alternate box 0 .vel file (all ensembles): "
-        "str, (default = None), "
+        "str, (default=None), "
         "The box 0 binary velocity file is used only for "
         "restarting a GOMC simulation, which provides increased "
         "numerical accuracy. These velocities are only passed thru "
         "GOMC since Monte Carlo simulations do not utilize any "
         "velocity information. ",
         "binCoordinates_box_1": "Required for alternate box 1 .coor file (all ensembles): "
-        "str, (default = None), "
+        "str, (default=None), "
         "The box 1 binary coordinate file is used only for restarting a "
         "GOMC simulation, which provides increased numerical accuracy. ",
         "extendedSystem_box_1": "Required for alternate box 1 .coor file (all ensembles): "
-        "str, (default = None), "
-        "The box 1 vectors origin file is used "
+        "str, (default=None), "
+        "The box 1 vectors and origin file is used "
         "only for restarting a GOMC simulation. ",
         "binVelocities_box_1": "Required for alternate box 1 .vel file (all ensembles): "
-        "str, (default = None), "
+        "str, (default=None), "
         "The box 1 binary velocity file is used only for restarting a "
         "GOMC simulation, which provides increased numerical accuracy. "
         "These velocities are only passed thru GOMC since Monte Carlo "
@@ -1325,7 +1328,7 @@ class GOMCControl:
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
     check_input_files_exist : bool, (default=True)
-        Override the check to see if the force field, psf, and pdb files exist.
+        Check if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
@@ -1336,31 +1339,31 @@ class GOMCControl:
         Determines whether to restart the simulation with the checkpoint
         file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
         would result in an identical outcome, as if previous simulation was continued.
-    Parameters : str, (default = None)
-        Override all other force field directory and filename inputs with the correct extension.
-    Coordinates_box_0 : str, (default = None)
+    Parameters : str, (default=None)
+        Override all other force field directory and filename input with the correct extension (.inp or .par).
+    Coordinates_box_0 : str, (default=None)
         Override all other box 0 pdb directory and filename inputs with the correct extension.
-    Structure_box_0 : str, (default = None)
+    Structure_box_0 : str, (default=None)
         Override all other box 0 psf directory and filename inputs with the correct extension.
-    Coordinates_box_1 : str, (default = None)
+    Coordinates_box_1 : str, (default=None)
         Override all other box 1 pdb directory and filename inputs with the correct extension.
-    Structure_box_1 : str, (default = None)
+    Structure_box_1 : str, (default=None)
         Override all other box 1  psf directory and filename inputs with the correct extension.
-    binCoordinates_box_0 : str, (default = None)
+    binCoordinates_box_0 : str, (default=None)
         The box 0 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
-    extendedSystem_box_0 : str, (default = None)
-        The box 0 vectors origin file is used only for restarting a GOMC simulation.
-    binVelocities_box_0 : str, (default = None)
+    extendedSystem_box_0 : str, (default=None)
+        The box 0 vectors and origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_0 : str, (default=None)
         The box 0 binary velocity file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy. These velocities are only passed thru
         GOMC since Monte Carlo simulations do not utilize any velocity information.
-    binCoordinates_box_1 : str, (default = None)
+    binCoordinates_box_1 : str, (default=None)
         The box 1 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
-    extendedSystem_box_1 : str, (default = None)
-        The box 1 vectors origin file is used only for restarting a GOMC simulation.
-    binVelocities_box_1 : str, (default = None)
+    extendedSystem_box_1 : str, (default=None)
+        The box 1 vectors and origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_1 : str, (default=None)
         The box 1 binary velocity file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy. These velocities are only passed thru
         GOMC since Monte Carlo simulations do not utilize any velocity information.
@@ -1373,7 +1376,7 @@ class GOMCControl:
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
 
-        Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,
+        Example : input_variables_dict = {'PRNG' : 123,
                                           'ParaTypeCHARMM' : True }
 
     # *******************************************************************
@@ -1939,7 +1942,7 @@ class GOMCControl:
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
     check_input_files_exist : bool, (default=True)
-        Override the check to see if the force field, psf, and pdb files exist.
+        Check if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
@@ -1950,31 +1953,31 @@ class GOMCControl:
         Determines whether to restart the simulation with the checkpoint
         file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
         would result in an identical outcome, as if previous simulation was continued.
-    Parameters : str, (default = None)
-        Override all other force field directory and filename inputs with the correct extension.
-    Coordinates_box_0 : str, (default = None)
+    Parameters : str, (default=None)
+        Override all other force field directory and filename input with the correct extension (.inp or .par).
+    Coordinates_box_0 : str, (default=None)
         Override all other box 0 pdb directory and filename inputs with the correct extension.
-    Structure_box_0 : str, (default = None)
+    Structure_box_0 : str, (default=None)
         Override all other box 0 psf directory and filename inputs with the correct extension.
-    Coordinates_box_1 : str, (default = None)
+    Coordinates_box_1 : str, (default=None)
         Override all other box 1 pdb directory and filename inputs with the correct extension.
-    Structure_box_1 : str, (default = None)
+    Structure_box_1 : str, (default=None)
         Override all other box 1  psf directory and filename inputs with the correct extension.
-    binCoordinates_box_0 : str, (default = None)
+    binCoordinates_box_0 : str, (default=None)
         The box 0 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
-    extendedSystem_box_0 : str, (default = None)
-        The box 0 vectors origin file is used only for restarting a GOMC simulation.
-    binVelocities_box_0 : str, (default = None)
+    extendedSystem_box_0 : str, (default=None)
+        The box 0 vectors and origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_0 : str, (default=None)
         The box 0 binary velocity file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy. These velocities are only passed thru
         GOMC since Monte Carlo simulations do not utilize any velocity information.
-    binCoordinates_box_1 : str, (default = None)
+    binCoordinates_box_1 : str, (default=None)
         The box 1 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
-    extendedSystem_box_1 : str, (default = None)
-        The box 1 vectors origin file is used only for restarting a GOMC simulation.
-    binVelocities_box_1 : str, (default = None)
+    extendedSystem_box_1 : str, (default=None)
+        The box 1 vectors and origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_1 : str, (default=None)
         The box 1 binary velocity file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy. These velocities are only passed thru
         GOMC since Monte Carlo simulations do not utilize any velocity information.
@@ -1986,7 +1989,7 @@ class GOMCControl:
         >>> print_valid_ensemble_input_variables('GCMC', description = True)
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
-        Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,
+        Example : input_variables_dict = {'PRNG' : 123,
                                           'ParaTypeCHARMM' : True }
     conf_filename : str
         The name of the GOMC contol file, which will be created.  The extension
@@ -4885,7 +4888,7 @@ class GOMCControl:
             data_control_file.write(" \n")
             data_control_file.write("####################################\n")
             data_control_file.write(
-                "# INPUT BINARY FILES FOR RESTARTING (COORDINATE, XSC, VELOCITY FILES)\n"
+                "# INPUT FILES FOR RESTARTING (COORDINATE, XSC, VELOCITY FILES)\n"
             )
             data_control_file.write("####################################\n")
             data_control_file.write(
@@ -6400,7 +6403,7 @@ def _check_if_input_files_exist(
     type_of_file : str
         A brief description of the file which is evaluated.
     check_input_files_exist: bool (default=True)
-        Override the check to see if the force field, psf, and pdb files exist.
+        Check if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
@@ -6564,7 +6567,7 @@ def write_gomc_control_file(
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
     check_input_files_exist : bool, (default=True)
-        Override the check to see if the force field, psf, and pdb files exist.
+        Check if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
@@ -6575,31 +6578,31 @@ def write_gomc_control_file(
         Determines whether to restart the simulation with the checkpoint
         file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
         would result in an identical outcome, as if previous simulation was continued.
-    Parameters : str, (default = None)
-        Override all other force field directory and filename inputs with the correct extension.
-    Coordinates_box_0 : str, (default = None)
+    Parameters : str, (default=None)
+        Override all other force field directory and filename input with the correct extension (.inp or .par).
+    Coordinates_box_0 : str, (default=None)
         Override all other box 0 pdb directory and filename inputs with the correct extension.
-    Structure_box_0 : str, (default = None)
+    Structure_box_0 : str, (default=None)
         Override all other box 0 psf directory and filename inputs with the correct extension.
-    Coordinates_box_1 : str, (default = None)
+    Coordinates_box_1 : str, (default=None)
         Override all other box 1 pdb directory and filename inputs with the correct extension.
-    Structure_box_1 : str, (default = None)
+    Structure_box_1 : str, (default=None)
         Override all other box 1  psf directory and filename inputs with the correct extension.
-    binCoordinates_box_0 : str, (default = None)
+    binCoordinates_box_0 : str, (default=None)
         The box 0 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
-    extendedSystem_box_0 : str, (default = None)
-        The box 0 vectors origin file is used only for restarting a GOMC simulation.
-    binVelocities_box_0 : str, (default = None)
+    extendedSystem_box_0 : str, (default=None)
+        The box 0 vectors and origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_0 : str, (default=None)
         The box 0 binary velocity file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy. These velocities are only passed thru
         GOMC since Monte Carlo simulations do not utilize any velocity information.
-    binCoordinates_box_1 : str, (default = None)
+    binCoordinates_box_1 : str, (default=None)
         The box 1 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
-    extendedSystem_box_1 : str, (default = None)
-        The box 1 vectors origin file is used only for restarting a GOMC simulation.
-    binVelocities_box_1 : str, (default = None)
+    extendedSystem_box_1 : str, (default=None)
+        The box 1 vectors and origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_1 : str, (default=None)
         The box 1 binary velocity file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy. These velocities are only passed thru
         GOMC since Monte Carlo simulations do not utilize any velocity information.
@@ -6612,7 +6615,7 @@ def write_gomc_control_file(
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
 
-        Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,
+        Example : input_variables_dict = {'PRNG' : 123,
         'ParaTypeCHARMM' : True }
 
     # *******************************************************************
@@ -7177,7 +7180,7 @@ def write_gomc_control_file(
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
     check_input_files_exist: bool (default=True)
-        Override the check to see if the force field, psf, and pdb files exist.
+        Check if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
@@ -7188,31 +7191,31 @@ def write_gomc_control_file(
         Determines whether to restart the simulation with the checkpoint
         file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
         would result in an identical outcome, as if previous simulation was continued.
-    Parameters : str, (default = None)
-        Override all other force field directory and filename inputs with the correct extension.
-    Coordinates_box_0 : str, (default = None)
+    Parameters : str, (default=None)
+        Override all other force field directory and filename input with the correct extension (.inp or .par).
+    Coordinates_box_0 : str, (default=None)
         Override all other box 0 pdb directory and filename inputs with the correct extension.
-    Structure_box_0 : str, (default = None)
+    Structure_box_0 : str, (default=None)
         Override all other box 0 psf directory and filename inputs with the correct extension.
-    Coordinates_box_1 : str, (default = None)
+    Coordinates_box_1 : str, (default=None)
         Override all other box 1 pdb directory and filename inputs with the correct extension.
-    Structure_box_1 : str, (default = None)
+    Structure_box_1 : str, (default=None)
         Override all other box 1  psf directory and filename inputs with the correct extension.
-    binCoordinates_box_0 : str, (default = None)
+    binCoordinates_box_0 : str, (default=None)
         The box 0 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
-    extendedSystem_box_0 : str, (default = None)
-        The box 0 vectors origin file is used only for restarting a GOMC simulation.
-    binVelocities_box_0 : str, (default = None)
+    extendedSystem_box_0 : str, (default=None)
+        The box 0 vectors and origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_0 : str, (default=None)
         The box 0 binary velocity file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy. These velocities are only passed thru
         GOMC since Monte Carlo simulations do not utilize any velocity information.
-    binCoordinates_box_1 : str, (default = None)
+    binCoordinates_box_1 : str, (default=None)
         The box 1 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
-    extendedSystem_box_1 : str, (default = None)
-        The box 1 vectors origin file is used only for restarting a GOMC simulation.
-    binVelocities_box_1 : str, (default = None)
+    extendedSystem_box_1 : str, (default=None)
+        The box 1 vectors and origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_1 : str, (default=None)
         The box 1 binary velocity file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy. These velocities are only passed thru
         GOMC since Monte Carlo simulations do not utilize any velocity information.
@@ -7224,7 +7227,7 @@ def write_gomc_control_file(
         >>> print_valid_ensemble_input_variables('GCMC', description = True)
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
-        Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,
+        Example : input_variables_dict = {'PRNG' : 123,
         'ParaTypeCHARMM' : True }
     conf_filename : str
         The name of the GOMC contol file, which will be created.  The extension

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -97,19 +97,24 @@ def _get_required_data(description=False):
         "as if previous simulation was continued.",
         "Parameters": "Required for alternate force field file (all ensembles): "
         "str, (default=None), "
-        "Override all other force field directory and filename input with the correct extension (.inp or .par).",
+        "Override all other force field directory and filename input with the correct extension (.inp or .par). "
+        "Note: the default directory is the current directory with the Charmm object file name.",
         "Coordinates_box_0": "Required for alternate box 0 .pdb file (all ensembles): "
         "str, (default=None), "
-        "Override all other box 0 pdb directory and filename inputs.",
+        "Override all other box 0 pdb directory and filename inputs. "
+        "Note: the default directory is the current directory with the Charmm object file name.",
         "Structure_box_0": "Required for alternate box 0 .psf file (all ensembles): "
         "str, (default=None), "
-        "Override all other box 0 psf directory and filename inputs.",
+        "Override all other box 0 psf directory and filename inputs. "
+        "Note: the default directory is the current directory with the Charmm object file name.",
         "Coordinates_box_1": "Required for alternate box 1 .pdb file (all ensembles): "
         "str, (default=None), "
-        "Override all other box 1 pdb directory and filename inputs.",
+        "Override all other box 1 pdb directory and filename inputs. "
+        "Note: the default directory is the current directory with the Charmm object file name.",
         "Structure_box_1": "Required for alternate box 1 .psf file  (all ensembles): "
         "str, (default=None), "
-        "Override all other box 1 psf directory and filename inputs.",
+        "Override all other box 1 psf directory and filename inputs. "
+        "Note: the default directory is the current directory with the Charmm object file name.",
         "binCoordinates_box_0": "Required for alternate box 0 .coor file (all ensembles): "
         "str, (default=None), "
         "The box 0 binary coordinate file is used only for restarting "
@@ -1341,14 +1346,19 @@ class GOMCControl:
         would result in an identical outcome, as if previous simulation was continued.
     Parameters : str, (default=None)
         Override all other force field directory and filename input with the correct extension (.inp or .par).
+        Note: the default directory is the current directory with the Charmm object file name.
     Coordinates_box_0 : str, (default=None)
         Override all other box 0 pdb directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Structure_box_0 : str, (default=None)
         Override all other box 0 psf directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Coordinates_box_1 : str, (default=None)
         Override all other box 1 pdb directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Structure_box_1 : str, (default=None)
         Override all other box 1  psf directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     binCoordinates_box_0 : str, (default=None)
         The box 0 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
@@ -1955,14 +1965,19 @@ class GOMCControl:
         would result in an identical outcome, as if previous simulation was continued.
     Parameters : str, (default=None)
         Override all other force field directory and filename input with the correct extension (.inp or .par).
+        Note: the default directory is the current directory with the Charmm object file name.
     Coordinates_box_0 : str, (default=None)
         Override all other box 0 pdb directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Structure_box_0 : str, (default=None)
         Override all other box 0 psf directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Coordinates_box_1 : str, (default=None)
         Override all other box 1 pdb directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Structure_box_1 : str, (default=None)
         Override all other box 1  psf directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     binCoordinates_box_0 : str, (default=None)
         The box 0 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
@@ -6588,14 +6603,19 @@ def write_gomc_control_file(
         would result in an identical outcome, as if previous simulation was continued.
     Parameters : str, (default=None)
         Override all other force field directory and filename input with the correct extension (.inp or .par).
+        Note: the default directory is the current directory with the Charmm object file name.
     Coordinates_box_0 : str, (default=None)
         Override all other box 0 pdb directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Structure_box_0 : str, (default=None)
         Override all other box 0 psf directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Coordinates_box_1 : str, (default=None)
         Override all other box 1 pdb directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Structure_box_1 : str, (default=None)
         Override all other box 1  psf directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     binCoordinates_box_0 : str, (default=None)
         The box 0 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.
@@ -7201,14 +7221,19 @@ def write_gomc_control_file(
         would result in an identical outcome, as if previous simulation was continued.
     Parameters : str, (default=None)
         Override all other force field directory and filename input with the correct extension (.inp or .par).
+        Note: the default directory is the current directory with the Charmm object file name.
     Coordinates_box_0 : str, (default=None)
         Override all other box 0 pdb directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Structure_box_0 : str, (default=None)
         Override all other box 0 psf directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Coordinates_box_1 : str, (default=None)
         Override all other box 1 pdb directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     Structure_box_1 : str, (default=None)
         Override all other box 1  psf directory and filename inputs with the correct extension.
+        Note: the default directory is the current directory with the Charmm object file name.
     binCoordinates_box_0 : str, (default=None)
         The box 0 binary coordinate file is used only for restarting a GOMC simulation,
         which provides increased numerical accuracy.

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -69,33 +69,73 @@ def _get_required_data(description=False):
 
     required_data = {
         "charmm_object": "Charmm object, "
-        "A Charmm object, which by definition has been parameterized "
-        "from the selected force field.",
-        "ensemble_type": "Required files or System Info (all ensembles): str, "
-        "(valid strings are 'NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', or 'GCMC'), "
-        "the ensemble type for the simulation.",
+                         "A Charmm object, which by definition has been parameterized "
+                         "from the selected force field.",
+        "ensemble_type": "Required files or System Info (all ensembles): str. "
+                         "(valid strings are 'NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', or 'GCMC'), "
+                         "the ensemble type for the simulation,",
         "RunSteps": "Required files or System Info (all ensembles): int (> 0), "
-        "The number or run steps for the simulation.",
+                    "The number or run steps for the simulation.",
         "Temperature": "Required files or System Info (all ensembles): float or integer (> 0), "
-        "Temperature of system in Kelvin (K)",
-        "ff_psf_pdb_file_directory": "str (optional), default=None (i.e., the current directory)."
-        "The full or relative directory added to the force field, psf, and pdb"
-        "file names, created via the Charmm object.",
-        "override_check_input_files_exist": "bool (default = False) "
-        "Override the check to see if the force field, psf, and pdb files exist. "
-        "If the files are checked and do not exist, the writer will throw a ValueError."
-        "True, check if the force field, psf, and pdb files exist."
-        "False, do not check if the force field, psf, and pdb files exist.",
-        "override_ff_directory_filename": "str, (default = None)"
-        "Override all other force field directory and filename inputs.",
-        "override_box_0_pdb_directory_filename": "str, (default = None)"
-        "Override all other box 0 pdb directory and filename inputs.",
-        "override_box_0_psf_directory_filename": "str, (default = None)"
-        "Override all other box 0 psf directory and filename inputs.",
-        "override_box_1_pdb_directory_filename": "str, (default = None)"
-        "Override all other box 1 pdb directory and filename inputs.",
-        "override_box_1_psf_directory_filename": "str, (default = None)"
-        "Override all other box 1 psf directory and filename inputs.",
+                       "Temperature of system in Kelvin (K)",
+        "ff_psf_pdb_file_directory": "str (optional), default=None (i.e., the current directory). "
+                                     "The full or relative directory added to the force field, psf, and pdb "
+                                     "file names, created via the Charmm object.",
+        "check_input_files_exist": "Required to check if files exist (all ensembles): bool (default=True), "
+                                            "Override the check to see if the force field, psf, and pdb files exist. "
+                                            "If the files are checked and do not exist, the writer will throw "
+                                            "a ValueError. "
+                                            "True, check if the force field, psf, and pdb files exist. "
+                                            "False, do not check if the force field, psf, and pdb files exist.",
+        "Restart": "Required for restarting (all ensembles): boolean (default=False), "
+                   "Determines whether to restart the simulation "
+                   "from restart file (*_restart.pdb and *_restart.psf) or not.",
+        "RestartCheckpoint": "Required for optimal restarting (all ensembles): boolean (default=False),"
+                             "Determines whether to restart the simulation with the "
+                             "checkpoint file (checkpoint.dat) or not. Restarting the "
+                             "simulation with checkpoint.dat would result in an identical outcome, "
+                             "as if previous simulation was continued.",
+        "Coordinates_box_0": "Required for alternate box 0 .pdb file (all ensembles): "
+                             "str, (default = None), "
+                             "Override all other box 0 pdb directory and filename inputs.",
+        "Structure_box_0": "Required for alternate box 0 .psf file (all ensembles): "
+                           "str, (default = None), "
+                           "Override all other box 0 psf directory and filename inputs.",
+        "Coordinates_box_1": "Required for alternate box 1 .pdb file (all ensembles): "
+                             "str, (default = None), "
+                             "Override all other box 1 pdb directory and filename inputs.",
+        "Structure_box_1": "Required for alternate box 1 .psf file  (all ensembles): "
+                           "str, (default = None), "
+                           "Override all other box 1 psf directory and filename inputs.",
+        "binCoordinates_box_0": "Required for alternate box 0 .coor file (all ensembles): "
+                                "str, (default = None), "
+                                "The box 0 binary coordinate file is used only for restarting "
+                                "a GOMC simulation, which provides increased numerical accuracy.",
+        "extendedSystem_box_0": "Required for alternate box 0 .xsc file (all ensembles): "
+                                "str, (default = None), "
+                                "The box 0 vectors origin file is used only for restarting a "
+                                "GOMC simulation. ",
+        "binVelocities_box_0": "Required for alternate box 0 .vel file (all ensembles): "
+                               "str, (default = None), "
+                               "The box 0 binary velocity file is used only for "
+                               "restarting a GOMC simulation, which provides increased "
+                               "numerical accuracy. These velocities are only passed thru "
+                               "GOMC since Monte Carlo simulations do not utilize any "
+                               "velocity information. ",
+        "binCoordinates_box_1": "Required for alternate box 1 .coor file (all ensembles): "
+                                "str, (default = None), "
+                                "The box 1 binary coordinate file is used only for restarting a "
+                                "GOMC simulation, which provides increased numerical accuracy. ",
+        "extendedSystem_box_1": "Required for alternate box 1 .coor file (all ensembles): "
+                                "str, (default = None), "
+                                "The box 1 vectors origin file is used "
+                                "only for restarting a GOMC simulation. ",
+        "binVelocities_box_1": "Required for alternate box 1 .vel file (all ensembles): "
+                               "str, (default = None), "
+                               "The box 1 binary velocity file is used only for restarting a "
+                               "GOMC simulation, which provides increased numerical accuracy. "
+                               "These velocities are only passed thru GOMC since Monte Carlo "
+                               "simulations do not utilize any velocity information.",
     }
 
     if description:
@@ -132,665 +172,641 @@ def _get_all_possible_input_variables(description=False):
         # Definitions in this function are copied to a large extent from the GOMC manual release version 2.60 (start)
         # insert citation here:
         # ******************************************************************************************************
-        "Restart": "Simulation info (all ensembles): boolean, default = {}. "
-        "Determines whether to restart the simulation "
-        "from restart file (*_restart.pdb and *_restart.psf) or not."
-        "".format(_get_default_variables_dict()["Restart"]),
-        "RestartCheckpoint": "Simulation info (all ensembles): boolean, default = {}. "
-        "Determines whether to restart the "
-        "simulation with the checkpoint file (checkpoint.dat) or not. Restarting the "
-        "simulation with checkpoint.dat would result in an identical outcome, as if "
-        "previous simulation was continued."
-        "".format(_get_default_variables_dict()["RestartCheckpoint"]),
         "PRNG": 'Simulation info (all ensembles): string or int (>= 0) ("RANDOM" or integer), default = {}. '
-        "PRNG = Pseudo-Random Number Generator (PRNG). "
-        'There are two (2) options, entering the string, "RANDOM", or a integer.  \n'
-        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "RANDOM", which selects a random seed number. '
-        'This will enter the line "PRNG RANDOM" in the gomc configuration file. \n'
-        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- integer, which defines the integer seed number "
-        "for the simulation. "
-        "This is equivalent to entering the following two lines in the configuration file: "
-        "line 1 = PRNG INTSEED, "
-        "line 2 = Random_Seed user_selected_integer. "
-        'Example 1: for a random seed enter the string "RANDOM. '
-        "Example 2: for a specific seed number enter a integer of your choosing. "
-        "".format(_get_default_variables_dict()["PRNG"]),
+                "PRNG = Pseudo-Random Number Generator (PRNG). "
+                'There are two (2) options, entering the string, "RANDOM", or a integer.  \n'
+                '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "RANDOM", which selects a random seed number. '
+                'This will enter the line "PRNG RANDOM" in the gomc configuration file. \n'
+                "\t\t\t\t\t\t\t\t\t\t\t\t\t --- integer, which defines the integer seed number "
+                "for the simulation. "
+                "This is equivalent to entering the following two lines in the configuration file: "
+                "line 1 = PRNG INTSEED, "
+                "line 2 = Random_Seed user_selected_integer. "
+                'Example 1: for a random seed enter the string "RANDOM. '
+                "Example 2: for a specific seed number enter a integer of your choosing. "
+                "".format(_get_default_variables_dict()["PRNG"]),
         "ParaTypeCHARMM": "Simulation info (all ensembles): boolean, default = {}. "
-        "True if a CHARMM forcefield, False otherwise."
-        "".format(_get_default_variables_dict()["ParaTypeCHARMM"]),
+                          "True if a CHARMM forcefield, False otherwise."
+                          "".format(_get_default_variables_dict()["ParaTypeCHARMM"]),
         "ParaTypeMie": "Simulation info (all ensembles): boolean, default = {}. "
-        "True if a Mie forcefield type, False otherwise."
-        "".format(_get_default_variables_dict()["ParaTypeMie"]),
+                       "True if a Mie forcefield type, False otherwise."
+                       "".format(_get_default_variables_dict()["ParaTypeMie"]),
         "ParaTypeMARTINI": "Simulation info (all ensembles): boolean, default = {}. "
-        "True if a MARTINI forcefield, False otherwise."
-        "".format(_get_default_variables_dict()["ParaTypeMARTINI"]),
+                           "True if a MARTINI forcefield, False otherwise."
+                           "".format(_get_default_variables_dict()["ParaTypeMARTINI"]),
         "RcutCoulomb_box_0": "Simulation info (all ensembles): int or float (>= 0), default = {}."
-        "Sets a specific radius in box 0 where the short-range "
-        "electrostatic energy will be calculated (i.e., The distance to truncate the "
-        "short-range electrostatic energy in box 0.)"
-        "Note: if None, GOMC will default to the Rcut value"
-        "".format(_get_default_variables_dict()["RcutCoulomb_box_0"]),
+                             "Sets a specific radius in box 0 where the short-range "
+                             "electrostatic energy will be calculated (i.e., The distance to truncate the "
+                             "Note: if None, GOMC will default to the Rcut value"
+                             "".format(_get_default_variables_dict()["RcutCoulomb_box_0"]),
         "RcutCoulomb_box_1": "Simulation info (all ensembles): int or float (>= 0), default = {}."
-        "Sets a specific radius in box 1 where the short-range  "
-        "electrostatic energy will be calculated. (i.e., The distance to truncate the "
-        "short-range electrostatic energy in box 1.)"
-        "Note: if None, GOMC will default to the Rcut value"
-        "".format(_get_default_variables_dict()["RcutCoulomb_box_1"]),
+                             "Sets a specific radius in box 1 where the short-range  "
+                             "electrostatic energy will be calculated. (i.e., The distance to truncate the "
+                             "short-range electrostatic energy in box 1.)"
+                             "Note: if None, GOMC will default to the Rcut value"
+                             "".format(_get_default_variables_dict()["RcutCoulomb_box_1"]),
         "Pressure": "Simulation info (only GEMC_NPT and NPT): int or float (>= 0), default = {}. "
-        "The pressure in bar utilized for the NPT "
-        "and GEMC_NPT simulations."
-        "".format(_get_default_variables_dict()["Pressure"]),
+                    "The pressure in bar utilized for the NPT "
+                    "and GEMC_NPT simulations."
+                    "".format(_get_default_variables_dict()["Pressure"]),
         "Rcut": "Simulation info (all ensembles): int or float (>= 0 and RcutLow < Rswitch < Rcut), default = {}. "
-        "Sets a specific radius in Angstroms that non-bonded interaction "
-        "energy and force will be considered and calculated using defined potential function. "
-        "The distance in Angstoms to truncate the LJ, Mie, or other VDW type potential at. "
-        'Note: Rswitch is only used when the "Potential" = SWITCH. '
-        "".format(_get_default_variables_dict()["Rcut"]),
+                "Sets a specific radius in Angstroms that non-bonded interaction "
+                "energy and force will be considered and calculated using defined potential function. "
+                "The distance in Angstoms to truncate the LJ, Mie, or other VDW type potential at. "
+                'Note: Rswitch is only used when the "Potential" = SWITCH. '
+                "".format(_get_default_variables_dict()["Rcut"]),
         "RcutLow": "Simulation info (all ensembles): int or float (>= 0 and RcutLow < Rswitch < Rcut), default = {}. "
-        "Sets a specific minimum possible distance in Angstroms that reject "
-        "any move that places any atom closer than specified distance. The minimum possible "
-        "distance between any atoms. "
-        "Sets a specific radius in Angstroms that non-bonded interaction "
-        'Note: Rswitch is only used when the "Potential" = SWITCH. '
-        "".format(_get_default_variables_dict()["RcutLow"]),
+                   "Sets a specific minimum possible distance in Angstroms that reject "
+                   "any move that places any atom closer than specified distance. The minimum possible "
+                   "distance between any atoms. "
+                   "Sets a specific radius in Angstroms that non-bonded interaction "
+                   'Note: Rswitch is only used when the "Potential" = SWITCH. '
+                   "".format(_get_default_variables_dict()["RcutLow"]),
         "LRC": "Simulation info (all ensembles): boolean, default = {}. "
-        "If True, the simulation considers the long range tail corrections for the non-bonded VDW or "
-        "dispersion interactions. "
-        "Note: In case of using SHIFT or SWITCH potential functions, LRC will be ignored."
-        "".format(_get_default_variables_dict()["LRC"]),
+               "If True, the simulation considers the long range tail corrections for the non-bonded VDW or "
+               "dispersion interactions. "
+               "Note: In case of using SHIFT or SWITCH potential functions, LRC will be ignored."
+               "".format(_get_default_variables_dict()["LRC"]),
         "Exclude": "Simulation info (all ensembles): str "
-        '(The string inputs are "1-2", "1-3", or "1-4"), default = {}. '
-        "Note: In CHARMM force field, the 1-4 interaction needs to be considered. "
-        'Choosing "Excude 1-3", will modify 1-4 interaction based on 1-4 parameters '
-        "in parameter file. If a kind force field is used, where "
-        '1-4 interaction needs to be ignored, such as TraPPE, either Exlcude "1-4" needs to be '
-        "chosen or 1-4 parameter needs to be assigned to zero in the parameter file. \n"
-        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-2": All interaction pairs of bonded atoms, '
-        "except the ones that separated with one bond, "
-        "will be considered and modified using 1-4 parameters defined in parameter file. \n"
-        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-3": All interaction pairs of bonded atoms, '
-        "except the ones that separated with one or two "
-        "bonds, will be considered and modified using 1-4 parameters defined in parameter file. \n"
-        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-4": All interaction pairs of bonded atoms, '
-        "except the ones that separated with one, "
-        "two or three bonds, will be considered using non-bonded parameters defined in parameter file."
-        "".format(_get_default_variables_dict()["Exclude"]),
+                   '(The string inputs are "1-2", "1-3", or "1-4"), default = {}. '
+                   "Note: In CHARMM force field, the 1-4 interaction needs to be considered. "
+                   'Choosing "Excude 1-3", will modify 1-4 interaction based on 1-4 parameters '
+                   "in parameter file. If a kind force field is used, where "
+                   '1-4 interaction needs to be ignored, such as TraPPE, either Exlcude "1-4" needs to be '
+                   "chosen or 1-4 parameter needs to be assigned to zero in the parameter file. \n"
+                   '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-2": All interaction pairs of bonded atoms, '
+                   "except the ones that separated with one bond, "
+                   "will be considered and modified using 1-4 parameters defined in parameter file. \n"
+                   '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-3": All interaction pairs of bonded atoms, '
+                   "except the ones that separated with one or two "
+                   "bonds, will be considered and modified using 1-4 parameters defined in parameter file. \n"
+                   '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-4": All interaction pairs of bonded atoms, '
+                   "except the ones that separated with one, "
+                   "two or three bonds, will be considered using non-bonded parameters defined in parameter file."
+                   "".format(_get_default_variables_dict()["Exclude"]),
         "Potential": 'Simulation info (all ensembles): str, ["VDW", "EXP6", "SHIFT" or "SWITCH"], default = {}. '
-        "Defines the potential function type to calculate non-bonded dispersion interaction "
-        "energy and force between atoms. \n"
-        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "VDW":    Non-bonded dispersion interaction energy and force '
-        "calculated based on n-6 (Lennard - Jones) equation. This function will be discussed "
-        "further in the Intermolecular energy and "
-        "Virial calculation section. \n"
-        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "EXP6":   Non-bonded dispersion interaction energy and force '
-        "calculated based on exp-6 (Buckingham potential) equation. \n"
-        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "SHIFT":  This option forces the potential energy to be '
-        "zero at Rcut distance.  \n"
-        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "SWITCH": This option smoothly forces the potential '
-        "energy to be zero at Rcut distance and starts modifying the potential at Rswitch "
-        "distance. Depending on force field type, specific potential function will be applied. "
-        "".format(_get_default_variables_dict()["Potential"]),
+                     "Defines the potential function type to calculate non-bonded dispersion interaction "
+                     "energy and force between atoms. \n"
+                     '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "VDW":    Non-bonded dispersion interaction energy and force '
+                     "calculated based on n-6 (Lennard - Jones) equation. This function will be discussed "
+                     "further in the Intermolecular energy and "
+                     "Virial calculation section. \n"
+                     '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "EXP6":   Non-bonded dispersion interaction energy and force '
+                     "calculated based on exp-6 (Buckingham potential) equation. \n"
+                     '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "SHIFT":  This option forces the potential energy to be '
+                     "zero at Rcut distance.  \n"
+                     '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "SWITCH": This option smoothly forces the potential '
+                     "energy to be zero at Rcut distance and starts modifying the potential at Rswitch "
+                     "distance. Depending on force field type, specific potential function will be applied. "
+                     "".format(_get_default_variables_dict()["Potential"]),
         "Rswitch": "Simulation info (all ensembles): int or float (>= 0 and RcutLow < Rswitch < Rcut), default = {}. "
-        'Note: Rswitch is only used when the SWITCH function is used (i.e., "Potential" = SWITCH). '
-        "The Rswitch distance is in Angstrom. If the “SWITCH” function is chosen, "
-        "Rswitch needs to be defined, otherwise, the program will be terminated. When using "
-        'choosing "SWITCH" as potential function, the Rswitch distance defines where the'
-        "non-bonded interaction energy modification is started, which is eventually truncated "
-        "smoothly at Rcut distance."
-        "".format(_get_default_variables_dict()["Rswitch"]),
+                   'Note: Rswitch is only used when the SWITCH function is used (i.e., "Potential" = SWITCH). '
+                   "The Rswitch distance is in Angstrom. If the “SWITCH” function is chosen, "
+                   "Rswitch needs to be defined, otherwise, the program will be terminated. When using "
+                   'choosing "SWITCH" as potential function, the Rswitch distance defines where the'
+                   "non-bonded interaction energy modification is started, which is eventually truncated "
+                   "smoothly at Rcut distance."
+                   "".format(_get_default_variables_dict()["Rswitch"]),
         "ElectroStatic": "Simulation info (all ensembles): boolean, default = {}. "
-        "Considers the coulomb interactions or not. "
-        "If True, coulomb interactions are considered and false if not. "
-        "Note: To simulate the polar molecule in MARTINI force field, ElectroStatic needs to be "
-        "turn on. The MARTINI force field uses short-range coulomb interaction with constant "
-        "Dielectric of 15.0."
-        "".format(_get_default_variables_dict()["ElectroStatic"]),
+                         "Considers the coulomb interactions or not. "
+                         "If True, coulomb interactions are considered and false if not. "
+                         "Note: To simulate the polar molecule in MARTINI force field, ElectroStatic needs to be "
+                         "turn on. The MARTINI force field uses short-range coulomb interaction with constant "
+                         "Dielectric of 15.0."
+                         "".format(_get_default_variables_dict()["ElectroStatic"]),
         "Ewald": "Simulation info (all ensembles): boolean, default = {}. "
-        "Considers the standard Ewald summation method for electrostatic calculations. "
-        "If True, Ewald summation calculation needs to be considered and false if not. "
-        "Note: By default, GOMC will set ElectroStatic to True if Ewald summation  "
-        "method was used to calculate coulomb interaction."
-        "".format(_get_default_variables_dict()["Ewald"]),
+                 "Considers the standard Ewald summation method for electrostatic calculations. "
+                 "If True, Ewald summation calculation needs to be considered and false if not. "
+                 "Note: By default, GOMC will set ElectroStatic to True if Ewald summation  "
+                 "method was used to calculate coulomb interaction."
+                 "".format(_get_default_variables_dict()["Ewald"]),
         "CachedFourier": "Simulation info (all ensembles): boolean, default = {}. "
-        "Considers storing the reciprocal terms for Ewald summation "
-        "calculation in order to improve the code performance. This option would increase the code "
-        "performance with the cost of memory usage. If True, to store reciprocal terms of Ewald "
-        "summation calculation and False if not. "
-        "Warning: Monte Carlo moves, such as MEMC-1, MEMC-2, MEMC-3, "
-        "IntraMEMC-1, IntraMEMC-2, and IntraMEMC-3 are not support with CachedFourier."
-        "".format(_get_default_variables_dict()["CachedFourier"]),
+                         "Considers storing the reciprocal terms for Ewald summation "
+                         "calculation in order to improve the code performance. This option would increase the code "
+                         "performance with the cost of memory usage. If True, to store reciprocal terms of Ewald "
+                         "summation calculation and False if not. "
+                         "Warning: Monte Carlo moves, such as MEMC-1, MEMC-2, MEMC-3, "
+                         "IntraMEMC-1, IntraMEMC-2, and IntraMEMC-3 are not support with CachedFourier."
+                         "".format(_get_default_variables_dict()["CachedFourier"]),
         "Tolerance": "Simulation info (all ensembles): float (0.0 < float < 1.0), default = {}. "
-        "Sets the accuracy in Ewald summation calculation. Ewald separation parameter and number "
-        "of reciprocal vectors for the Ewald summation are determined based on the accuracy parameter."
-        "".format(_get_default_variables_dict()["Tolerance"]),
+                     "Sets the accuracy in Ewald summation calculation. Ewald separation parameter and number "
+                     "of reciprocal vectors for the Ewald summation are determined based on the accuracy parameter."
+                     "".format(_get_default_variables_dict()["Tolerance"]),
         "Dielectric": "Simulation info (all ensembles): int or float (>= 0.0), default = {}. "
-        "Sets dielectric value used in coulomb interaction when the Martini "
-        "force field is used. Note: In MARTINI force field, Dielectric needs to be set to 15.0."
-        "".format(_get_default_variables_dict()["Dielectric"]),
+                      "Sets dielectric value used in coulomb interaction when the Martini "
+                      "force field is used. Note: In MARTINI force field, Dielectric needs to be set to 15.0."
+                      "".format(_get_default_variables_dict()["Dielectric"]),
         "PressureCalc": "Simulation info (all ensembles): list [bool , int (> 0)] or [bool , step_frequency], "
-        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-        "Calculate the system pressure or not. bool = True, enables the pressure calculation "
-        "during the simulation, false disables the calculation. The int/step frequency sets the "
-        "frequency of calculating the pressure."
-        "".format(
-            _get_default_variables_dict()["PressureCalc"],
-            _get_default_variables_dict()["PressureCalc"][0],
-            _get_default_variables_dict()["PressureCalc"][1],
-        ),
+                        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+                        "Calculate the system pressure or not. bool = True, enables the pressure calculation "
+                        "during the simulation, false disables the calculation. The int/step frequency sets the "
+                        "frequency of calculating the pressure."
+                        "".format(_get_default_variables_dict()["PressureCalc"],
+                                  _get_default_variables_dict()["PressureCalc"][0],
+                                  _get_default_variables_dict()["PressureCalc"][1],
+                                  ),
         "EqSteps": "Simulation info (all ensembles): int (> 0), "
-        "default = set via formula based on the number of RunSteps or {} max. "
-        "Sets the number of steps necessary to equilibrate the system. "
-        "Averaging will begin at this step. "
-        "Note: In GCMC simulations, the Histogram files will be outputed at EqSteps."
-        "".format(_get_default_variables_dict()["EqSteps"]),
+                   "default = set via formula based on the number of RunSteps or {} max. "
+                   "Sets the number of steps necessary to equilibrate the system. "
+                   "Averaging will begin at this step. "
+                   "Note: In GCMC simulations, the Histogram files will be outputed at EqSteps."
+                   "".format(_get_default_variables_dict()["EqSteps"]),
         "AdjSteps": "Simulation info (all ensembles): int (> 0), "
-        "default = set via formula based on the number of RunSteps or {} max. "
-        "Sets the number of steps per adjustment of the parameter associated with each move "
-        "(e.g. maximum translate distance, maximum rotation, maximum volume exchange, etc.)."
-        "".format(_get_default_variables_dict()["AdjSteps"]),
+                    "default = set via formula based on the number of RunSteps or {} max. "
+                    "Sets the number of steps per adjustment of the parameter associated with each move "
+                    "(e.g. maximum translate distance, maximum rotation, maximum volume exchange, etc.)."
+                    "".format(_get_default_variables_dict()["AdjSteps"]),
         "VDWGeometricSigma": "Simulation info (all ensembles): boolean, default = {}. "
-        "Use geometric mean, as required by OPLS force field, "
-        "to combining Lennard-Jones sigma parameters for different atom types. "
-        "If set to True, GOMC uses geometric mean to combine Lennard-Jones or VDW sigmas. "
-        "Note: The default setting of VDWGeometricSigma is false, which uses the arithmetic "
-        "mean when combining Lennard-Jones or VDW sigma parameters for different atom types."
-        "".format(_get_default_variables_dict()["VDWGeometricSigma"]),
+                             "Use geometric mean, as required by OPLS force field, "
+                             "to combining Lennard-Jones sigma parameters for different atom types. "
+                             "If set to True, GOMC uses geometric mean to combine Lennard-Jones or VDW sigmas. "
+                             "Note: The default setting of VDWGeometricSigma is false, which uses the arithmetic "
+                             "mean when combining Lennard-Jones or VDW sigma parameters for different atom types."
+                             "".format(_get_default_variables_dict()["VDWGeometricSigma"]),
         "useConstantArea": "Simulation info (only GEMC_NPT and NPT): boolean: default = {}. "
-        "Changes the volume of the simulation box by fixing the cross-sectional "
-        "area (x-y plane). If true, the volume will change only in z axis, If False, "
-        "the volume of the box will change in a way to maintain the constant axis ratio. "
-        "".format(_get_default_variables_dict()["useConstantArea"]),
+                           "Changes the volume of the simulation box by fixing the cross-sectional "
+                           "area (x-y plane). If true, the volume will change only in z axis, If False, "
+                           "the volume of the box will change in a way to maintain the constant axis ratio. "
+                           "".format(_get_default_variables_dict()["useConstantArea"]),
         "FixVolBox0": "Simulation info (only GEMC_NPT): boolean, default = {}. "
-        "Changing the volume of fluid phase (Box 1) to maintain the constant imposed pressure and "
-        "Temperature, while keeping the volume of adsorbed phase (Box 0) fixed. Note: By default, "
-        "GOMC will set useConstantArea to False if no value was set. It means, the volume of the "
-        "box will change in a way to maintain the constant axis ratio."
-        "".format(_get_default_variables_dict()["FixVolBox0"]),
+                      "Changing the volume of fluid phase (Box 1) to maintain the constant imposed pressure and "
+                      "Temperature, while keeping the volume of adsorbed phase (Box 0) fixed. Note: By default, "
+                      "GOMC will set useConstantArea to False if no value was set. It means, the volume of the "
+                      "box will change in a way to maintain the constant axis ratio."
+                      "".format(_get_default_variables_dict()["FixVolBox0"]),
         # GCMC only properties
-        "ChemPot": "Simulation info (only GCMC): dict {str (4 dig limit) , int or float}, "
-        + "default = {} (i.e., the user must set this variable as there is no working default)."
-        ""
-        "".format(_get_default_variables_dict()["ChemPot"])
-        + "The chemical potentials in GOMC units of energy, K. "
-        "There is a 4 character limit for the string/residue name since the PDB/PSF "
-        "files have a 4 character limitation and require and exact match in the conf file. "
-        "Note: These strings must match the residue in the psf and psb files or it will fail. "
-        "The name of the residues and their corresponding chemical potential must specified "
-        'for every residue in the system (i.e., {"residue_name" : chemical_potential}). '
-        "Note: IF 2 KEYS WITH THE SAME STRING/RESIDUE ARE PROVIDED, ONE WILL BE AUTOMATICALLY "
-        "OVERWRITTEN AND NO ERROR WILL BE THROWN IN THIS CONTROL FILE WRITER. "
-        'Example 1 (system with only water):  {"H2O" : -4000} . '
-        'Example 2 (system with water and ethanol):  {"H2O" : -4000, "ETH" : -8000} ',
+        "ChemPot": "Simulation info (only GCMC): dict {str (4 dig limit) , int or float}, "+
+                   "default = {} ".format(_get_default_variables_dict()["ChemPot"])+
+                   "(i.e., the user must set this variable as there is no working default)."
+                   "The chemical potentials in GOMC units of energy, K. "
+                   "There is a 4 character limit for the string/residue name since the PDB/PSF "
+                   "files have a 4 character limitation and require and exact match in the conf file. "
+                   "Note: These strings must match the residue in the psf and psb files or it will fail. "
+                   "The name of the residues and their corresponding chemical potential must specified "
+                   'for every residue in the system (i.e., {"residue_name" : chemical_potential}). '
+                   "Note: IF 2 KEYS WITH THE SAME STRING/RESIDUE ARE PROVIDED, ONE WILL BE AUTOMATICALLY "
+                   "OVERWRITTEN AND NO ERROR WILL BE THROWN IN THIS CONTROL FILE WRITER. "
+                   'Example 1 (system with only water):  {"H2O" : -4000} . '
+                   'Example 2 (system with water and ethanol):  {"H2O" : -4000, "ETH" : -8000} ',
         "Fugacity": "Simulation info (only GCMC): dict {str , int or float (>= 0)}, "
-        + "default = {} (i.e., the user must set this variable as there is no working default). "
-        "".format(_get_default_variables_dict()["Fugacity"])
-        + "The fugacity in GOMC units of pressure, bar. "
-        "There is a 4 character limit for the string/residue name since the PDB/PSF "
-        "files have a 4 character limitation and require and exact match in the conf file. "
-        "Note: These strings must match the residue in the psf and psb files or it will fail. "
-        "The name of the residues and their corresponding fugacity must specified "
-        'for every residue in the system (i.e., {"residue_name" : fugacity}). '
-        "Note: IF 2 KEYS WITH THE SAME STRING/RESIDUE ARE PROVIDED, ONE WILL BE AUTOMATICALLY "
-        "OVERWRITTEN AND NO ERROR WILL BE THROWN IN THIS CONTROL FILE WRITER. "
-        'Example 1 (system with only water):  {"H2O" : 1} . '
-        'Example 2 (system with water and ethanol):  {"H2O" : 0.5, "ETH" : 10} ',
+                    +"default = {} ".format(_get_default_variables_dict()["Fugacity"])
+                    +"(i.e., the user must set this variable as there is no working default). "
+                    "The fugacity in GOMC units of pressure, bar. "
+                    "There is a 4 character limit for the string/residue name since the PDB/PSF "
+                    "files have a 4 character limitation and require and exact match in the conf file. "
+                    "Note: These strings must match the residue in the psf and psb files or it will fail. "
+                    "The name of the residues and their corresponding fugacity must specified "
+                    'for every residue in the system (i.e., {"residue_name" : fugacity}). '
+                    "Note: IF 2 KEYS WITH THE SAME STRING/RESIDUE ARE PROVIDED, ONE WILL BE AUTOMATICALLY "
+                    "OVERWRITTEN AND NO ERROR WILL BE THROWN IN THIS CONTROL FILE WRITER. "
+                    'Example 1 (system with only water):  {"H2O" : 1} . '
+                    'Example 2 (system with water and ethanol):  {"H2O" : 0.5, "ETH" : 10} ',
         # CBMC inputs
         "CBMC_First": "CBMC inputs (all ensembles): int (>= 0), default = {}, "
-        "The number of CD-CBMC trials to choose the first atom position"
-        "(Lennard-Jones trials for first seed growth)."
-        "".format(_get_default_variables_dict()["CBMC_First"]),
+                      "The number of CD-CBMC trials to choose the first atom position"
+                      "(Lennard-Jones trials for first seed growth)."
+                      "".format(_get_default_variables_dict()["CBMC_First"]),
         "CBMC_Nth": "CBMC inputs (all ensembles): int (>= 0), default = {},  "
-        "The number of CD-CBMC trials to choose the later atom positions "
-        "(Lennard-Jones trials for first seed growth)."
-        "".format(_get_default_variables_dict()["CBMC_Nth"]),
+                    "The number of CD-CBMC trials to choose the later atom positions "
+                    "(Lennard-Jones trials for first seed growth)."
+                    "".format(_get_default_variables_dict()["CBMC_Nth"]),
         "CBMC_Ang": "CBMC inputs (all ensembles): int (>= 0), default = {}, "
-        "The number of CD-CBMC bending angle trials to perform for geometry "
-        "(per the coupled-decoupled CBMC scheme)."
-        "".format(_get_default_variables_dict()["CBMC_Ang"]),
+                    "The number of CD-CBMC bending angle trials to perform for geometry "
+                    "(per the coupled-decoupled CBMC scheme)."
+                    "".format(_get_default_variables_dict()["CBMC_Ang"]),
         "CBMC_Dih": "CBMC inputs (all ensembles): int (>= 0), default = {}, "
-        "The number of CD-CBMC dihedral angle trials to perform for geometry "
-        "(per the coupled-decoupled CBMC scheme)."
-        "".format(_get_default_variables_dict()["CBMC_Dih"]),
+                    "The number of CD-CBMC dihedral angle trials to perform for geometry "
+                    "(per the coupled-decoupled CBMC scheme)."
+                    "".format(_get_default_variables_dict()["CBMC_Dih"]),
         # Control file (.conf file ) output controls/parameters
         "OutputName": "Output Frequency (all ensembles): str (NO SPACES), default = {}. "
-        "The UNIQUE STRING NAME, WITH NO SPACES, which is used for the "
-        "output block average, PDB, and PSF file names."
-        "".format(_get_default_variables_dict()["OutputName"]),
-        "CoordinatesFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-        "[Generate_data_bool , steps_per_data_output_int], "
-        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-        "Controls output of PDB file (coordinates). "
-        "If bool is True, this enables outputting the coordinate files at the "
-        "integer frequency (set steps_per_data_output_int), "
-        'while "False" disables outputting the coordinates.'
-        "".format(
-            _get_default_variables_dict()["CoordinatesFreq"],
-            _get_default_variables_dict()["CoordinatesFreq"][0],
-            _get_default_variables_dict()["CoordinatesFreq"][1],
-        ),
+                      "The UNIQUE STRING NAME, WITH NO SPACES, which is used for the "
+                      "output block average, PDB, and PSF file names."
+                      "".format(_get_default_variables_dict()["OutputName"]),
+        "CoordinatesFreq": "PDB Output Frequency (all ensembles): list [bool , int (> 0)] or "
+                           "[Generate_data_bool , steps_per_data_output_int], "
+                           "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+                           "Controls output of PDB file (coordinates). "
+                           "If bool is True, this enables outputting the coordinate files at the "
+                           "integer frequency (set steps_per_data_output_int), "
+                           'while "False" disables outputting the coordinates.'
+                           "".format(_get_default_variables_dict()["CoordinatesFreq"],
+                                     _get_default_variables_dict()["CoordinatesFreq"][0],
+                                     _get_default_variables_dict()["CoordinatesFreq"][1],
+                                     ),
+        "DCDFreq": "DCD Output Frequency (all ensembles): list [bool , int (> 0)] or "
+                   "[Generate_data_bool , steps_per_data_output_int], "
+                   "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+                   "Controls output of DCD file (coordinates). "
+                   "If bool is True, this enables outputting the coordinate files at the "
+                   "integer frequency (set steps_per_data_output_int), "
+                   'while "False" disables outputting the coordinates.'
+                   "".format( _get_default_variables_dict()["DCDFreq"],
+                              _get_default_variables_dict()["DCDFreq"][0],
+                              _get_default_variables_dict()["DCDFreq"][1],
+                              ),
         "RestartFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-        "[Generate_data_bool , steps_per_data_output_int], "
-        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-        "This creates the PDB and PSF (coordinate and topology) files for restarting the system "
-        "at the set steps_per_data_output_int (frequency) "
-        "If bool is True, this enables outputting the PDB/PSF restart files at the "
-        "integer frequency (set steps_per_data_output_int), "
-        "while “false” disables outputting the PDB/PSF restart files. "
-        "".format(
-            _get_default_variables_dict()["RestartFreq"],
-            _get_default_variables_dict()["RestartFreq"][0],
-            _get_default_variables_dict()["RestartFreq"][1],
-        ),
+                       "[Generate_data_bool , steps_per_data_output_int], "
+                       "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+                       "This creates the PDB and PSF (coordinate and topology) files for restarting the system "
+                       "at the set steps_per_data_output_int (frequency) "
+                       "If bool is True, this enables outputting the PDB/PSF restart files at the "
+                       "integer frequency (set steps_per_data_output_int), "
+                       "while “false” disables outputting the PDB/PSF restart files. "
+                       "".format(_get_default_variables_dict()["RestartFreq"],
+                                 _get_default_variables_dict()["RestartFreq"][0],
+                                 _get_default_variables_dict()["RestartFreq"][1],
+                                 ),
         "CheckpointFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-        "[Generate_data_bool , steps_per_data_output_int], "
-        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-        "Controls the output of the last state of simulation at a specified step, in a "
-        "binary file format (checkpoint.dat). Checkpoint file contains the following "
-        "information in full precision: "
-        "(1) Last simulation step that saved into checkpoint file "
-        "(2) Simulation cell dimensions and angles "
-        "(3) Maximum amount of displacement (Å), rotation (δ), and volume (Å^3) that is used in "
-        "the Displacement, Rotation, MultiParticle, and Volume moves "
-        "(4) Number of Monte Carlo move trial and acceptance "
-        "(5) All molecule’s coordinates "
-        "(6) Random number sequence "
-        "If bool is True, this enables outputting the checkpoint file at the "
-        "integer frequency (set steps_per_data_output_int), "
-        'while "False" disables outputting the checkpoint file.'
-        "".format(
-            _get_default_variables_dict()["CheckpointFreq"],
-            _get_default_variables_dict()["CheckpointFreq"][0],
-            _get_default_variables_dict()["CheckpointFreq"][1],
-        ),
+                          "[Generate_data_bool , steps_per_data_output_int], "
+                          "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+                          "Controls the output of the last state of simulation at a specified step, in a "
+                          "binary file format (checkpoint.dat). Checkpoint file contains the following "
+                          "information in full precision: "
+                          "(1) Last simulation step that saved into checkpoint file "
+                          "(2) Simulation cell dimensions and angles "
+                          "(3) Maximum amount of displacement (Å), rotation (δ), and volume (Å^3) that is used in "
+                          "the Displacement, Rotation, MultiParticle, and Volume moves "
+                          "(4) Number of Monte Carlo move trial and acceptance "
+                          "(5) All molecule’s coordinates "
+                          "(6) Random number sequence "
+                          "If bool is True, this enables outputting the checkpoint file at the "
+                          "integer frequency (set steps_per_data_output_int), "
+                          'while "False" disables outputting the checkpoint file.'
+                          "".format(_get_default_variables_dict()["CheckpointFreq"],
+                                    _get_default_variables_dict()["CheckpointFreq"][0],
+                                    _get_default_variables_dict()["CheckpointFreq"][1],
+                                    ),
         "ConsoleFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-        "[Generate_data_bool , steps_per_data_output_int], "
-        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-        'Controls the output to the "console” or log file, which prints the '
-        "acceptance statistics, and run timing info. In addition, instantaneously-selected"
-        "thermodynamic properties will be output to this file.  If bool is True, "
-        "this enables outputting the console data at the integer frequency "
-        '(set steps_per_data_output_int), while "False" disables outputting the console '
-        "data file. "
-        "".format(
-            _get_default_variables_dict()["ConsoleFreq"],
-            _get_default_variables_dict()["ConsoleFreq"][0],
-            _get_default_variables_dict()["ConsoleFreq"][1],
-        ),
+                       "[Generate_data_bool , steps_per_data_output_int], "
+                       "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+                       'Controls the output to the "console” or log file, which prints the '
+                       "acceptance statistics, and run timing info. In addition, instantaneously-selected"
+                       "thermodynamic properties will be output to this file.  If bool is True, "
+                       "this enables outputting the console data at the integer frequency "
+                       '(set steps_per_data_output_int), while "False" disables outputting the console '
+                       "data file. "
+                       "".format(_get_default_variables_dict()["ConsoleFreq"],
+                                 _get_default_variables_dict()["ConsoleFreq"][0],
+                                 _get_default_variables_dict()["ConsoleFreq"][1],
+                                 ),
         "BlockAverageFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-        "[Generate_data_bool , steps_per_data_output_int], "
-        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-        "Controls the block averages output of selected thermodynamic properties. "
-        "Block averages are averages of thermodynamic values of interest for chunks of the "
-        "simulation (for post-processing of averages or std. dev. in those values)."
-        "If bool is True, this enables outputting the block averaging data/file at the "
-        "integer frequency (set steps_per_data_output_int), "
-        'while "False" disables outputting the block averaging data/file.'
-        "".format(
-            _get_default_variables_dict()["BlockAverageFreq"],
-            _get_default_variables_dict()["BlockAverageFreq"][0],
-            _get_default_variables_dict()["BlockAverageFreq"][1],
-        ),
+                            "[Generate_data_bool , steps_per_data_output_int], "
+                            "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+                            "Controls the block averages output of selected thermodynamic properties. "
+                            "Block averages are averages of thermodynamic values of interest for chunks of the "
+                            "simulation (for post-processing of averages or std. dev. in those values)."
+                            "If bool is True, this enables outputting the block averaging data/file at the "
+                            "integer frequency (set steps_per_data_output_int), "
+                            'while "False" disables outputting the block averaging data/file.'
+                            "".format(_get_default_variables_dict()["BlockAverageFreq"],
+                                      _get_default_variables_dict()["BlockAverageFreq"][0],
+                                      _get_default_variables_dict()["BlockAverageFreq"][1],
+                                      ),
         "HistogramFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-        "[Generate_data_bool , steps_per_data_output_int], "
-        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-        "Controls the histograms. Histograms are a binned listing of observation frequency "
-        "for a specific thermodynamic variable. In the GOMC code, they also control the output "
-        "of a file containing energy/molecule samples, "
-        'which is only used for the "GCMC" ensemble simulations for histogram reweighting purposes.'
-        "If bool is True, this enables outputting the data to the histogram data at the "
-        "integer frequency (set steps_per_data_output_int), "
-        'while "False" disables outputting the histogram data.'
-        "".format(
-            _get_default_variables_dict()["HistogramFreq"],
-            _get_default_variables_dict()["HistogramFreq"][0],
-            _get_default_variables_dict()["HistogramFreq"][1],
-        ),
+                         "[Generate_data_bool , steps_per_data_output_int], "
+                         "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+                         "Controls the histograms. Histograms are a binned listing of observation frequency "
+                         "for a specific thermodynamic variable. In the GOMC code, they also control the output "
+                         "of a file containing energy/molecule samples, "
+                         'which is only used for the "GCMC" ensemble simulations for histogram reweighting purposes.'
+                         "If bool is True, this enables outputting the data to the histogram data at the "
+                         "integer frequency (set steps_per_data_output_int), "
+                         'while "False" disables outputting the histogram data.'
+                         "".format(_get_default_variables_dict()["HistogramFreq"],
+                                   _get_default_variables_dict()["HistogramFreq"][0],
+                                   _get_default_variables_dict()["HistogramFreq"][1],
+                                   ),
         # Histogram data
         "DistName": "Histogram Output (all ensembles): str (NO SPACES), default = {}. "
-        "Short phrase which will be combined with RunNumber and RunLetter "
-        "to use in the name of the binned histogram for molecule distribution."
-        "".format(_get_default_variables_dict()["DistName"]),
+                    "Short phrase which will be combined with RunNumber and RunLetter "
+                    "to use in the name of the binned histogram for molecule distribution."
+                    "".format(_get_default_variables_dict()["DistName"]),
         "HistName": "Histogram Output (all ensembles): str (NO SPACES), default = {}. "
-        "Short phrase, which will be combined with RunNumber and RunLetter, "
-        "to use in the name of the energy/molecule count sample file."
-        "".format(_get_default_variables_dict()["HistName"]),
+                    "Short phrase, which will be combined with RunNumber and RunLetter, "
+                    "to use in the name of the energy/molecule count sample file."
+                    "".format(_get_default_variables_dict()["HistName"]),
         "RunNumber": "Histogram Output (all ensembles): int  ( > 0 ), default = {}. "
-        "Sets a number, which is a part of DistName and HistName file name."
-        "".format(_get_default_variables_dict()["RunNumber"]),
+                     "Sets a number, which is a part of DistName and HistName file name."
+                     "".format(_get_default_variables_dict()["RunNumber"]),
         "RunLetter": "Histogram Output (all ensembles): str (1 alphabetic character only), default = {}. "
-        "Sets a letter, which is a part of DistName and HistName file name."
-        "".format(_get_default_variables_dict()["RunLetter"]),
+                     "Sets a letter, which is a part of DistName and HistName file name."
+                     "".format(_get_default_variables_dict()["RunLetter"]),
         "SampleFreq": "Histogram Output (all ensembles): int ( > 0 ), default = {}. "
-        "The number of steps per histogram sample or frequency."
-        "".format(_get_default_variables_dict()["SampleFreq"]),
+                      "The number of steps per histogram sample or frequency."
+                      "".format(_get_default_variables_dict()["SampleFreq"]),
         # Data output for the console and bulk properties calculations
         "OutEnergy": "Output Data (all ensembles): [bool, bool], default = {}.   "
-        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-        "This outputs the energy data into the block averages and console output/log files."
-        "".format(_get_default_variables_dict()["OutEnergy"]),
+                     "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+                     "This outputs the energy data into the block averages and console output/log files."
+                     "".format(_get_default_variables_dict()["OutEnergy"]),
         "OutPressure": "Output Data (all ensembles): [bool, bool], default = {}.   "
-        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-        "This outputs the pressure data into the block averages and console output/log files."
-        "".format(_get_default_variables_dict()["OutPressure"]),
+                       "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+                       "This outputs the pressure data into the block averages and console output/log files."
+                       "".format(_get_default_variables_dict()["OutPressure"]),
         "OutMolNumber": "Output Data (all ensembles): [bool, bool], default = {}.   "
-        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-        "This outputs the number of molecules data into the block averages and console output/log files."
-        "".format(_get_default_variables_dict()["OutMolNumber"]),
+                        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+                        "This outputs the number of molecules data into the block averages and console "
+                        "output/log files."
+                        "".format(_get_default_variables_dict()["OutMolNumber"]),
         "OutDensity": "Output Data (all ensembles): [bool, bool], default = {}.   "
-        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-        "This outputs the density data into the block averages and console output/log files."
-        "".format(_get_default_variables_dict()["OutDensity"]),
+                      "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+                      "This outputs the density data into the block averages and console output/log files."
+                      "".format(_get_default_variables_dict()["OutDensity"]),
         "OutVolume": "Output Data (all ensembles): [bool, bool], default = {}.   "
-        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-        "This outputs the volume data into the block averages and console output/log files."
-        "".format(_get_default_variables_dict()["OutVolume"]),
+                     "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+                     "This outputs the volume data into the block averages and console output/log files."
+                     "".format(_get_default_variables_dict()["OutVolume"]),
         "OutSurfaceTension": "Output Data (all ensembles): [bool, bool], default = {}. "
-        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-        "This outputs the surface tension data into the block averages and console "
-        "output/log files."
-        "".format(_get_default_variables_dict()["OutSurfaceTension"]),
+                             "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+                             "This outputs the surface tension data into the block averages and console "
+                             "output/log files."
+                             "".format(_get_default_variables_dict()["OutSurfaceTension"]),
         # free energy calculation in NVT and NPT ensembles.
         "FreeEnergyCalc": "Free Energy Calcs (NVT and NPT only): list [bool , int (> 0)] or "
-        "[Generate_data_bool , steps_per_data_output_int], default = {}. "
-        "bool = True enabling free energy calculation during the simulation, false disables "
-        "the calculation. The int/step frequency sets the frequency of calculating the free energy."
-        "".format(_get_default_variables_dict()["FreeEnergyCalc"]),
+                          "[Generate_data_bool , steps_per_data_output_int], default = {}. "
+                          "bool = True enabling free energy calculation during the simulation, false disables "
+                          "the calculation. The int/step frequency sets the frequency of calculating the free energy."
+                          "".format(_get_default_variables_dict()["FreeEnergyCalc"]),
         "MoleculeType": "Free Energy Calcs (NVT and NPT only): list [str , int (> 0)] or "
-        '["residue_name" , residue_ID], '
-        "The user must set this variable as there is no working default (default = {}). "
-        'Note: ONLY 4 characters can be used for the string (i.e., "residue_name"). '
-        "Sets the solute molecule kind (residue name) and molecule number (residue ID), "
-        "which absolute solvation free will be calculated for."
-        "".format(_get_default_variables_dict()["MoleculeType"]),
+                        '["residue_name" , residue_ID], '
+                        "The user must set this variable as there is no working default (default = {}). "
+                        'Note: ONLY 4 characters can be used for the string (i.e., "residue_name"). '
+                        "Sets the solute molecule kind (residue name) and molecule number (residue ID), "
+                        "which absolute solvation free will be calculated for."
+                        "".format(_get_default_variables_dict()["MoleculeType"]),
         "InitialState": "Free Energy Calcs (NVT and NPT only): int (>= 0), "
-        "The user must set this variable as there is no working default (default = {}). "
-        "The index of LambdaCoulomb and LambdaVDW vectors. Sets the index of the"
-        "LambdaCoulomb and LambdaVDW vectors, to determine the simulation lambda value for"
-        "VDW and Coulomb interactions. "
-        "WARNING : This must an integer within the vector count of the LambdaVDW and LambdaCoulomb, "
-        "in which the counting starts at 0.  "
-        "".format(_get_default_variables_dict()["InitialState"]),
+                        "The user must set this variable as there is no working default (default = {}). "
+                        "The index of LambdaCoulomb and LambdaVDW vectors. Sets the index of the"
+                        "LambdaCoulomb and LambdaVDW vectors, to determine the simulation lambda value for"
+                        "VDW and Coulomb interactions. "
+                        "WARNING : This must an integer within the vector count of the LambdaVDW and LambdaCoulomb, "
+                        "in which the counting starts at 0.  "
+                        "".format(_get_default_variables_dict()["InitialState"]),
         "LambdaVDW": "Free Energy Calcs (NVT and NPT only): list of floats (0 <= floats <= 1), "
-        "The user must set this variable as there is no working default (default = {}). "
-        "Lambda values for VDW interaction in ascending order. Sets the intermediate "
-        "lambda states to which solute-solvent VDW interactions are scaled. "
-        'WARNING : This list must be the same length as the "LambdaCoulomb" list length. '
-        "WARNING : All lambda values must be stated in the ascending order, otherwise "
-        "the program will terminate.  "
-        "Example of ascending order 1: [0.1, 1.0,]  "
-        "Example of ascending order 2: [0.1, 0.2, 0.4, 0.9] "
-        "".format(_get_default_variables_dict()["LambdaVDW"]),
+                     "The user must set this variable as there is no working default (default = {}). "
+                     "Lambda values for VDW interaction in ascending order. Sets the intermediate "
+                     "lambda states to which solute-solvent VDW interactions are scaled. "
+                     'WARNING : This list must be the same length as the "LambdaCoulomb" list length. '
+                     "WARNING : All lambda values must be stated in the ascending order, otherwise "
+                     "Example of ascending order 1: [0.1, 1.0,]  "
+                     "Example of ascending order 2: [0.1, 0.2, 0.4, 0.9] "
+                     "".format(_get_default_variables_dict()["LambdaVDW"]),
         "LambdaCoulomb": "Free Energy Calcs (NVT and NPT only):  list of floats (0 <= floats <= 1), "
-        "The user must set this variable as there is no working default (default = {}). "
-        "Lambda values for Coulombic interaction in ascending order. Sets the intermediate "
-        "lambda states to which solute-solvent Coulombic interactions are scaled. "
-        'GOMC defauts to the "LambdaVDW" values for the Coulombic interaction '
-        'if no "LambdaCoulomb" variable is set. '
-        'WARNING : This list must be the same length as the "LambdaVDW" list length. '
-        "WARNING : All lambda values must be stated in the ascending order, otherwise "
-        "the program will terminate.  "
-        "Example of ascending order 1: [0.1, 1.0,]  "
-        "Example of ascending order 2: [0.1, 0.2, 0.4, 0.9] "
-        "".format(_get_default_variables_dict()["LambdaCoulomb"]),
+                         "The user must set this variable as there is no working default (default = {}). "
+                         "Lambda values for Coulombic interaction in ascending order. Sets the intermediate "
+                         "lambda states to which solute-solvent Coulombic interactions are scaled. "
+                         'GOMC defauts to the "LambdaVDW" values for the Coulombic interaction '
+                         'if no "LambdaCoulomb" variable is set. '
+                         'WARNING : This list must be the same length as the "LambdaVDW" list length. '
+                         "WARNING : All lambda values must be stated in the ascending order, otherwise "
+                         "the program will terminate.  "
+                         "Example of ascending order 1: [0.1, 1.0,]  "
+                         "Example of ascending order 2: [0.1, 0.2, 0.4, 0.9] "
+                         "".format(_get_default_variables_dict()["LambdaCoulomb"]),
         "ScaleCoulomb": "Free Energy Calcs (NVT and NPT only): bool, default = {}, "
-        "Determines to scale the Coulombic interaction non-linearly (soft-core scheme) or not. "
-        "True if the Coulombic interaction needs to be scaled non-linearly. "
-        "False if the Coulombic interaction needs to be scaled linearly. "
-        "".format(_get_default_variables_dict()["ScaleCoulomb"]),
+                        "Determines to scale the Coulombic interaction non-linearly (soft-core scheme) or not. "
+                        "True if the Coulombic interaction needs to be scaled non-linearly. "
+                        "False if the Coulombic interaction needs to be scaled linearly. "
+                        "".format(_get_default_variables_dict()["ScaleCoulomb"]),
         "ScalePower": "Free Energy Calcs (NVT and NPT only): int (>= 0), default = {}, "
-        "The p value in the soft-core scaling scheme, where the distance between "
-        "solute and solvent is scaled non-linearly."
-        "".format(_get_default_variables_dict()["ScalePower"]),
+                      "The p value in the soft-core scaling scheme, where the distance between "
+                      "solute and solvent is scaled non-linearly."
+                      "".format(_get_default_variables_dict()["ScalePower"]),
         "ScaleAlpha": "Free Energy Calcs (NVT and NPT only): int or float (>= 0), default = {}, "
-        "The alpha value in the soft-core scaling scheme, where the distance "
-        "between solute and solvent is scaled non-linearly."
-        "".format(_get_default_variables_dict()["ScaleAlpha"]),
+                      "The alpha value in the soft-core scaling scheme, where the distance "
+                      "between solute and solvent is scaled non-linearly."
+                      "".format(_get_default_variables_dict()["ScaleAlpha"]),
         "MinSigma": "Free Energy Calcs (NVT and NPT only): int or float (>= 0), default = {}, "
-        "The minimum sigma value in the soft-core scaling scheme, where the "
-        "distance between solute and solvent is scaled non-linearly."
-        "".format(_get_default_variables_dict()["MinSigma"]),
+                    "The minimum sigma value in the soft-core scaling scheme, where the "
+                    "distance between solute and solvent is scaled non-linearly."
+                    "".format(_get_default_variables_dict()["MinSigma"]),
         # moves without MEMC
         "DisFreq": "Std. MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which the displacement move will occur "
-        "(i.e., fraction of displacement moves). Note: all of the move types"
-        "are not available in for every ensemble. Note: all of the move fractions"
-        "must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["DisFreq"]),
+                   "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                   "Fractional percentage at which the displacement move will occur "
+                   "(i.e., fraction of displacement moves). Note: all of the move types"
+                   "are not available in for every ensemble. Note: all of the move fractions"
+                   "must sum to 1, or the control file writer will fail.  "
+                   "".format(_get_default_variables_dict()["DisFreq"]),
         "RotFreq": "Std. MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which the rotation move will occur "
-        "(i.e., fraction of rotation moves). Note: all of the move types"
-        "are not available in for every ensemble. Note: all of the move fractions"
-        "must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["RotFreq"]),
+                   "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                   "Fractional percentage at which the rotation move will occur "
+                   "(i.e., fraction of rotation moves). Note: all of the move types"
+                   "are not available in for every ensemble. Note: all of the move fractions"
+                   "must sum to 1, or the control file writer will fail.  "
+                   "".format(_get_default_variables_dict()["RotFreq"]),
         "IntraSwapFreq": "Std. MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which the molecule will be removed from a "
-        "box and inserted into the same box using coupled-decoupled configurational-bias"
-        "algorithm. (i.e., fraction of intra-molecule swap moves). Note: all of the move types"
-        "are not available in for every ensemble. Note: all of the move fractions"
-        "must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["IntraSwapFreq"]),
+                         "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                         "Fractional percentage at which the molecule will be removed from a "
+                         "box and inserted into the same box using coupled-decoupled configurational-bias"
+                         "algorithm. (i.e., fraction of intra-molecule swap moves). Note: all of the move types"
+                         "are not available in for every ensemble. Note: all of the move fractions"
+                         "must sum to 1, or the control file writer will fail.  "
+                         "".format(_get_default_variables_dict()["IntraSwapFreq"]),
         "SwapFreq": "Std. MC moves (only GEMC_NPT, GEMC_NVT, and GCMC) : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "For Gibbs and Grand Canonical (GC) ensemble runs only: Fractional "
-        "percentage at which molecule swap move will occur using coupled-decoupled "
-        "configurational-bias. (i.e., fraction of molecule swaps moves). Note: all of the move types"
-        "are not available in for every ensemble. Note: all of the move fractions"
-        "must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["SwapFreq"]),
+                    "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                    "For Gibbs and Grand Canonical (GC) ensemble runs only: Fractional "
+                    "percentage at which molecule swap move will occur using coupled-decoupled "
+                    "configurational-bias. (i.e., fraction of molecule swaps moves). Note: all of the move types"
+                    "are not available in for every ensemble. Note: all of the move fractions"
+                    "must sum to 1, or the control file writer will fail.  "
+                    "".format(_get_default_variables_dict()["SwapFreq"]),
         "RegrowthFreq": "Std. MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which part of the molecule will be "
-        "deleted and then regrown using coupled- decoupled configurational-bias algorithm "
-        "(i.e., fraction of molecular growth moves). Note: all of the move types"
-        "are not available in for every ensemble. Note: all of the move fractions"
-        "must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["RegrowthFreq"]),
+                        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                        "Fractional percentage at which part of the molecule will be "
+                        "deleted and then regrown using coupled- decoupled configurational-bias algorithm "
+                        "(i.e., fraction of molecular growth moves). Note: all of the move types"
+                        "are not available in for every ensemble. Note: all of the move fractions"
+                        "must sum to 1, or the control file writer will fail.  "
+                        "".format(_get_default_variables_dict()["RegrowthFreq"]),
         "CrankShaftFreq": "Std. MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which crankshaft move will occur. "
-        "In this move, two atoms that are forming angle or dihedral are selected randomly and "
-        "form a shaft. Then any atoms or group that are within these two selected atoms, will "
-        "rotate around the shaft to sample intra-molecular degree of freedom "
-        "(i.e., fraction of crankshaft moves). Note: all of the move types"
-        "are not available in for every ensemble. Note: all of the move fractions"
-        "must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["CrankShaftFreq"]),
+                          "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                          "Fractional percentage at which crankshaft move will occur. "
+                          "In this move, two atoms that are forming angle or dihedral are selected randomly and "
+                          "form a shaft. Then any atoms or group that are within these two selected atoms, will "
+                          "rotate around the shaft to sample intra-molecular degree of freedom "
+                          "(i.e., fraction of crankshaft moves). Note: all of the move types"
+                          "are not available in for every ensemble. Note: all of the move fractions"
+                          "must sum to 1, or the control file writer will fail. "
+                          "".format(_get_default_variables_dict()["CrankShaftFreq"]),
         "VolFreq": "Std. MC moves (only  GEMC_NPT  and  NPT )         : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. Fractional percentage at  which a volume move will occur "
-        "(i.e., fraction of Volume moves). "
-        "Note: all of the move types are not available in for every ensemble. "
-        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-        "".format(_get_default_variables_dict()["VolFreq"]),
+                   "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                   "Fractional percentage at  which a volume move will occur "
+                   "(i.e., fraction of Volume moves). "
+                   "Note: all of the move types are not available in for every ensemble. "
+                   "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+                   "".format(_get_default_variables_dict()["VolFreq"]),
         "MultiParticleFreq": "Std. MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which multi-particle move will "
-        "occur. In this move, all molecules in the selected simulation box will be rigidly "
-        "rotated or displaced simultaneously, along the calculated torque or force "
-        "respectively (i.e., fraction of multi-particle moves). Note: all of the move types"
-        "are not available in for every ensemble. Note: all of the move fractions"
-        "must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["MultiParticleFreq"]),
+                             "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                             "Fractional percentage at which multi-particle move will "
+                             "occur. In this move, all molecules in the selected simulation box will be rigidly "
+                             "rotated or displaced simultaneously, along the calculated torque or force "
+                             "respectively (i.e., fraction of multi-particle moves). Note: all of the move types"
+                             "are not available in for every ensemble. Note: all of the move fractions"
+                             "must sum to 1, or the control file writer will fail.  "
+                             "".format(_get_default_variables_dict()["MultiParticleFreq"]),
         # MEMC moves
         "IntraMEMC-1Freq": "MEMC MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which specified number of small molecule kind will be "
-        "exchanged with a specified large molecule kind in defined sub-volume within "
-        "same simulation box.  This move need additional information such as "
-        "ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, and ExchangeLargeKind."
-        "Note: all of the move types are not available in for every ensemble."
-        "Note: all of the move fractions must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["IntraMEMC-1Freq"]),
+                           "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                           "Fractional percentage at which specified number of small molecule kind will be "
+                           "exchanged with a specified large molecule kind in defined sub-volume within "
+                           "same simulation box.  This move need additional information such as "
+                           "ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, and ExchangeLargeKind."
+                           "Note: all of the move types are not available in for every ensemble."
+                           "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+                           "".format(_get_default_variables_dict()["IntraMEMC-1Freq"]),
         "MEMC-1Freq": "MEMC MC moves (only GEMC_NPT, GEMC_NVT, and GCMC) : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which specified number of small molecule kind will be exchanged "
-        "with a specified large molecule kind in defined sub-volume, between simulation boxes. "
-        "This move needs additional information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
-        "and ExchangeLargeKind."
-        "Note: all of the move types are not available in for every ensemble."
-        "Note: all of the move fractions must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["MEMC-1Freq"]),
+                      "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                      "Fractional percentage at which specified number of small molecule kind will be exchanged "
+                      "with a specified large molecule kind in defined sub-volume, between simulation boxes. "
+                      "This move needs additional information such as ExchangeVolumeDim, ExchangeRatio, "
+                      "ExchangeSmallKind, and ExchangeLargeKind."
+                      "Note: all of the move types are not available in for every ensemble."
+                      "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+                      "".format(_get_default_variables_dict()["MEMC-1Freq"]),
         "IntraMEMC-2Freq": "MEMC MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which specified number of small molecule kind "
-        "will be exchanged with a specified large molecule kind in defined sub-volume "
-        "within same simulation box. Backbone of small and large molecule kind will be "
-        "used to insert the large molecule more efficiently. This move need additional "
-        "information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
-        "ExchangeLargeKind, SmallKindBackBone, and LargeKindBackBone. "
-        "Note: all of the move types are not available in for every ensemble."
-        "Note: all of the move fractions must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["IntraMEMC-2Freq"]),
+                           "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                           "Fractional percentage at which specified number of small molecule kind "
+                           "will be exchanged with a specified large molecule kind in defined sub-volume "
+                           "within same simulation box. Backbone of small and large molecule kind will be "
+                           "used to insert the large molecule more efficiently. This move need additional "
+                           "information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
+                           "ExchangeLargeKind, SmallKindBackBone, and LargeKindBackBone. "
+                           "Note: all of the move types are not available in for every ensemble."
+                           "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+                           "".format(_get_default_variables_dict()["IntraMEMC-2Freq"]),
         "MEMC-2Freq": "MEMC MC moves (only GEMC_NPT, GEMC_NVT, and GCMC) : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which specified number of small molecule kind will be "
-        "exchanged with a specified large molecule kind in defined sub-volume, between"
-        "simulation boxes. Backbone of small and large molecule kind will be used to insert "
-        "the large molecule more efficiently. "
-        "This move needs additional information such as ExchangeVolumeDim, ExchangeRatio, "
-        "ExchangeSmallKind, ExchangeLargeKind, SmallKindBackBone, and LargeKindBackBone. "
-        "Note: all of the move types are not available in for every ensemble."
-        "Note: all of the move fractions must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["MEMC-2Freq"]),
+                      "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                      "Fractional percentage at which specified number of small molecule kind will be "
+                      "exchanged with a specified large molecule kind in defined sub-volume, between"
+                      "simulation boxes. Backbone of small and large molecule kind will be used to insert "
+                      "the large molecule more efficiently. "
+                      "This move needs additional information such as ExchangeVolumeDim, ExchangeRatio, "
+                      "ExchangeSmallKind, ExchangeLargeKind, SmallKindBackBone, and LargeKindBackBone. "
+                      "Note: all of the move types are not available in for every ensemble."
+                      "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+                      "".format(_get_default_variables_dict()["MEMC-2Freq"]),
         "IntraMEMC-3Freq": "MEMC MC moves (all ensembles)                     : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which specified number of small molecule kind will be "
-        "exchanged with a specified large molecule kind in defined sub-volume within same "
-        "simulation box. Specified atom of the large molecule kind will be used to insert "
-        "the large molecule using coupled-decoupled configurational-bias. This move needs "
-        "additional information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
-        "ExchangeLargeKind, and LargeKindBackBone. "
-        "Note: all of the move types are not available in for every ensemble."
-        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-        "".format(_get_default_variables_dict()["IntraMEMC-3Freq"]),
+                           "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                           "Fractional percentage at which specified number of small molecule kind will be "
+                           "exchanged with a specified large molecule kind in defined sub-volume within same "
+                           "simulation box. Specified atom of the large molecule kind will be used to insert "
+                           "the large molecule using coupled-decoupled configurational-bias. This move needs "
+                           "additional information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
+                           "ExchangeLargeKind, and LargeKindBackBone. "
+                           "Note: all of the move types are not available in for every ensemble."
+                           "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+                           "".format(_get_default_variables_dict()["IntraMEMC-3Freq"]),
         "MEMC-3Freq": "MEMC MC moves (only GEMC_NPT, GEMC_NVT, and GCMC) : "
-        "int or float (0 <= value <= 1), default are specific for each "
-        "ensemble {}. "
-        "Fractional percentage at which specified number of small molecule kind will be exchanged "
-        "with a specified large molecule kind in defined sub-volume, between simulation boxes. "
-        "Specified atom of the large molecule kind will be used to insert the large molecule "
-        "using coupled-decoupled configurational-bias. This move need additional information "
-        "such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, ExchangeLargeKind, "
-        "and LargeKindBackBone. "
-        "Note: all of the move types are not available in for every ensemble."
-        "Note: all of the move fractions must sum to 1, or the control file writer will fail.  "
-        "".format(_get_default_variables_dict()["MEMC-3Freq"]),
+                      "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+                      "Fractional percentage at which specified number of small molecule kind will be exchanged "
+                      "with a specified large molecule kind in defined sub-volume, between simulation boxes. "
+                      "Specified atom of the large molecule kind will be used to insert the large molecule "
+                      "using coupled-decoupled configurational-bias. This move need additional information "
+                      "such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, ExchangeLargeKind, "
+                      "and LargeKindBackBone. "
+                      "Note: all of the move types are not available in for every ensemble."
+                      "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+                      "".format(_get_default_variables_dict()["MEMC-3Freq"]),
         # MEMC move parameters
         "ExchangeVolumeDim": "MEMC parameters (all ensembles)                   : "
-        "list of 3 floats or integers "
-        "[int or float (> 0), int or float (> 0), int or float (> 0)]"
-        " or [X-dimension, Y-dimension, Z-dimension)], "
-        "default = {}. "
-        "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, the exchange "
-        "subvolume must be defined. The exchange sub-volume is defined as an orthogonal box "
-        "with x, y, and z-dimensions, where small molecule/molecules kind will be selected "
-        "from to be exchanged with a large molecule kind. "
-        "Note: Currently, the X and Y dimension cannot be set independently (X = Y = max(X, Y)). "
-        "Note: A heuristic for setting good values of the x, y, and z-dimensions is to use"
-        "the geometric size of the large molecule plus 1-2 Å in each dimension. "
-        "Note: In case of exchanging 1 small molecule kind with 1 large molecule kind in "
-        "IntraMEMC-2, IntraMEMC-3, MEMC-2, MEMC-3 Monte Carlo moves, the sub-volume "
-        "dimension has no effect on acceptance rate. "
-        "".format(_get_default_variables_dict()["ExchangeVolumeDim"]),
+                             "list of 3 floats or integers "
+                             "[int or float (> 0), int or float (> 0), int or float (> 0)]"
+                             " or [X-dimension, Y-dimension, Z-dimension)], default = {}. "
+                             "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, the exchange "
+                             "subvolume must be defined. The exchange sub-volume is defined as an orthogonal box "
+                             "with x, y, and z-dimensions, where small molecule/molecules kind will be selected "
+                             "from to be exchanged with a large molecule kind. "
+                             "Note: Currently, the X and Y dimension cannot be set independently (X = Y = max(X, Y)). "
+                             "Note: A heuristic for setting good values of the x, y, and z-dimensions is to use "
+                             "the geometric size of the large molecule plus 1-2 Å in each dimension. "
+                             "Note: In case of exchanging 1 small molecule kind with 1 large molecule kind in "
+                             "IntraMEMC-2, IntraMEMC-3, MEMC-2, MEMC-3 Monte Carlo moves, the sub-volume "
+                             "dimension has no effect on acceptance rate. "
+                             "".format(_get_default_variables_dict()["ExchangeVolumeDim"]),
         "MEMC_DataInput": "MEMC parameters (availablity based on selelection): nested lists, "
-        + "default = {}.  ".format(
-            _get_default_variables_dict()["MEMC_DataInput"]
-        )
-        + "Enter data as a list with some sub-lists as follows: "
-        "[[ExchangeRatio_int (> 0), ExchangeLargeKind_str, "
-        "[LargeKindBackBone_atom_1_str_or_NONE, LargeKindBackBone_atom_2_str_or_NONE ], "
-        "ExchangeSmallKind_str, "
-        "[SmallKindBackBone_atom_1_str_or_NONE, SmallKindBackBone_atom_2_str_or_NONE ]], ..., "
-        "[ExchangeRatio_int (> 0), ExchangeLargeKind_str, "
-        "[LargeKindBackBone_atom_1_str_or_NONE, LargeKindBackBone_atom_2_str_or_NONE ], "
-        "ExchangeSmallKind_str, "
-        "[SmallKindBackBone_atom_1_str_or_NONE, SmallKindBackBone_atom_2_str_or_NONE ]. "
-        "NOTE: CURRENTLY ALL THESE INPUTS NEED TO BE SPECIFIED, REGARDLESS OF THE MEMC TYPE "
-        "SELECTION. IF THE SmallKindBackBone or LargeKindBackBone IS NOT REQUIRED FOR THE "
-        "MEMC TYPE, "
-        "None CAN BE USED IN PLACE OF A STRING. "
-        "Note: These strings must match the residue in the psf and psb files or it will fail. "
-        "It is recommended that the user print the Charmm object psf and pdb files "
-        "and review the residue names that match the atom name before using the in "
-        "the  MEMC_DataInput variable input."
-        "Note: see the below data explanations for the ExchangeRatio, ExchangeSmallKind, "
-        "ExchangeLargeKind, LargeKindBackBone, SmallKindBackBone. "
-        "Example 1 (MEMC-1) : [ [1, 'WAT', [None, None], 'wat', [None, None]] , "
-        "[1, 'WAT', [None, None], 'wat', [None, None]] . "
-        "Example 2 (MEMC-2): [ [1, 'WAT', ['O1', 'H1'], 'wat', ['O1', 'H1' ]] , "
-        " [1, 'WAT', ['H1', 'H2'], 'wat', ['H1', 'H2' ]] . "
-        "Example 3 (MEMC-3) : [ [2, 'WAT', 'O1', 'H1'], 'wat', [None, None]] , "
-        "[2, 'WAT', ['H1', 'H2'], 'wat', [None, None]] .\n"
-        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeRatio     = MEMC parameters (all ensembles): "
-        "int (> 0), default = None. The Ratio of exchanging "
-        "small molecule/molecules with 1 large molecule. "
-        "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, "
-        "the exchange ratio must be defined. "
-        "The exchange ratio defines how many small molecule will be "
-        "exchanged with 1 large molecule. For each large-small molecule pairs, "
-        "one exchange ratio must be defined. \n"
-        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeSmallKind = MEMC parameters (all ensembles): "
-        "str, default = None. The small molecule "
-        "kind (resname) to be exchanged. "
-        "Note: ONLY 4 characters can be used for the strings. "
-        "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, "
-        "the small molecule kind to be exchanged with a large molecule "
-        "kind must be defined. Multiple small molecule kind can be specified.  \n"
-        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeLargeKind = MEMC parameters (all ensembles): "
-        "str, default = None. The large molecule "
-        "kind (resname) to be exchanged. "
-        "Note: ONLY 4 characters can be used for the strings. "
-        "To use all variations of MEMC and Intra-MEMC Monte Carlo moves, "
-        "the large molecule kind to be exchanged with small molecule "
-        "kind must be defined. Multiple large molecule kind can be specified. \n"
-        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- LargeKindBackBone = MEMC parameters (all ensembles): "
-        "list [str, str] or [None, None], default = None "
-        "Note: ONLY 4 characters can be used for the strings. "
-        "The [None, None] values can only be used if that MEMC type does not require them. "
-        "The strings for the the atom name 1 and atom name 2 that belong to the large "
-        "molecule’s backbone (i.e., [str_for_atom_name_1, str_for_atom_name_2]) "
-        "To use MEMC-2, MEMC-3, IntraMEMC-2, and IntraMEMC-3 Monte Carlo moves, the "
-        "large molecule backbone must be defined. The backbone of the molecule is defined "
-        "as a vector that connects two atoms belong to the large molecule. The large "
-        "molecule backbone will be used to align the sub-volume in MEMC-2 and IntraMEMC-2 "
-        "moves, while in MEMC-3 and IntraMEMC-3 moves, it uses the atom name to start "
-        "growing the large molecule using coupled-decoupled configurational-bias. For "
-        "each large-small molecule pairs, two atom names must be defined. "
-        "Note: all atom names in the molecule must be unique. "
-        "Note: In MEMC-3 and IntraMEMC-3 Monte Carlo moves, both atom names must be same, "
-        "otherwise program will be terminated. "
-        "Note: If the large molecule has only one atom (mono atomic molecules), "
-        "same atom name must be used for str_for_atom_name_1 and str_for_atom_name_2 "
-        "of the LargeKindBackBone.  \n"
-        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- SmallKindBackBone = MEMC parameters (all ensembles): "
-        " list [str, str] or [None, None], default = None "
-        "Note: ONLY 4 characters can be used for the strings. "
-        "The [None, None] values can only be used if that MEMC type does not require them."
-        "The strings for the the atom name 1 and atom name 2 that belong to the small "
-        "molecule’s backbone (i.e., [str_for_atom_name_1, str_for_atom_name_2]) "
-        "To use MEMC-2, and IntraMEMC-2 Monte Carlo moves, the small molecule backbone "
-        "must be defined. The backbone of the molecule is defined as a vector that "
-        "connects two atoms belong to the small molecule and will be used to align the "
-        "sub-volume. For each large-small molecule pairs, two atom names must be defined. "
-        "Note: all atom names in the molecule must be unique. "
-        "Note: If the small molecule has only one atom (mono atomic molecules), same atom "
-        "name must be used str_for_atom_name_1 and str_for_atom_name_2 "
-        "of the SmallKindBackBone. ",
+                          + "default = {}.  ".format(_get_default_variables_dict()["MEMC_DataInput"]
+                                                     )
+                          + "Enter data as a list with some sub-lists as follows: "
+                            "[[ExchangeRatio_int (> 0), ExchangeLargeKind_str, "
+                            "[LargeKindBackBone_atom_1_str_or_NONE, LargeKindBackBone_atom_2_str_or_NONE ], "
+                            "ExchangeSmallKind_str, "
+                            "[SmallKindBackBone_atom_1_str_or_NONE, SmallKindBackBone_atom_2_str_or_NONE ]], ..., "
+                            "[ExchangeRatio_int (> 0), ExchangeLargeKind_str, "
+                            "[LargeKindBackBone_atom_1_str_or_NONE, LargeKindBackBone_atom_2_str_or_NONE ], "
+                            "ExchangeSmallKind_str, "
+                            "[SmallKindBackBone_atom_1_str_or_NONE, SmallKindBackBone_atom_2_str_or_NONE ]. "
+                            "NOTE: CURRENTLY ALL THESE INPUTS NEED TO BE SPECIFIED, REGARDLESS OF THE MEMC TYPE "
+                            "SELECTION. IF THE SmallKindBackBone or LargeKindBackBone IS NOT REQUIRED FOR THE "
+                            "MEMC TYPE, None CAN BE USED IN PLACE OF A STRING. "
+                            "Note: These strings must match the residue in the psf and psb files or it will fail. "
+                            "It is recommended that the user print the Charmm object psf and pdb files "
+                            "and review the residue names that match the atom name before using the in "
+                            "the  MEMC_DataInput variable input."
+                            "Note: see the below data explanations for the ExchangeRatio, ExchangeSmallKind, "
+                            "ExchangeLargeKind, LargeKindBackBone, SmallKindBackBone. "
+                            "Example 1 (MEMC-1) : [ [1, 'WAT', [None, None], 'wat', [None, None]] , "
+                            "[1, 'WAT', [None, None], 'wat', [None, None]] . "
+                            "Example 2 (MEMC-2): [ [1, 'WAT', ['O1', 'H1'], 'wat', ['O1', 'H1' ]] , "
+                            "[1, 'WAT', ['H1', 'H2'], 'wat', ['H1', 'H2' ]] . "
+                            "Example 3 (MEMC-3) : [ [2, 'WAT', 'O1', 'H1'], 'wat', [None, None]] , "
+                            "[2, 'WAT', ['H1', 'H2'], 'wat', [None, None]] .\n"
+                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeRatio     = MEMC parameters (all ensembles): "
+                            "int (> 0), default = None. The Ratio of exchanging "
+                            "small molecule/molecules with 1 large molecule. "
+                            "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, "
+                            "the exchange ratio must be defined. "
+                            "The exchange ratio defines how many small molecule will be "
+                            "exchanged with 1 large molecule. For each large-small molecule pairs, "
+                            "one exchange ratio must be defined. \n"
+                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeSmallKind = MEMC parameters (all ensembles): "
+                            "str, default = None. The small molecule "
+                            "kind (resname) to be exchanged. "
+                            "Note: ONLY 4 characters can be used for the strings. "
+                            "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, "
+                            "the small molecule kind to be exchanged with a large molecule "
+                            "kind must be defined. Multiple small molecule kind can be specified.  \n"
+                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeLargeKind = MEMC parameters (all ensembles): "
+                            "str, default = None. The large molecule "
+                            "kind (resname) to be exchanged. "
+                            "Note: ONLY 4 characters can be used for the strings. "
+                            "To use all variations of MEMC and Intra-MEMC Monte Carlo moves, "
+                            "the large molecule kind to be exchanged with small molecule "
+                            "kind must be defined. Multiple large molecule kind can be specified. \n"
+                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- LargeKindBackBone = MEMC parameters (all ensembles): "
+                            "list [str, str] or [None, None], default = None "
+                            "Note: ONLY 4 characters can be used for the strings. "
+                            "The [None, None] values can only be used if that MEMC type does not require them. "
+                            "The strings for the the atom name 1 and atom name 2 that belong to the large "
+                            "molecule’s backbone (i.e., [str_for_atom_name_1, str_for_atom_name_2]) "
+                            "To use MEMC-2, MEMC-3, IntraMEMC-2, and IntraMEMC-3 Monte Carlo moves, the "
+                            "large molecule backbone must be defined. The backbone of the molecule is defined "
+                            "as a vector that connects two atoms belong to the large molecule. The large "
+                            "molecule backbone will be used to align the sub-volume in MEMC-2 and IntraMEMC-2 "
+                            "moves, while in MEMC-3 and IntraMEMC-3 moves, it uses the atom name to start "
+                            "growing the large molecule using coupled-decoupled configurational-bias. For "
+                            "each large-small molecule pairs, two atom names must be defined. "
+                            "Note: all atom names in the molecule must be unique. "
+                            "Note: In MEMC-3 and IntraMEMC-3 Monte Carlo moves, both atom names must be same, "
+                            "otherwise program will be terminated. "
+                            "Note: If the large molecule has only one atom (mono atomic molecules), "
+                            "same atom name must be used for str_for_atom_name_1 and str_for_atom_name_2 "
+                            "of the LargeKindBackBone.  \n"
+                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- SmallKindBackBone = MEMC parameters (all ensembles): "
+                            " list [str, str] or [None, None], default = None "
+                            "Note: ONLY 4 characters can be used for the strings. "
+                            "The [None, None] values can only be used if that MEMC type does not require them."
+                            "The strings for the the atom name 1 and atom name 2 that belong to the small "
+                            "molecule’s backbone (i.e., [str_for_atom_name_1, str_for_atom_name_2]) "
+                            "To use MEMC-2, and IntraMEMC-2 Monte Carlo moves, the small molecule backbone "
+                            "must be defined. The backbone of the molecule is defined as a vector that "
+                            "connects two atoms belong to the small molecule and will be used to align the "
+                            "sub-volume. For each large-small molecule pairs, two atom names must be defined. "
+                            "Note: all atom names in the molecule must be unique. "
+                            "Note: If the small molecule has only one atom (mono atomic molecules), same atom "
+                            "name must be used str_for_atom_name_1 and str_for_atom_name_2 "
+                            "of the SmallKindBackBone. ",
         # ******************************************************************************************************
         # Definitions in this function are copied to a large extent from the GOMC manual release version 2.60 (end)
         # insert citation here:
@@ -814,8 +830,6 @@ def _get_default_variables_dict():
     """
 
     default_input_variables_dict = {
-        "Restart": False,
-        "RestartCheckpoint": False,
         "PRNG": "RANDOM",
         "ParaTypeCHARMM": True,
         "ParaTypeMie": False,
@@ -852,6 +866,7 @@ def _get_default_variables_dict():
         # Control file (.conf file ) output controls/parameters
         "OutputName": "Output_data",
         "CoordinatesFreq": [True, 1000000],
+        "DCDFreq": [False, 1000000],  # set to False until this is in the new official GOMC software release
         "RestartFreq": [True, 1000000],
         "CheckpointFreq": [True, 1000000],
         "ConsoleFreq": [True, 10000],
@@ -1010,7 +1025,7 @@ def check_valid_ensemble_files(ensemble_type, testing_ensemble_files_list):
     bad_key_inputs_List = []
 
     req_ensemble_files_set = set(_get_required_data(description=False))
-    testing_ensemble_files_set = set(testing_ensemble_files_List)
+    testing_ensemble_files_set = set(testing_ensemble_files_list)
 
     extra = testing_ensemble_files_set - req_ensemble_files_set
     missing = req_ensemble_files_set - testing_ensemble_files_set
@@ -1193,6 +1208,7 @@ def _get_possible_ensemble_input_variables(ensemble_type):
     output_freq_variables_list = [
         "OutputName",
         "CoordinatesFreq",
+        "DCDFreq",
         "RestartFreq",
         "CheckpointFreq",
         "ConsoleFreq",
@@ -1232,8 +1248,6 @@ def _get_possible_ensemble_input_variables(ensemble_type):
     ]
 
     basic_sim_info_variables_list = [
-        "Restart",
-        "RestartCheckpoint",
         "PRNG",
         "ParaTypeCHARMM",
         "ParaTypeMie",
@@ -1336,21 +1350,46 @@ class GOMCControl:
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_files_inputs_exist : bool, (default = False)
+    check_input_files_exist : bool, (default=True)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
-    override_ff_directory_filename : str, (default = None)
-        Override all other force field directory and filename inputs.
-    override_box_0_pdb_directory_filename : str, (default = None)
-        Override all other box 0 pdb directory and filename inputs.
-    override_box_0_psf_directory_filename : str, (default = None)
-        Override all other box 0 psf directory and filename inputs.
-    override_box_1_pdb_directory_filename : str, (default = None)
-        Override all other box 1 pdb directory and filename inputs.
-    override_box_1_psf_directory_filename : str, (default = None)
-        Override all other box 1  psf directory and filename inputs.
+    Restart : boolean, default = False
+        Determines whether to restart the simulation from restart file
+        (``*_restart.pdb`` and ``*_restart.psf``) or not.
+    RestartCheckpoint : boolean, default = False
+        Determines whether to restart the simulation with the checkpoint
+        file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
+        would result in an identical outcome, as if previous simulation was continued.
+    Parameters : str, (default = None)
+        Override all other force field directory and filename inputs with the correct extension.
+    Coordinates_box_0 : str, (default = None)
+        Override all other box 0 pdb directory and filename inputs with the correct extension.
+    Structure_box_0 : str, (default = None)
+        Override all other box 0 psf directory and filename inputs with the correct extension.
+    Coordinates_box_1 : str, (default = None)
+        Override all other box 1 pdb directory and filename inputs with the correct extension.
+    Structure_box_1 : str, (default = None)
+        Override all other box 1  psf directory and filename inputs with the correct extension.
+    binCoordinates_box_0 : str, (default = None)
+        The box 0 binary coordinate file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy.
+    extendedSystem_box_0 : str, (default = None)
+        The box 0 vectors origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_0 : str, (default = None)
+        The box 0 binary velocity file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy. These velocities are only passed thru
+        GOMC since Monte Carlo simulations do not utilize any velocity information.
+    binCoordinates_box_1 : str, (default = None)
+        The box 1 binary coordinate file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy.
+    extendedSystem_box_1 : str, (default = None)
+        The box 1 vectors origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_1 : str, (default = None)
+        The box 1 binary velocity file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy. These velocities are only passed thru
+        GOMC since Monte Carlo simulations do not utilize any velocity information.
     input_variables_dict: dict, default = None
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
@@ -1367,13 +1406,6 @@ class GOMCControl:
     # input_variables_dict options (keys and values) - (start)
     # Note: the input_variables_dict keys are also attributes
     # *******************************************************************
-    Restart : boolean, default = False
-        Determines whether to restart the simulation from restart file
-        (``*_restart.pdb`` and ``*_restart.psf``) or not.
-    RestartCheckpoint : boolean, default = False
-        Determines whether to restart the simulation with the checkpoint
-        file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
-        would result in an identical outcome, as if previous simulation was continued.
     PRNG : string or int (>= 0) ("RANDOM" or int), default = "RANDOM"
         PRNG = Pseudo-Random Number Generator (PRNG). There are two (2) options, entering
         the string, "RANDOM", or a integer.
@@ -1572,6 +1604,12 @@ class GOMCControl:
     CoordinatesFreq : list [bool , int (> 0)] or [Generate_data_bool , steps_per_data_output_int],
         default = [True, 1M] or [True , set via formula based on the number of RunSteps or M max]
         Controls output of PDB file (coordinates). If bool is True, this
+        enables outputting the coordinate files at the integer frequency
+        (set steps_per_data_output_int), while "False" disables outputting
+        the coordinates.
+    DCDFreq : list [bool , int (> 0)] or [Generate_data_bool , steps_per_data_output_int],
+        default = [True, 1M] or [True , set via formula based on the number of RunSteps or M max]
+        Controls output of DCD file (coordinates). If bool is True, this
         enables outputting the coordinate files at the integer frequency
         (set steps_per_data_output_int), while "False" disables outputting
         the coordinates.
@@ -1926,21 +1964,46 @@ class GOMCControl:
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_files_inputs_exist : bool, (default = False)
+    check_input_files_exist : bool, (default=True)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
-    override_ff_directory_filename : str, (default = None)
-        Override all other force field directory and filename inputs.
-    override_box_0_pdb_directory_filename : str, (default = None)
-        Override all other box 0 pdb directory and filename inputs.
-    override_box_0_psf_directory_filename : str, (default = None)
-        Override all other box 0 psf directory and filename inputs.
-    override_box_1_pdb_directory_filename : str, (default = None)
-        Override all other box 1 pdb directory and filename inputs.
-    override_box_1_psf_directory_filename : str, (default = None)
-        Override all other box 1  psf directory and filename inputs.
+    Restart : boolean, default = False
+        Determines whether to restart the simulation from restart file
+        (``*_restart.pdb`` and ``*_restart.psf``) or not.
+    RestartCheckpoint : boolean, default = False
+        Determines whether to restart the simulation with the checkpoint
+        file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
+        would result in an identical outcome, as if previous simulation was continued.
+    Parameters : str, (default = None)
+        Override all other force field directory and filename inputs with the correct extension.
+    Coordinates_box_0 : str, (default = None)
+        Override all other box 0 pdb directory and filename inputs with the correct extension.
+    Structure_box_0 : str, (default = None)
+        Override all other box 0 psf directory and filename inputs with the correct extension.
+    Coordinates_box_1 : str, (default = None)
+        Override all other box 1 pdb directory and filename inputs with the correct extension.
+    Structure_box_1 : str, (default = None)
+        Override all other box 1  psf directory and filename inputs with the correct extension.
+    binCoordinates_box_0 : str, (default = None)
+        The box 0 binary coordinate file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy.
+    extendedSystem_box_0 : str, (default = None)
+        The box 0 vectors origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_0 : str, (default = None)
+        The box 0 binary velocity file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy. These velocities are only passed thru
+        GOMC since Monte Carlo simulations do not utilize any velocity information.
+    binCoordinates_box_1 : str, (default = None)
+        The box 1 binary coordinate file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy.
+    extendedSystem_box_1 : str, (default = None)
+        The box 1 vectors origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_1 : str, (default = None)
+        The box 1 binary velocity file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy. These velocities are only passed thru
+        GOMC since Monte Carlo simulations do not utilize any velocity information.
     input_variables_dict: dict, default = None
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
@@ -2038,12 +2101,20 @@ class GOMCControl:
         RunSteps,
         Temperature,
         ff_psf_pdb_file_directory=None,
-        override_check_input_files_exist=False,
-        override_ff_directory_filename=None,
-        override_box_0_pdb_directory_filename=None,
-        override_box_0_psf_directory_filename=None,
-        override_box_1_pdb_directory_filename=None,
-        override_box_1_psf_directory_filename=None,
+        check_input_files_exist=True,
+        Restart=False,
+        RestartCheckpoint=False,
+        Parameters=None,
+        Coordinates_box_0=None,
+        Structure_box_0=None,
+        Coordinates_box_1=None,
+        Structure_box_1=None,
+        binCoordinates_box_0=None,
+        extendedSystem_box_0=None,
+        binVelocities_box_0=None,
+        binCoordinates_box_1=None,
+        extendedSystem_box_1=None,
+        binVelocities_box_1=None,
         input_variables_dict=None,
     ):
 
@@ -2059,7 +2130,7 @@ class GOMCControl:
             print_error_message = (
                 "The variable supplied as a charmm_object ({}) is not a "
                 "charmm_object ({})".format(
-                    type(mf_charmm.Charmm), type(mf_charmm.Charmm)
+                    type(charmm_object), type(mf_charmm.Charmm)
                 )
             )
             raise TypeError(print_error_message)
@@ -2080,6 +2151,75 @@ class GOMCControl:
             )
             raise ValueError(print_error_message)
 
+        # check if check_input_files_exist is a boolean
+        if check_input_files_exist is not None:
+            _check_if_bool("check_input_files_exist", check_input_files_exist)
+
+        # set the restart attributes:
+        if Restart is not None:
+            _check_if_bool("Restart", Restart)
+            self.Restart = Restart
+        if RestartCheckpoint is not None:
+            _check_if_bool("RestartCheckpoint", RestartCheckpoint)
+            self.RestartCheckpoint = RestartCheckpoint
+
+        self.binCoordinates_box_0 = binCoordinates_box_0
+        self.extendedSystem_box_0 = extendedSystem_box_0
+        self.binVelocities_box_0 = binVelocities_box_0
+        self.binCoordinates_box_1 = binCoordinates_box_1
+        self.extendedSystem_box_1 = extendedSystem_box_1
+        self.binVelocities_box_1 = binVelocities_box_1
+
+        # check if the binary restart files are provided correctly
+        if self.Restart is True and self.ensemble_type in ["NVT", "NPT"]:
+            if (self.binCoordinates_box_0 is not None \
+                    or self.extendedSystem_box_0 is not None) \
+                    and (self.binCoordinates_box_0 is None \
+                         or self.extendedSystem_box_0 is None):
+                print_error_message = 'ERROR: To restart a simulation with the binary files both the coor and ' \
+                                      'xsc files for box 0 must be provided.'
+                raise ValueError(print_error_message)
+
+            elif self.binVelocities_box_0 is not None \
+                    and (self.binCoordinates_box_0 is None \
+                    or self.extendedSystem_box_0 is None):
+                print_error_message = 'ERROR: To restart a "NVT", "NPT" simulation with the ' \
+                                      'velocity binary files, the velocity files for box 0 ' \
+                                      'must be provided.'
+                raise ValueError(print_error_message)
+
+        if self.Restart is True and self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]:
+            if (self.binCoordinates_box_0 is not None \
+                or self.extendedSystem_box_0 is not None \
+                or self.binCoordinates_box_1 is not None \
+                or self.extendedSystem_box_1 is not None) \
+                    and (self.binCoordinates_box_0 is None \
+                         or self.extendedSystem_box_0 is None \
+                         or self.binCoordinates_box_1 is None \
+                         or self.extendedSystem_box_1 is None):
+                print_error_message = 'ERROR: To restart a simulation with the binary files both the coor and ' \
+                                      'xsc files for box 0 and box 1 must be provided.'
+                raise ValueError(print_error_message)
+
+            elif (self.binVelocities_box_0 is not None \
+                        or self.binVelocities_box_1 is not None) \
+                    and (self.binVelocities_box_0 is None \
+                         or self.binVelocities_box_1 is None):
+                print_error_message = 'ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the ' \
+                                      'velocity binary files, both the velocity files for box 0 and box 1 ' \
+                                      'must be provided.'
+                raise ValueError(print_error_message)
+
+            if self.binCoordinates_box_0 is None \
+                or self.extendedSystem_box_0 is None \
+                or self.binCoordinates_box_1 is None \
+                or self.extendedSystem_box_1 is None:
+                print_error_message = 'ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the ' \
+                                      'velocity binary files, both the coor and xsc files files for box 0 ' \
+                                      'and box 1 must be provided.'
+                raise ValueError(print_error_message)
+
+
         self.RunSteps = RunSteps
         self.Temperature = Temperature
         self.ff_psf_pdb_file_directory = ff_psf_pdb_file_directory
@@ -2087,19 +2227,21 @@ class GOMCControl:
             not isinstance(self.ff_psf_pdb_file_directory, str)
             and self.ff_psf_pdb_file_directory is not None
         ):
-            _check_if_string('ff_psf_pdb_file_directory',
-                             self.ff_psf_pdb_file_directory,
-                             'force field, pdb, and psf')
+            _check_if_string_and_extension('ff_psf_pdb_file_directory',
+                                           self.ff_psf_pdb_file_directory,
+                                           'force field, pdb, and psf',
+                                           expected_file_extension=None)
 
         if (
             charmm_object.ff_filename is not None
             and isinstance(charmm_object.ff_filename, str) is True
         ):
-            if override_ff_directory_filename is not None:
-                _check_if_string('override_ff_directory_filename',
-                                 override_ff_directory_filename,
-                                 'force field')
-                self.ff_filename = override_ff_directory_filename
+            if Parameters is not None:
+                _check_if_string_and_extension('Parameters',
+                                               Parameters,
+                                               'force field',
+                                               expected_file_extension=['.inp', '.par'])
+                self.ff_filename = Parameters
             elif self.ff_psf_pdb_file_directory is None:
                 self.ff_filename = charmm_object.ff_filename
             else:
@@ -2111,7 +2253,7 @@ class GOMCControl:
             _check_if_input_files_exist(
                 self.ff_filename,
                 "force field file or parameter file",
-                override_check_input_files_exist=override_check_input_files_exist,
+                check_input_files_exist=check_input_files_exist,
             )
         elif (
             charmm_object.ff_filename is None
@@ -2132,15 +2274,17 @@ class GOMCControl:
             charmm_object.filename_box_0 is not None
             and isinstance(charmm_object.filename_box_0, str) is True
         ):
-            if override_box_0_pdb_directory_filename is not None:
-                _check_if_string('override_box_0_pdb_directory_filename',
-                                 override_box_0_pdb_directory_filename,
-                                 'pdb')
-                _check_if_string('override_box_0_psf_directory_filename',
-                                 override_box_0_psf_directory_filename,
-                                 'psf')
-                self.Coordinates_box_0 = override_box_0_pdb_directory_filename
-                self.Structures_box_0 = override_box_0_psf_directory_filename
+            if Coordinates_box_0 is not None:
+                _check_if_string_and_extension('Coordinates_box_0',
+                                               Coordinates_box_0,
+                                               'pdb',
+                                               expected_file_extension=['.pdb'])
+                _check_if_string_and_extension('Structure_box_0',
+                                               Structure_box_0,
+                                               'psf',
+                                               expected_file_extension=['.psf'])
+                self.Coordinates_box_0 = Coordinates_box_0
+                self.Structures_box_0 = Structure_box_0
             elif self.ff_psf_pdb_file_directory is None:
                 self.Coordinates_box_0 = "{}.pdb".format(
                     charmm_object.filename_box_0
@@ -2159,27 +2303,62 @@ class GOMCControl:
             _check_if_input_files_exist(
                 self.Coordinates_box_0,
                 "box 0 pdb file",
-                override_check_input_files_exist=override_check_input_files_exist,
+                check_input_files_exist=check_input_files_exist,
             )
             _check_if_input_files_exist(
                 self.Structures_box_0,
                 "box 0 psf file",
-                override_check_input_files_exist=override_check_input_files_exist,
+                check_input_files_exist=check_input_files_exist,
             )
+
+            # Box 0 restarting files with increased accuracy (coor, xsc) and a velocity passing input
+            if self.binCoordinates_box_0 is not None \
+                    and self.extendedSystem_box_0 is not None:
+                _check_if_string_and_extension('binCoordinates_box_0',
+                                               self.binCoordinates_box_0,
+                                               'coor',
+                                               expected_file_extension=['.coor'])
+                _check_if_string_and_extension('Structure_box_0',
+                                               self.extendedSystem_box_0,
+                                               'xsc',
+                                               expected_file_extension=['.xsc'])
+                _check_if_input_files_exist(
+                    self.binCoordinates_box_0,
+                    "box 0 coor file",
+                    check_input_files_exist=check_input_files_exist,
+                )
+                _check_if_input_files_exist(
+                    self.extendedSystem_box_0,
+                    "box 0 xsc file",
+                    check_input_files_exist=check_input_files_exist,
+                )
+
+            if self.binVelocities_box_0 is not None:
+                _check_if_string_and_extension('binVelocities_box_0',
+                                               self.binVelocities_box_0,
+                                               'velocity',
+                                               expected_file_extension=['.vel'])
+                _check_if_input_files_exist(
+                    self.binVelocities_box_0,
+                    "box 0 velocity file",
+                    check_input_files_exist=check_input_files_exist,
+                )
 
         if (
             charmm_object.filename_box_1 is not None
             and isinstance(charmm_object.filename_box_1, str) is True
         ):
-            if override_box_1_pdb_directory_filename is not None:
-                _check_if_string('override_box_1_pdb_directory_filename',
-                                 override_box_1_pdb_directory_filename,
-                                 'pdb')
-                _check_if_string('override_box_1_psf_directory_filename',
-                                 override_box_1_psf_directory_filename,
-                                 'psf')
-                self.Coordinates_box_1 = override_box_1_pdb_directory_filename
-                self.Structures_box_1 = override_box_1_psf_directory_filename
+            if Coordinates_box_1 is not None:
+                _check_if_string_and_extension('Coordinates_box_1',
+                                               Coordinates_box_1,
+                                               'pdb',
+                                               expected_file_extension=['.pdb'])
+                _check_if_string_and_extension('Structure_box_1',
+                                               Structure_box_1,
+                                               'psf',
+                                               expected_file_extension=['.psf'])
+                self.Coordinates_box_1 = Coordinates_box_1
+                self.Structures_box_1 = Structure_box_1
             elif self.ff_psf_pdb_file_directory is None:
                 self.Coordinates_box_1 = "{}.pdb".format(
                     charmm_object.filename_box_1
@@ -2198,13 +2377,46 @@ class GOMCControl:
             _check_if_input_files_exist(
                 self.Coordinates_box_1,
                 "box 1 pdb file",
-                override_check_input_files_exist=override_check_input_files_exist,
+                check_input_files_exist=check_input_files_exist,
             )
             _check_if_input_files_exist(
                 self.Structures_box_1,
                 "box 1 psf file",
-                override_check_input_files_exist=override_check_input_files_exist,
+                check_input_files_exist=check_input_files_exist,
             )
+
+            # Box 1 restarting files with increased accuracy (coor, xsc) and a velocity passing input
+            if self.binCoordinates_box_1 is not None \
+                    and self.extendedSystem_box_1 is not None:
+                _check_if_string_and_extension('binCoordinates_box_1',
+                                               self.binCoordinates_box_1,
+                                               'coor',
+                                               expected_file_extension=['.coor'])
+                _check_if_string_and_extension('Structure_box_1',
+                                               self.extendedSystem_box_1,
+                                               'xsc',
+                                               expected_file_extension=['.xsc'])
+                _check_if_input_files_exist(
+                    self.binCoordinates_box_1,
+                    "box 1 coor file",
+                    check_input_files_exist=check_input_files_exist,
+                )
+                _check_if_input_files_exist(
+                    self.extendedSystem_box_1,
+                    "box 1 xsc file",
+                    check_input_files_exist=check_input_files_exist,
+                )
+
+            if self.binVelocities_box_1 is not None:
+                _check_if_string_and_extension('binVelocities_box_1',
+                                               self.binVelocities_box_1,
+                                               'velocity',
+                                               expected_file_extension=['.vel'])
+                _check_if_input_files_exist(
+                    self.binVelocities_box_1,
+                    "box 0 velocity file",
+                    check_input_files_exist=check_input_files_exist,
+                )
 
         else:
             self.Coordinates_box_1 = None
@@ -2299,10 +2511,6 @@ class GOMCControl:
         # set all the other variable initally to None (they are corrected to their set or default values later)
         default_input_variables_dict = _get_default_variables_dict()
 
-        self.Restart = default_input_variables_dict["Restart"]
-        self.RestartCheckpoint = default_input_variables_dict[
-            "RestartCheckpoint"
-        ]
         self.PRNG = default_input_variables_dict["PRNG"]
         self.ParaTypeCHARMM = default_input_variables_dict["ParaTypeCHARMM"]
         self.ParaTypeMie = default_input_variables_dict["ParaTypeMie"]
@@ -2440,6 +2648,11 @@ class GOMCControl:
         # auto calculate the best CoordinatesFreq  for the number of self.RunSteps
         self.CoordinatesFreq = scale_gen_freq_for_run_steps_list_bool_int(
             default_input_variables_dict["CoordinatesFreq"], self.RunSteps
+        )
+
+        # auto calculate the best DCDFreq for the number of self.RunSteps
+        self.DCDFreq = scale_gen_freq_for_run_steps_list_bool_int(
+            default_input_variables_dict["DCDFreq"], self.RunSteps
         )
 
         # auto calculate the best ConsoleFreq  for the number of self.RunSteps
@@ -2710,34 +2923,6 @@ class GOMCControl:
 
         # check for bad input variables and list the bad ones
         for var_iter in range(0, len(input_var_keys_list)):
-            key = "Restart"
-            if input_var_keys_list[var_iter] == key:
-                self.ck_input_variable_true_or_false(
-                    self.input_variables_dict,
-                    key,
-                    bad_input_variables_values_list,
-                )
-
-                if (
-                    input_var_keys_list[var_iter] == key
-                    and key in possible_ensemble_variables_list
-                ):
-                    self.Restart = self.input_variables_dict[key]
-
-            key = "RestartCheckpoint"
-            if input_var_keys_list[var_iter] == key:
-                self.ck_input_variable_true_or_false(
-                    self.input_variables_dict,
-                    key,
-                    bad_input_variables_values_list,
-                )
-
-                if (
-                    input_var_keys_list[var_iter] == key
-                    and key in possible_ensemble_variables_list
-                ):
-                    self.RestartCheckpoint = self.input_variables_dict[key]
-
             key = "PRNG"
             if input_var_keys_list[var_iter] == key:
                 if (
@@ -3226,6 +3411,20 @@ class GOMCControl:
                     and key in possible_ensemble_variables_list
                 ):
                     self.CoordinatesFreq = self.input_variables_dict[key]
+
+            key = "DCDFreq"
+            if input_var_keys_list[var_iter] == key:
+                self.ck_input_variable_list_bool_int_greater_zero(
+                    self.input_variables_dict,
+                    key,
+                    bad_input_variables_values_list,
+                )
+
+                if (
+                    input_var_keys_list[var_iter] == key
+                    and key in possible_ensemble_variables_list
+                ):
+                    self.DCDFreq = self.input_variables_dict[key]
 
             key = "RestartFreq"
             if input_var_keys_list[var_iter] == key:
@@ -4665,6 +4864,40 @@ class GOMCControl:
             data_control_file.write(
                 "{:25s} {}\n".format("Structure 1", self.Structures_box_1)
             )
+
+        if self.Restart is True and self.binCoordinates_box_0 is not None \
+                and self.extendedSystem_box_0 is not None \
+                and self.ensemble_type in ["NVT", "NPT", "GEMC_NPT", "GEMC_NVT", "GCMC"]:
+            data_control_file.write(" \n")
+            data_control_file.write("####################################\n")
+            data_control_file.write("# INPUT BINARY FILES FOR RESTARTING (COORDINATE, XSC, VELOCITY FILES)\n")
+            data_control_file.write("####################################\n")
+            data_control_file.write(
+                "{:25s} {}\n".format("binCoordinates   0", self.binCoordinates_box_0)
+            )
+            data_control_file.write(
+                "{:25s} {}\n".format("extendedSystem 	0", self.extendedSystem_box_0)
+            )
+            if self.binVelocities_box_0 is not None:
+                data_control_file.write(
+                    "{:25s} {}\n".format("binVelocities   	0", self.binVelocities_box_0)
+                )
+            data_control_file.write(" \n")
+
+            if self.binCoordinates_box_1 is not None \
+                    and self.extendedSystem_box_1 is not None \
+                    and self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]:
+                data_control_file.write(
+                    "{:25s} {}\n".format("binCoordinates   1", self.binCoordinates_box_1)
+                )
+                data_control_file.write(
+                    "{:25s} {}\n".format("extendedSystem 	1", self.extendedSystem_box_1)
+                )
+                if self.binVelocities_box_1 is not None:
+                    data_control_file.write(
+                        "{:25s} {}\n".format("binVelocities   	1", self.binVelocities_box_1)
+                    )
+
         data_control_file.write(" \n")
         data_control_file.write(
             "############################################################################\n"
@@ -5116,6 +5349,15 @@ class GOMCControl:
                 self.CoordinatesFreq[1],
             )
         )
+        # set this only true if use dcd is true, until the DCDFreq is in a official release of GOMC
+        if self.DCDFreq[0] is True:
+            data_control_file.write(
+                "{:25s} {:10s} {}\n".format(
+                    "DCDFreq",
+                    str(self.DCDFreq[0]),
+                    self.DCDFreq[1],
+                )
+            )
         data_control_file.write(
             "{:25s} {:10s} {}\n".format(
                 "ConsoleFreq", str(self.ConsoleFreq[0]), self.ConsoleFreq[1]
@@ -6116,7 +6358,7 @@ def _check_box_vectors_char_limit(vectors, char_limit):
 def _check_if_input_files_exist(
     file_directory_and_name,
     type_of_file,
-    override_check_input_files_exist=False,
+    check_input_files_exist=True,
 ):
     """
     Checks to see GOMC FF, pdb, and psf files exist
@@ -6127,7 +6369,7 @@ def _check_if_input_files_exist(
         The file directory and name of the file.
     type_of_file : str
         A brief description of the file which is evaluated.
-    override_check_input_files_exist: bool (default = False)
+    check_input_files_exist: bool (default=True)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
@@ -6140,7 +6382,7 @@ def _check_if_input_files_exist(
     """
     if (
         os.path.isfile(file_directory_and_name) is False
-        and override_check_input_files_exist is False
+        and check_input_files_exist is True
     ):
 
         print_error_message = (
@@ -6149,10 +6391,11 @@ def _check_if_input_files_exist(
         )
         raise ValueError(print_error_message)
 
-def _check_if_string(
+def _check_if_string_and_extension(
         file_directory_and_name,
         file_directory_and_name_variable,
         type_of_file,
+        expected_file_extension=None,
 ):
     """
     Checks to see GOMC FF, pdb, and psf files exist
@@ -6165,16 +6408,20 @@ def _check_if_string(
         The variable for the file directory and name of the file.
     type_of_file : str
         A brief description of the file which is evaluated (force file, psf, pdb).
+    expected_file_extension : list of strings (optional), [str, ..., str], default=None
+        The expected file extensions that are checked against the actual file extension.
 
     Returns
     -------
     If the variable is a string : None
     If the variable is not a string : raise TypeError
+    If the variable is a string and has the correct extension : None
+    If the variable is a string and has the wrong extension  : raise TypeError
     """
     if (
-            not isinstance(file_directory_and_name_variable, str)
-            and file_directory_and_name_variable is not None
+        not isinstance(file_directory_and_name_variable, str) and file_directory_and_name_variable is not None
     ):
+        print('file_directory_and_name_variable =' +str(file_directory_and_name_variable))
         print_error_message = (
             r"ERROR: The {} variable for directly entering the "
             r"{} file directory and name is a {} and not a string.".format(
@@ -6185,6 +6432,43 @@ def _check_if_string(
         )
         raise TypeError(print_error_message)
 
+    if expected_file_extension is not None:
+        acutal_file_extension = os.path.splitext(file_directory_and_name_variable)[-1]
+        if acutal_file_extension not in expected_file_extension:
+            print_error_message = (
+                r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                r''.format(
+                    file_directory_and_name,
+                    expected_file_extension,
+                    acutal_file_extension,
+                )
+            )
+            raise TypeError(print_error_message)
+
+def _check_if_bool(
+        variable_as_a_string,
+        variable,
+):
+    """
+    Checks to see if the variable is a boolean.
+
+    Parameters
+    ----------
+    variable_as_a_string : str
+        The variable name as a string.
+    variable : variable
+        The variable to test if it is a boolean.
+
+    Returns
+    -------
+    If the variable is a bool : None
+    If the variable is not a bool : raise TypeError
+    """
+    if not isinstance(variable, bool):
+        print_error_message = 'ERROR: The {} input is {} and needs to be a boolean (i.e., True or False).' \
+                              ''.format(variable_as_a_string, type(variable))
+        raise TypeError(print_error_message)
+
 # user callable function to write the GOMC control file
 def write_gomc_control_file(
     charmm_object,
@@ -6193,12 +6477,20 @@ def write_gomc_control_file(
     RunSteps,
     Temperature,
     ff_psf_pdb_file_directory=None,
-    override_check_input_files_exist=False,
-    override_ff_directory_filename=None,
-    override_box_0_pdb_directory_filename=None,
-    override_box_0_psf_directory_filename=None,
-    override_box_1_pdb_directory_filename=None,
-    override_box_1_psf_directory_filename=None,
+    check_input_files_exist=True,
+    Restart=False,
+    RestartCheckpoint=False,
+    Parameters=None,
+    Coordinates_box_0=None,
+    Structure_box_0=None,
+    Coordinates_box_1=None,
+    Structure_box_1=None,
+    binCoordinates_box_0=None,
+    extendedSystem_box_0=None,
+    binVelocities_box_0=None,
+    binCoordinates_box_1=None,
+    extendedSystem_box_1=None,
+    binVelocities_box_1=None,
     input_variables_dict=None,
 ):
     """
@@ -6229,21 +6521,46 @@ def write_gomc_control_file(
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_files_inputs_exist : bool, (default = False)
+    check_input_files_exist : bool, (default=True)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
-    override_ff_directory_filename : str, (default = None)
-        Override all other force field directory and filename inputs.
-    override_box_0_pdb_directory_filename : str, (default = None)
-        Override all other box 0 pdb directory and filename inputs.
-    override_box_0_psf_directory_filename : str, (default = None)
-        Override all other box 0 psf directory and filename inputs.
-    override_box_1_pdb_directory_filename : str, (default = None)
-        Override all other box 1 pdb directory and filename inputs.
-    override_box_1_psf_directory_filename : str, (default = None)
-        Override all other box 1  psf directory and filename inputs.
+    Restart : boolean, default = False
+        Determines whether to restart the simulation from restart file
+        (``*_restart.pdb`` and ``*_restart.psf``) or not.
+    RestartCheckpoint : boolean, default = False
+        Determines whether to restart the simulation with the checkpoint
+        file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
+        would result in an identical outcome, as if previous simulation was continued.
+    Parameters : str, (default = None)
+        Override all other force field directory and filename inputs with the correct extension.
+    Coordinates_box_0 : str, (default = None)
+        Override all other box 0 pdb directory and filename inputs with the correct extension.
+    Structure_box_0 : str, (default = None)
+        Override all other box 0 psf directory and filename inputs with the correct extension.
+    Coordinates_box_1 : str, (default = None)
+        Override all other box 1 pdb directory and filename inputs with the correct extension.
+    Structure_box_1 : str, (default = None)
+        Override all other box 1  psf directory and filename inputs with the correct extension.
+    binCoordinates_box_0 : str, (default = None)
+        The box 0 binary coordinate file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy.
+    extendedSystem_box_0 : str, (default = None)
+        The box 0 vectors origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_0 : str, (default = None)
+        The box 0 binary velocity file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy. These velocities are only passed thru
+        GOMC since Monte Carlo simulations do not utilize any velocity information.
+    binCoordinates_box_1 : str, (default = None)
+        The box 1 binary coordinate file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy.
+    extendedSystem_box_1 : str, (default = None)
+        The box 1 vectors origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_1 : str, (default = None)
+        The box 1 binary velocity file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy. These velocities are only passed thru
+        GOMC since Monte Carlo simulations do not utilize any velocity information.
     input_variables_dict: dict, default=None
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
@@ -6260,13 +6577,6 @@ def write_gomc_control_file(
     # input_variables_dict options (keys and values) - (start)
     # Note: the input_variables_dict keys are also attributes
     # *******************************************************************
-    Restart : boolean, default = False
-        Determines whether to restart the simulation from restart file
-        (``*_restart.pdb`` and ``*_restart.psf``) or not.
-    RestartCheckpoint : boolean, default = False
-        Determines whether to restart the simulation with the checkpoint
-        file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
-        would result in an identical outcome, as if previous simulation was continued.
     PRNG : string or int (>= 0) ("RANDOM" or int), default = "RANDOM"
         PRNG = Pseudo-Random Number Generator (PRNG). There are two (2) options, entering
         the string, "RANDOM", or a integer.
@@ -6465,6 +6775,12 @@ def write_gomc_control_file(
     CoordinatesFreq : list [bool , int (> 0)] or [Generate_data_bool , steps_per_data_output_int],
         default = [True, 1M] or [True , set via formula based on the number of RunSteps or M max]
         Controls output of PDB file (coordinates). If bool is True, this
+        enables outputting the coordinate files at the integer frequency
+        (set steps_per_data_output_int), while "False" disables outputting
+        the coordinates.
+    DCDFreq : list [bool , int (> 0)] or [Generate_data_bool , steps_per_data_output_int],
+        default = [True, 1M] or [True , set via formula based on the number of RunSteps or M max]
+        Controls output of DCD file (coordinates). If bool is True, this
         enables outputting the coordinate files at the integer frequency
         (set steps_per_data_output_int), while "False" disables outputting
         the coordinates.
@@ -6818,21 +7134,46 @@ def write_gomc_control_file(
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_input_files_exist: bool (default = False)
+    check_input_files_exist: bool (default=True)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
         False, do not check if the force field, psf, and pdb files exist.
-    override_ff_directory_filename : str, (default = None)
-        Override all other force field directory and filename inputs.
-    override_box_0_pdb_directory_filename : str, (default = None)
-        Override all other box 0 pdb directory and filename inputs.
-    override_box_0_psf_directory_filename : str, (default = None)
-        Override all other box 0 psf directory and filename inputs.
-    override_box_1_pdb_directory_filename : str, (default = None)
-        Override all other box 1 pdb directory and filename inputs.
-    override_box_1_psf_directory_filename : str, (default = None)
-        Override all other box 1  psf directory and filename inputs.
+    Restart : boolean, default = False
+        Determines whether to restart the simulation from restart file
+        (``*_restart.pdb`` and ``*_restart.psf``) or not.
+    RestartCheckpoint : boolean, default = False
+        Determines whether to restart the simulation with the checkpoint
+        file (checkpoint.dat) or not. Restarting the simulation with checkpoint.dat
+        would result in an identical outcome, as if previous simulation was continued.
+    Parameters : str, (default = None)
+        Override all other force field directory and filename inputs with the correct extension.
+    Coordinates_box_0 : str, (default = None)
+        Override all other box 0 pdb directory and filename inputs with the correct extension.
+    Structure_box_0 : str, (default = None)
+        Override all other box 0 psf directory and filename inputs with the correct extension.
+    Coordinates_box_1 : str, (default = None)
+        Override all other box 1 pdb directory and filename inputs with the correct extension.
+    Structure_box_1 : str, (default = None)
+        Override all other box 1  psf directory and filename inputs with the correct extension.
+    binCoordinates_box_0 : str, (default = None)
+        The box 0 binary coordinate file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy.
+    extendedSystem_box_0 : str, (default = None)
+        The box 0 vectors origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_0 : str, (default = None)
+        The box 0 binary velocity file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy. These velocities are only passed thru
+        GOMC since Monte Carlo simulations do not utilize any velocity information.
+    binCoordinates_box_1 : str, (default = None)
+        The box 1 binary coordinate file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy.
+    extendedSystem_box_1 : str, (default = None)
+        The box 1 vectors origin file is used only for restarting a GOMC simulation.
+    binVelocities_box_1 : str, (default = None)
+        The box 1 binary velocity file is used only for restarting a GOMC simulation,
+        which provides increased numerical accuracy. These velocities are only passed thru
+        GOMC since Monte Carlo simulations do not utilize any velocity information.
     input_variables_dict: dict, default = None
         These input variables are optional and override the default settings.
         Changing these variables likely required for more advanced systems.
@@ -6935,12 +7276,20 @@ def write_gomc_control_file(
         RunSteps,
         Temperature,
         ff_psf_pdb_file_directory=ff_psf_pdb_file_directory,
-        override_check_input_files_exist=override_check_input_files_exist,
-        override_ff_directory_filename=override_ff_directory_filename,
-        override_box_0_pdb_directory_filename=override_box_0_pdb_directory_filename,
-        override_box_0_psf_directory_filename=override_box_0_psf_directory_filename,
-        override_box_1_pdb_directory_filename=override_box_1_pdb_directory_filename,
-        override_box_1_psf_directory_filename=override_box_1_psf_directory_filename,
+        check_input_files_exist=check_input_files_exist,
+        Restart=Restart,
+        RestartCheckpoint=RestartCheckpoint,
+        Parameters=Parameters,
+        Coordinates_box_0=Coordinates_box_0,
+        Structure_box_0=Structure_box_0,
+        Coordinates_box_1=Coordinates_box_1,
+        Structure_box_1=Structure_box_1,
+        binCoordinates_box_0=binCoordinates_box_0,
+        extendedSystem_box_0=extendedSystem_box_0,
+        binVelocities_box_0=binVelocities_box_0,
+        binCoordinates_box_1=binCoordinates_box_1,
+        extendedSystem_box_1=extendedSystem_box_1,
+        binVelocities_box_1=binVelocities_box_1,
         input_variables_dict=input_variables_dict,
     )
     test_gomc_control_write_conf_file = gomc_control.write_conf_file(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2031,21 +2031,6 @@ class GOMCControl:
         of the GOMC control file can be .conf, or no extension can be provided.
         If no extension is provided, this writer will automatically add the
         .conf extension to the provided string.
-    Coordinates_box_0 : str
-        The coordinate or PDB file for box 0 in the simulation.
-    Coordinates_box_1 : str or None
-        The coordinate or PDB file for box 1 in the simulation.  This is only for
-        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-        simulation, the value will be None.
-    Structures_box_0 : str
-        The structure file or PSF file for box 0 in the simulation.
-        The coordinate or PDB file for box 1 in the simulation.  This is only for
-        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-        simulation, the value will be None.
-    Structures_box_1 : str or None
-        The structure file or PSF file for box 1 in the simulation.  This is only for
-        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-        simulation, the value will be None.
     box_0_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
         Three (3) sets vectors for box 0 each with 3 float values, which represent
         the vectors for the Charmm-style systems (units in Angstroms (Ang))
@@ -7282,21 +7267,6 @@ def write_gomc_control_file(
         of the GOMC control file can be .conf, or no extension can be provided.
         If no extension is provided, this writer will automatically add the
         .conf extension to the provided string.
-    Coordinates_box_0 : str
-        The coordinate or PDB file for box 0 in the simulation.
-    Coordinates_box_1 : str or None
-        The coordinate or PDB file for box 1 in the simulation.  This is only for
-        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-        simulation, the value will be None.
-    Structures_box_0 : str
-        The structure file or PSF file for box 0 in the simulation.
-        The coordinate or PDB file for box 1 in the simulation.  This is only for
-        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-        simulation, the value will be None.
-    Structures_box_1 : str or None
-        The structure file or PSF file for box 1 in the simulation.  This is only for
-        GCMC, GEMC_NVT, and GEMC_NVT simulations. If running a NVT or NPT
-        simulation, the value will be None.
     box_0_vectors : numpy.ndarray, [[float float float], [float float float], [float float float]]
         Three (3) sets vectors for box 0 each with 3 float values, which represent
         the vectors for the Charmm-style systems (units in Angstroms (Ang))

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -4484,7 +4484,6 @@ class GOMCControl:
         Returns
         ---------
         Writes the GOMC control file with the name provided via conf_filename
-
             If completed without errors: str, "PASSED
             If completed with errors :  None
         """
@@ -5099,7 +5098,6 @@ class GOMCControl:
         data_control_file.write(
             "{:25s} {}\n".format("SampleFreq", self.SampleFreq)
         )
-        # print("{:10s}:    {}".format(arg, description))
         data_control_file.write(" \n")
 
         data_control_file.write("####################################\n")

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1326,7 +1326,7 @@ class GOMCControl:
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_files_exist : bool (default = False)
+    override_check_files_exist : bool, (default = False)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
@@ -1336,7 +1336,7 @@ class GOMCControl:
         Changing these variables likely required for more advanced systems.
         The details of the acceptable input variables for the selected
         ensembles can be found by running this python workbook,
-            print_valid_ensemble_input_variables('GCMC', description = True)
+        >>> print_valid_ensemble_input_variables('GCMC', description = True)
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
 
@@ -1904,7 +1904,7 @@ class GOMCControl:
     ff_psf_pdb_file_directory : str (optional), default=None (i.e., the current directory).
         The full or relative directory added to the force field, psf, and pdb
         file names, created via the Charmm object.
-    override_check_files_exist : bool (default = False)
+    override_check_files_exist : bool, (default = False)
         Override the check to see if the force field, psf, and pdb files exist.
         If the files are checked and do not exist, the writer will throw a ValueError.
         True, check if the force field, psf, and pdb files exist.
@@ -1914,7 +1914,7 @@ class GOMCControl:
         Changing these variables likely required for more advanced systems.
         The details of the acceptable input variables for the selected
         ensembles can be found by running this python workbook,
-            print_valid_ensemble_input_variables('GCMC', description = True)
+        >>> print_valid_ensemble_input_variables('GCMC', description = True)
         which prints the input_variables with their subsection description
         for the selected 'GCMC' ensemble (other ensembles can be set as well).
         Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,
@@ -6067,7 +6067,7 @@ def _check_if_input_files_exist(
     override_check_input_files_exist=False,
 ):
     """
-    Checks to see if the vectors exceed the specified character limit
+    Checks to see GOMC FF, pdb, and psf files exist
 
     Parameters
     ----------
@@ -6724,7 +6724,7 @@ def write_gomc_control_file(
             Changing these variables likely required for more advanced systems.
             The details of the acceptable input variables for the selected
             ensembles can be found by running this python workbook,
-                print_valid_ensemble_input_variables('GCMC', description = True)
+            >>> print_valid_ensemble_input_variables('GCMC', description = True)
             which prints the input_variables with their subsection description
             for the selected 'GCMC' ensemble (other ensembles can be set as well).
             Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -1014,45 +1014,6 @@ def _get_default_variables_dict():
 
     return default_input_variables_dict
 
-
-def check_valid_ensemble_files(ensemble_type, testing_ensemble_files_list):
-    """
-    Checks if all the required ensemble inputs are provided,
-    and provides a list of the bad variables in the printed output.
-
-    Parameters
-    ----------
-    ensemble_type : str, valid options are 'NVT', 'NPT', 'GEMC_NVT', 'GEMC_NPT', 'GCMC'
-        The ensemble type of the simulation.
-    testing_ensemble_files_list  list
-        A list containing the required ensemble
-        files variables, which will be tested for to see if they are valid.
-
-    Returns
-    ---------
-    bool
-        True is all variables are valid, False otherwise
-    """
-
-    bad_key_inputs_List = []
-
-    req_ensemble_files_set = set(_get_required_data(description=False))
-    testing_ensemble_files_set = set(testing_ensemble_files_list)
-
-    extra = testing_ensemble_files_set - req_ensemble_files_set
-    missing = req_ensemble_files_set - testing_ensemble_files_set
-
-    if len(extra) != 0:
-        bad_key_inputs_List.extend(extra)
-    if len(missing) != 0:
-        bad_key_inputs_List.extend(missing)
-
-    if not bool(missing or extra):
-        return True
-    else:
-        return False
-
-
 def print_required_input(description=False):
     """
     Prints the required ensemble arguments with an optional description based on the ensemble type
@@ -1323,7 +1284,7 @@ def _get_possible_ensemble_input_variables(ensemble_type):
         )
     else:
         warn(
-            "WARNINR: The ensemble_type selected for the _get_possible_ensemble_input_variables "
+            "WARNING: The ensemble_type selected for the _get_possible_ensemble_input_variables "
             "function is not valid."
         )
         valid_input_variables_list = None
@@ -2125,9 +2086,10 @@ class GOMCControl:
         if not isinstance(charmm_object, mf_charmm.Charmm):
             self.input_error = True
             print_error_message = (
-                "The variable supplied as a charmm_object ({}) is not a "
-                "charmm_object ({})".format(
-                    type(charmm_object), type(mf_charmm.Charmm)
+                "ERROR: The variable supplied is a ({}), not a charmm_object ({})"
+                "".format(
+                    type(charmm_object),
+                    type(mf_charmm.Charmm)
                 )
             )
             raise TypeError(print_error_message)
@@ -2142,8 +2104,8 @@ class GOMCControl:
         else:
             self.input_error = True
             print_error_message = (
-                "ERROR: The ensemble type selection of {}  is not a valid ensemble option. "
-                "Please choose the 'NPT', 'NVT', 'GEMC_NVT','GEMC_NPT', or 'GCMC' "
+                "ERROR: The ensemble type selection of '{}' is not a valid ensemble option. "
+                "Please choose the 'NPT', 'NVT', 'GEMC_NVT', 'GEMC_NPT', or 'GCMC' "
                 "ensembles".format(ensemble_type)
             )
             raise ValueError(print_error_message)
@@ -2290,9 +2252,8 @@ class GOMCControl:
                 "The force field file name was not specified and in the Charmm object ({})."
                 "Therefore, the force field file (.inp) can not be written, and thus, the "
                 "GOMC control file (.conf) can not be created. Please use the force field file "
-                "name when building the Charmm object ({})".format(
-                    type(mf_charmm.Charmm), type(mf_charmm.Charmm)
-                )
+                "name when building the Charmm object".format(
+                    type(mf_charmm.Charmm))
             )
             raise ValueError(print_error_message)
 
@@ -2736,7 +2697,7 @@ class GOMCControl:
             self.input_variables_dict = input_variables_dict
         else:
             self.input_error = True
-            print_error_message = "ERROR: The input_variables_dict variable is not None or a dictionary. "
+            print_error_message = "ERROR: The input_variables_dict variable is not None or a dictionary."
             raise ValueError(print_error_message)
 
         # Create all lower case spelled keywords, and return case specific keywords

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -6087,6 +6087,7 @@ def _check_if_input_files_exist(
     If the file exists : None
     If the file does not exist : raise ValueError
     """
+
     if (
         os.path.isfile(file_directory_and_name) is False
         and override_check_input_files_exist is False
@@ -6730,7 +6731,7 @@ def write_gomc_control_file(
             which prints the input_variables with their subsection description
             for the selected 'GCMC' ensemble (other ensembles can be set as well).
             Example : input_variables_dict = {'Restart' : False, 'PRNG' : 123,
-                                              'ParaTypeCHARMM' : True }
+            'ParaTypeCHARMM' : True }
         conf_filename : str
             The name of the GOMC contol file, which will be created.  The extension
             of the GOMC control file can be .conf, or no extension can be provided.

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -69,73 +69,73 @@ def _get_required_data(description=False):
 
     required_data = {
         "charmm_object": "Charmm object, "
-                         "A Charmm object, which by definition has been parameterized "
-                         "from the selected force field.",
+        "A Charmm object, which by definition has been parameterized "
+        "from the selected force field.",
         "ensemble_type": "Required files or System Info (all ensembles): str. "
-                         "(valid strings are 'NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', or 'GCMC'), "
-                         "the ensemble type for the simulation,",
+        "(valid strings are 'NVT', 'NPT', 'GEMC_NPT', 'GCMC-NVT', or 'GCMC'), "
+        "the ensemble type for the simulation,",
         "RunSteps": "Required files or System Info (all ensembles): int (> 0), "
-                    "The number or run steps for the simulation.",
+        "The number or run steps for the simulation.",
         "Temperature": "Required files or System Info (all ensembles): float or integer (> 0), "
-                       "Temperature of system in Kelvin (K)",
+        "Temperature of system in Kelvin (K)",
         "ff_psf_pdb_file_directory": "str (optional), default=None (i.e., the current directory). "
-                                     "The full or relative directory added to the force field, psf, and pdb "
-                                     "file names, created via the Charmm object.",
+        "The full or relative directory added to the force field, psf, and pdb "
+        "file names, created via the Charmm object.",
         "check_input_files_exist": "Required to check if files exist (all ensembles): bool (default=True), "
-                                            "Override the check to see if the force field, psf, and pdb files exist. "
-                                            "If the files are checked and do not exist, the writer will throw "
-                                            "a ValueError. "
-                                            "True, check if the force field, psf, and pdb files exist. "
-                                            "False, do not check if the force field, psf, and pdb files exist.",
+        "Override the check to see if the force field, psf, and pdb files exist. "
+        "If the files are checked and do not exist, the writer will throw "
+        "a ValueError. "
+        "True, check if the force field, psf, and pdb files exist. "
+        "False, do not check if the force field, psf, and pdb files exist.",
         "Restart": "Required for restarting (all ensembles): boolean (default=False), "
-                   "Determines whether to restart the simulation "
-                   "from restart file (*_restart.pdb and *_restart.psf) or not.",
+        "Determines whether to restart the simulation "
+        "from restart file (*_restart.pdb and *_restart.psf) or not.",
         "RestartCheckpoint": "Required for optimal restarting (all ensembles): boolean (default=False),"
-                             "Determines whether to restart the simulation with the "
-                             "checkpoint file (checkpoint.dat) or not. Restarting the "
-                             "simulation with checkpoint.dat would result in an identical outcome, "
-                             "as if previous simulation was continued.",
+        "Determines whether to restart the simulation with the "
+        "checkpoint file (checkpoint.dat) or not. Restarting the "
+        "simulation with checkpoint.dat would result in an identical outcome, "
+        "as if previous simulation was continued.",
         "Coordinates_box_0": "Required for alternate box 0 .pdb file (all ensembles): "
-                             "str, (default = None), "
-                             "Override all other box 0 pdb directory and filename inputs.",
+        "str, (default = None), "
+        "Override all other box 0 pdb directory and filename inputs.",
         "Structure_box_0": "Required for alternate box 0 .psf file (all ensembles): "
-                           "str, (default = None), "
-                           "Override all other box 0 psf directory and filename inputs.",
+        "str, (default = None), "
+        "Override all other box 0 psf directory and filename inputs.",
         "Coordinates_box_1": "Required for alternate box 1 .pdb file (all ensembles): "
-                             "str, (default = None), "
-                             "Override all other box 1 pdb directory and filename inputs.",
+        "str, (default = None), "
+        "Override all other box 1 pdb directory and filename inputs.",
         "Structure_box_1": "Required for alternate box 1 .psf file  (all ensembles): "
-                           "str, (default = None), "
-                           "Override all other box 1 psf directory and filename inputs.",
+        "str, (default = None), "
+        "Override all other box 1 psf directory and filename inputs.",
         "binCoordinates_box_0": "Required for alternate box 0 .coor file (all ensembles): "
-                                "str, (default = None), "
-                                "The box 0 binary coordinate file is used only for restarting "
-                                "a GOMC simulation, which provides increased numerical accuracy.",
+        "str, (default = None), "
+        "The box 0 binary coordinate file is used only for restarting "
+        "a GOMC simulation, which provides increased numerical accuracy.",
         "extendedSystem_box_0": "Required for alternate box 0 .xsc file (all ensembles): "
-                                "str, (default = None), "
-                                "The box 0 vectors origin file is used only for restarting a "
-                                "GOMC simulation. ",
+        "str, (default = None), "
+        "The box 0 vectors origin file is used only for restarting a "
+        "GOMC simulation. ",
         "binVelocities_box_0": "Required for alternate box 0 .vel file (all ensembles): "
-                               "str, (default = None), "
-                               "The box 0 binary velocity file is used only for "
-                               "restarting a GOMC simulation, which provides increased "
-                               "numerical accuracy. These velocities are only passed thru "
-                               "GOMC since Monte Carlo simulations do not utilize any "
-                               "velocity information. ",
+        "str, (default = None), "
+        "The box 0 binary velocity file is used only for "
+        "restarting a GOMC simulation, which provides increased "
+        "numerical accuracy. These velocities are only passed thru "
+        "GOMC since Monte Carlo simulations do not utilize any "
+        "velocity information. ",
         "binCoordinates_box_1": "Required for alternate box 1 .coor file (all ensembles): "
-                                "str, (default = None), "
-                                "The box 1 binary coordinate file is used only for restarting a "
-                                "GOMC simulation, which provides increased numerical accuracy. ",
+        "str, (default = None), "
+        "The box 1 binary coordinate file is used only for restarting a "
+        "GOMC simulation, which provides increased numerical accuracy. ",
         "extendedSystem_box_1": "Required for alternate box 1 .coor file (all ensembles): "
-                                "str, (default = None), "
-                                "The box 1 vectors origin file is used "
-                                "only for restarting a GOMC simulation. ",
+        "str, (default = None), "
+        "The box 1 vectors origin file is used "
+        "only for restarting a GOMC simulation. ",
         "binVelocities_box_1": "Required for alternate box 1 .vel file (all ensembles): "
-                               "str, (default = None), "
-                               "The box 1 binary velocity file is used only for restarting a "
-                               "GOMC simulation, which provides increased numerical accuracy. "
-                               "These velocities are only passed thru GOMC since Monte Carlo "
-                               "simulations do not utilize any velocity information.",
+        "str, (default = None), "
+        "The box 1 binary velocity file is used only for restarting a "
+        "GOMC simulation, which provides increased numerical accuracy. "
+        "These velocities are only passed thru GOMC since Monte Carlo "
+        "simulations do not utilize any velocity information.",
     }
 
     if description:
@@ -173,640 +173,649 @@ def _get_all_possible_input_variables(description=False):
         # insert citation here:
         # ******************************************************************************************************
         "PRNG": 'Simulation info (all ensembles): string or int (>= 0) ("RANDOM" or integer), default = {}. '
-                "PRNG = Pseudo-Random Number Generator (PRNG). "
-                'There are two (2) options, entering the string, "RANDOM", or a integer.  \n'
-                '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "RANDOM", which selects a random seed number. '
-                'This will enter the line "PRNG RANDOM" in the gomc configuration file. \n'
-                "\t\t\t\t\t\t\t\t\t\t\t\t\t --- integer, which defines the integer seed number "
-                "for the simulation. "
-                "This is equivalent to entering the following two lines in the configuration file: "
-                "line 1 = PRNG INTSEED, "
-                "line 2 = Random_Seed user_selected_integer. "
-                'Example 1: for a random seed enter the string "RANDOM. '
-                "Example 2: for a specific seed number enter a integer of your choosing. "
-                "".format(_get_default_variables_dict()["PRNG"]),
+        "PRNG = Pseudo-Random Number Generator (PRNG). "
+        'There are two (2) options, entering the string, "RANDOM", or a integer.  \n'
+        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "RANDOM", which selects a random seed number. '
+        'This will enter the line "PRNG RANDOM" in the gomc configuration file. \n'
+        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- integer, which defines the integer seed number "
+        "for the simulation. "
+        "This is equivalent to entering the following two lines in the configuration file: "
+        "line 1 = PRNG INTSEED, "
+        "line 2 = Random_Seed user_selected_integer. "
+        'Example 1: for a random seed enter the string "RANDOM. '
+        "Example 2: for a specific seed number enter a integer of your choosing. "
+        "".format(_get_default_variables_dict()["PRNG"]),
         "ParaTypeCHARMM": "Simulation info (all ensembles): boolean, default = {}. "
-                          "True if a CHARMM forcefield, False otherwise."
-                          "".format(_get_default_variables_dict()["ParaTypeCHARMM"]),
+        "True if a CHARMM forcefield, False otherwise."
+        "".format(_get_default_variables_dict()["ParaTypeCHARMM"]),
         "ParaTypeMie": "Simulation info (all ensembles): boolean, default = {}. "
-                       "True if a Mie forcefield type, False otherwise."
-                       "".format(_get_default_variables_dict()["ParaTypeMie"]),
+        "True if a Mie forcefield type, False otherwise."
+        "".format(_get_default_variables_dict()["ParaTypeMie"]),
         "ParaTypeMARTINI": "Simulation info (all ensembles): boolean, default = {}. "
-                           "True if a MARTINI forcefield, False otherwise."
-                           "".format(_get_default_variables_dict()["ParaTypeMARTINI"]),
+        "True if a MARTINI forcefield, False otherwise."
+        "".format(_get_default_variables_dict()["ParaTypeMARTINI"]),
         "RcutCoulomb_box_0": "Simulation info (all ensembles): int or float (>= 0), default = {}."
-                             "Sets a specific radius in box 0 where the short-range "
-                             "electrostatic energy will be calculated (i.e., The distance to truncate the "
-                             "Note: if None, GOMC will default to the Rcut value"
-                             "".format(_get_default_variables_dict()["RcutCoulomb_box_0"]),
+        "Sets a specific radius in box 0 where the short-range "
+        "electrostatic energy will be calculated (i.e., The distance to truncate the "
+        "Note: if None, GOMC will default to the Rcut value"
+        "".format(_get_default_variables_dict()["RcutCoulomb_box_0"]),
         "RcutCoulomb_box_1": "Simulation info (all ensembles): int or float (>= 0), default = {}."
-                             "Sets a specific radius in box 1 where the short-range  "
-                             "electrostatic energy will be calculated. (i.e., The distance to truncate the "
-                             "short-range electrostatic energy in box 1.)"
-                             "Note: if None, GOMC will default to the Rcut value"
-                             "".format(_get_default_variables_dict()["RcutCoulomb_box_1"]),
+        "Sets a specific radius in box 1 where the short-range  "
+        "electrostatic energy will be calculated. (i.e., The distance to truncate the "
+        "short-range electrostatic energy in box 1.)"
+        "Note: if None, GOMC will default to the Rcut value"
+        "".format(_get_default_variables_dict()["RcutCoulomb_box_1"]),
         "Pressure": "Simulation info (only GEMC_NPT and NPT): int or float (>= 0), default = {}. "
-                    "The pressure in bar utilized for the NPT "
-                    "and GEMC_NPT simulations."
-                    "".format(_get_default_variables_dict()["Pressure"]),
+        "The pressure in bar utilized for the NPT "
+        "and GEMC_NPT simulations."
+        "".format(_get_default_variables_dict()["Pressure"]),
         "Rcut": "Simulation info (all ensembles): int or float (>= 0 and RcutLow < Rswitch < Rcut), default = {}. "
-                "Sets a specific radius in Angstroms that non-bonded interaction "
-                "energy and force will be considered and calculated using defined potential function. "
-                "The distance in Angstoms to truncate the LJ, Mie, or other VDW type potential at. "
-                'Note: Rswitch is only used when the "Potential" = SWITCH. '
-                "".format(_get_default_variables_dict()["Rcut"]),
+        "Sets a specific radius in Angstroms that non-bonded interaction "
+        "energy and force will be considered and calculated using defined potential function. "
+        "The distance in Angstoms to truncate the LJ, Mie, or other VDW type potential at. "
+        'Note: Rswitch is only used when the "Potential" = SWITCH. '
+        "".format(_get_default_variables_dict()["Rcut"]),
         "RcutLow": "Simulation info (all ensembles): int or float (>= 0 and RcutLow < Rswitch < Rcut), default = {}. "
-                   "Sets a specific minimum possible distance in Angstroms that reject "
-                   "any move that places any atom closer than specified distance. The minimum possible "
-                   "distance between any atoms. "
-                   "Sets a specific radius in Angstroms that non-bonded interaction "
-                   'Note: Rswitch is only used when the "Potential" = SWITCH. '
-                   "".format(_get_default_variables_dict()["RcutLow"]),
+        "Sets a specific minimum possible distance in Angstroms that reject "
+        "any move that places any atom closer than specified distance. The minimum possible "
+        "distance between any atoms. "
+        "Sets a specific radius in Angstroms that non-bonded interaction "
+        'Note: Rswitch is only used when the "Potential" = SWITCH. '
+        "".format(_get_default_variables_dict()["RcutLow"]),
         "LRC": "Simulation info (all ensembles): boolean, default = {}. "
-               "If True, the simulation considers the long range tail corrections for the non-bonded VDW or "
-               "dispersion interactions. "
-               "Note: In case of using SHIFT or SWITCH potential functions, LRC will be ignored."
-               "".format(_get_default_variables_dict()["LRC"]),
+        "If True, the simulation considers the long range tail corrections for the non-bonded VDW or "
+        "dispersion interactions. "
+        "Note: In case of using SHIFT or SWITCH potential functions, LRC will be ignored."
+        "".format(_get_default_variables_dict()["LRC"]),
         "Exclude": "Simulation info (all ensembles): str "
-                   '(The string inputs are "1-2", "1-3", or "1-4"), default = {}. '
-                   "Note: In CHARMM force field, the 1-4 interaction needs to be considered. "
-                   'Choosing "Excude 1-3", will modify 1-4 interaction based on 1-4 parameters '
-                   "in parameter file. If a kind force field is used, where "
-                   '1-4 interaction needs to be ignored, such as TraPPE, either Exlcude "1-4" needs to be '
-                   "chosen or 1-4 parameter needs to be assigned to zero in the parameter file. \n"
-                   '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-2": All interaction pairs of bonded atoms, '
-                   "except the ones that separated with one bond, "
-                   "will be considered and modified using 1-4 parameters defined in parameter file. \n"
-                   '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-3": All interaction pairs of bonded atoms, '
-                   "except the ones that separated with one or two "
-                   "bonds, will be considered and modified using 1-4 parameters defined in parameter file. \n"
-                   '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-4": All interaction pairs of bonded atoms, '
-                   "except the ones that separated with one, "
-                   "two or three bonds, will be considered using non-bonded parameters defined in parameter file."
-                   "".format(_get_default_variables_dict()["Exclude"]),
+        '(The string inputs are "1-2", "1-3", or "1-4"), default = {}. '
+        "Note: In CHARMM force field, the 1-4 interaction needs to be considered. "
+        'Choosing "Excude 1-3", will modify 1-4 interaction based on 1-4 parameters '
+        "in parameter file. If a kind force field is used, where "
+        '1-4 interaction needs to be ignored, such as TraPPE, either Exlcude "1-4" needs to be '
+        "chosen or 1-4 parameter needs to be assigned to zero in the parameter file. \n"
+        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-2": All interaction pairs of bonded atoms, '
+        "except the ones that separated with one bond, "
+        "will be considered and modified using 1-4 parameters defined in parameter file. \n"
+        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-3": All interaction pairs of bonded atoms, '
+        "except the ones that separated with one or two "
+        "bonds, will be considered and modified using 1-4 parameters defined in parameter file. \n"
+        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "1-4": All interaction pairs of bonded atoms, '
+        "except the ones that separated with one, "
+        "two or three bonds, will be considered using non-bonded parameters defined in parameter file."
+        "".format(_get_default_variables_dict()["Exclude"]),
         "Potential": 'Simulation info (all ensembles): str, ["VDW", "EXP6", "SHIFT" or "SWITCH"], default = {}. '
-                     "Defines the potential function type to calculate non-bonded dispersion interaction "
-                     "energy and force between atoms. \n"
-                     '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "VDW":    Non-bonded dispersion interaction energy and force '
-                     "calculated based on n-6 (Lennard - Jones) equation. This function will be discussed "
-                     "further in the Intermolecular energy and "
-                     "Virial calculation section. \n"
-                     '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "EXP6":   Non-bonded dispersion interaction energy and force '
-                     "calculated based on exp-6 (Buckingham potential) equation. \n"
-                     '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "SHIFT":  This option forces the potential energy to be '
-                     "zero at Rcut distance.  \n"
-                     '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "SWITCH": This option smoothly forces the potential '
-                     "energy to be zero at Rcut distance and starts modifying the potential at Rswitch "
-                     "distance. Depending on force field type, specific potential function will be applied. "
-                     "".format(_get_default_variables_dict()["Potential"]),
+        "Defines the potential function type to calculate non-bonded dispersion interaction "
+        "energy and force between atoms. \n"
+        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "VDW":    Non-bonded dispersion interaction energy and force '
+        "calculated based on n-6 (Lennard - Jones) equation. This function will be discussed "
+        "further in the Intermolecular energy and "
+        "Virial calculation section. \n"
+        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "EXP6":   Non-bonded dispersion interaction energy and force '
+        "calculated based on exp-6 (Buckingham potential) equation. \n"
+        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "SHIFT":  This option forces the potential energy to be '
+        "zero at Rcut distance.  \n"
+        '\t\t\t\t\t\t\t\t\t\t\t\t\t --- "SWITCH": This option smoothly forces the potential '
+        "energy to be zero at Rcut distance and starts modifying the potential at Rswitch "
+        "distance. Depending on force field type, specific potential function will be applied. "
+        "".format(_get_default_variables_dict()["Potential"]),
         "Rswitch": "Simulation info (all ensembles): int or float (>= 0 and RcutLow < Rswitch < Rcut), default = {}. "
-                   'Note: Rswitch is only used when the SWITCH function is used (i.e., "Potential" = SWITCH). '
-                   "The Rswitch distance is in Angstrom. If the “SWITCH” function is chosen, "
-                   "Rswitch needs to be defined, otherwise, the program will be terminated. When using "
-                   'choosing "SWITCH" as potential function, the Rswitch distance defines where the'
-                   "non-bonded interaction energy modification is started, which is eventually truncated "
-                   "smoothly at Rcut distance."
-                   "".format(_get_default_variables_dict()["Rswitch"]),
+        'Note: Rswitch is only used when the SWITCH function is used (i.e., "Potential" = SWITCH). '
+        "The Rswitch distance is in Angstrom. If the “SWITCH” function is chosen, "
+        "Rswitch needs to be defined, otherwise, the program will be terminated. When using "
+        'choosing "SWITCH" as potential function, the Rswitch distance defines where the'
+        "non-bonded interaction energy modification is started, which is eventually truncated "
+        "smoothly at Rcut distance."
+        "".format(_get_default_variables_dict()["Rswitch"]),
         "ElectroStatic": "Simulation info (all ensembles): boolean, default = {}. "
-                         "Considers the coulomb interactions or not. "
-                         "If True, coulomb interactions are considered and false if not. "
-                         "Note: To simulate the polar molecule in MARTINI force field, ElectroStatic needs to be "
-                         "turn on. The MARTINI force field uses short-range coulomb interaction with constant "
-                         "Dielectric of 15.0."
-                         "".format(_get_default_variables_dict()["ElectroStatic"]),
+        "Considers the coulomb interactions or not. "
+        "If True, coulomb interactions are considered and false if not. "
+        "Note: To simulate the polar molecule in MARTINI force field, ElectroStatic needs to be "
+        "turn on. The MARTINI force field uses short-range coulomb interaction with constant "
+        "Dielectric of 15.0."
+        "".format(_get_default_variables_dict()["ElectroStatic"]),
         "Ewald": "Simulation info (all ensembles): boolean, default = {}. "
-                 "Considers the standard Ewald summation method for electrostatic calculations. "
-                 "If True, Ewald summation calculation needs to be considered and false if not. "
-                 "Note: By default, GOMC will set ElectroStatic to True if Ewald summation  "
-                 "method was used to calculate coulomb interaction."
-                 "".format(_get_default_variables_dict()["Ewald"]),
+        "Considers the standard Ewald summation method for electrostatic calculations. "
+        "If True, Ewald summation calculation needs to be considered and false if not. "
+        "Note: By default, GOMC will set ElectroStatic to True if Ewald summation  "
+        "method was used to calculate coulomb interaction."
+        "".format(_get_default_variables_dict()["Ewald"]),
         "CachedFourier": "Simulation info (all ensembles): boolean, default = {}. "
-                         "Considers storing the reciprocal terms for Ewald summation "
-                         "calculation in order to improve the code performance. This option would increase the code "
-                         "performance with the cost of memory usage. If True, to store reciprocal terms of Ewald "
-                         "summation calculation and False if not. "
-                         "Warning: Monte Carlo moves, such as MEMC-1, MEMC-2, MEMC-3, "
-                         "IntraMEMC-1, IntraMEMC-2, and IntraMEMC-3 are not support with CachedFourier."
-                         "".format(_get_default_variables_dict()["CachedFourier"]),
+        "Considers storing the reciprocal terms for Ewald summation "
+        "calculation in order to improve the code performance. This option would increase the code "
+        "performance with the cost of memory usage. If True, to store reciprocal terms of Ewald "
+        "summation calculation and False if not. "
+        "Warning: Monte Carlo moves, such as MEMC-1, MEMC-2, MEMC-3, "
+        "IntraMEMC-1, IntraMEMC-2, and IntraMEMC-3 are not support with CachedFourier."
+        "".format(_get_default_variables_dict()["CachedFourier"]),
         "Tolerance": "Simulation info (all ensembles): float (0.0 < float < 1.0), default = {}. "
-                     "Sets the accuracy in Ewald summation calculation. Ewald separation parameter and number "
-                     "of reciprocal vectors for the Ewald summation are determined based on the accuracy parameter."
-                     "".format(_get_default_variables_dict()["Tolerance"]),
+        "Sets the accuracy in Ewald summation calculation. Ewald separation parameter and number "
+        "of reciprocal vectors for the Ewald summation are determined based on the accuracy parameter."
+        "".format(_get_default_variables_dict()["Tolerance"]),
         "Dielectric": "Simulation info (all ensembles): int or float (>= 0.0), default = {}. "
-                      "Sets dielectric value used in coulomb interaction when the Martini "
-                      "force field is used. Note: In MARTINI force field, Dielectric needs to be set to 15.0."
-                      "".format(_get_default_variables_dict()["Dielectric"]),
+        "Sets dielectric value used in coulomb interaction when the Martini "
+        "force field is used. Note: In MARTINI force field, Dielectric needs to be set to 15.0."
+        "".format(_get_default_variables_dict()["Dielectric"]),
         "PressureCalc": "Simulation info (all ensembles): list [bool , int (> 0)] or [bool , step_frequency], "
-                        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-                        "Calculate the system pressure or not. bool = True, enables the pressure calculation "
-                        "during the simulation, false disables the calculation. The int/step frequency sets the "
-                        "frequency of calculating the pressure."
-                        "".format(_get_default_variables_dict()["PressureCalc"],
-                                  _get_default_variables_dict()["PressureCalc"][0],
-                                  _get_default_variables_dict()["PressureCalc"][1],
-                                  ),
+        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+        "Calculate the system pressure or not. bool = True, enables the pressure calculation "
+        "during the simulation, false disables the calculation. The int/step frequency sets the "
+        "frequency of calculating the pressure."
+        "".format(
+            _get_default_variables_dict()["PressureCalc"],
+            _get_default_variables_dict()["PressureCalc"][0],
+            _get_default_variables_dict()["PressureCalc"][1],
+        ),
         "EqSteps": "Simulation info (all ensembles): int (> 0), "
-                   "default = set via formula based on the number of RunSteps or {} max. "
-                   "Sets the number of steps necessary to equilibrate the system. "
-                   "Averaging will begin at this step. "
-                   "Note: In GCMC simulations, the Histogram files will be outputed at EqSteps."
-                   "".format(_get_default_variables_dict()["EqSteps"]),
+        "default = set via formula based on the number of RunSteps or {} max. "
+        "Sets the number of steps necessary to equilibrate the system. "
+        "Averaging will begin at this step. "
+        "Note: In GCMC simulations, the Histogram files will be outputed at EqSteps."
+        "".format(_get_default_variables_dict()["EqSteps"]),
         "AdjSteps": "Simulation info (all ensembles): int (> 0), "
-                    "default = set via formula based on the number of RunSteps or {} max. "
-                    "Sets the number of steps per adjustment of the parameter associated with each move "
-                    "(e.g. maximum translate distance, maximum rotation, maximum volume exchange, etc.)."
-                    "".format(_get_default_variables_dict()["AdjSteps"]),
+        "default = set via formula based on the number of RunSteps or {} max. "
+        "Sets the number of steps per adjustment of the parameter associated with each move "
+        "(e.g. maximum translate distance, maximum rotation, maximum volume exchange, etc.)."
+        "".format(_get_default_variables_dict()["AdjSteps"]),
         "VDWGeometricSigma": "Simulation info (all ensembles): boolean, default = {}. "
-                             "Use geometric mean, as required by OPLS force field, "
-                             "to combining Lennard-Jones sigma parameters for different atom types. "
-                             "If set to True, GOMC uses geometric mean to combine Lennard-Jones or VDW sigmas. "
-                             "Note: The default setting of VDWGeometricSigma is false, which uses the arithmetic "
-                             "mean when combining Lennard-Jones or VDW sigma parameters for different atom types."
-                             "".format(_get_default_variables_dict()["VDWGeometricSigma"]),
+        "Use geometric mean, as required by OPLS force field, "
+        "to combining Lennard-Jones sigma parameters for different atom types. "
+        "If set to True, GOMC uses geometric mean to combine Lennard-Jones or VDW sigmas. "
+        "Note: The default setting of VDWGeometricSigma is false, which uses the arithmetic "
+        "mean when combining Lennard-Jones or VDW sigma parameters for different atom types."
+        "".format(_get_default_variables_dict()["VDWGeometricSigma"]),
         "useConstantArea": "Simulation info (only GEMC_NPT and NPT): boolean: default = {}. "
-                           "Changes the volume of the simulation box by fixing the cross-sectional "
-                           "area (x-y plane). If true, the volume will change only in z axis, If False, "
-                           "the volume of the box will change in a way to maintain the constant axis ratio. "
-                           "".format(_get_default_variables_dict()["useConstantArea"]),
+        "Changes the volume of the simulation box by fixing the cross-sectional "
+        "area (x-y plane). If true, the volume will change only in z axis, If False, "
+        "the volume of the box will change in a way to maintain the constant axis ratio. "
+        "".format(_get_default_variables_dict()["useConstantArea"]),
         "FixVolBox0": "Simulation info (only GEMC_NPT): boolean, default = {}. "
-                      "Changing the volume of fluid phase (Box 1) to maintain the constant imposed pressure and "
-                      "Temperature, while keeping the volume of adsorbed phase (Box 0) fixed. Note: By default, "
-                      "GOMC will set useConstantArea to False if no value was set. It means, the volume of the "
-                      "box will change in a way to maintain the constant axis ratio."
-                      "".format(_get_default_variables_dict()["FixVolBox0"]),
+        "Changing the volume of fluid phase (Box 1) to maintain the constant imposed pressure and "
+        "Temperature, while keeping the volume of adsorbed phase (Box 0) fixed. Note: By default, "
+        "GOMC will set useConstantArea to False if no value was set. It means, the volume of the "
+        "box will change in a way to maintain the constant axis ratio."
+        "".format(_get_default_variables_dict()["FixVolBox0"]),
         # GCMC only properties
-        "ChemPot": "Simulation info (only GCMC): dict {str (4 dig limit) , int or float}, "+
-                   "default = {} ".format(_get_default_variables_dict()["ChemPot"])+
-                   "(i.e., the user must set this variable as there is no working default)."
-                   "The chemical potentials in GOMC units of energy, K. "
-                   "There is a 4 character limit for the string/residue name since the PDB/PSF "
-                   "files have a 4 character limitation and require and exact match in the conf file. "
-                   "Note: These strings must match the residue in the psf and psb files or it will fail. "
-                   "The name of the residues and their corresponding chemical potential must specified "
-                   'for every residue in the system (i.e., {"residue_name" : chemical_potential}). '
-                   "Note: IF 2 KEYS WITH THE SAME STRING/RESIDUE ARE PROVIDED, ONE WILL BE AUTOMATICALLY "
-                   "OVERWRITTEN AND NO ERROR WILL BE THROWN IN THIS CONTROL FILE WRITER. "
-                   'Example 1 (system with only water):  {"H2O" : -4000} . '
-                   'Example 2 (system with water and ethanol):  {"H2O" : -4000, "ETH" : -8000} ',
+        "ChemPot": "Simulation info (only GCMC): dict {str (4 dig limit) , int or float}, "
+        + "default = {} ".format(_get_default_variables_dict()["ChemPot"])
+        + "(i.e., the user must set this variable as there is no working default)."
+        "The chemical potentials in GOMC units of energy, K. "
+        "There is a 4 character limit for the string/residue name since the PDB/PSF "
+        "files have a 4 character limitation and require and exact match in the conf file. "
+        "Note: These strings must match the residue in the psf and psb files or it will fail. "
+        "The name of the residues and their corresponding chemical potential must specified "
+        'for every residue in the system (i.e., {"residue_name" : chemical_potential}). '
+        "Note: IF 2 KEYS WITH THE SAME STRING/RESIDUE ARE PROVIDED, ONE WILL BE AUTOMATICALLY "
+        "OVERWRITTEN AND NO ERROR WILL BE THROWN IN THIS CONTROL FILE WRITER. "
+        'Example 1 (system with only water):  {"H2O" : -4000} . '
+        'Example 2 (system with water and ethanol):  {"H2O" : -4000, "ETH" : -8000} ',
         "Fugacity": "Simulation info (only GCMC): dict {str , int or float (>= 0)}, "
-                    +"default = {} ".format(_get_default_variables_dict()["Fugacity"])
-                    +"(i.e., the user must set this variable as there is no working default). "
-                    "The fugacity in GOMC units of pressure, bar. "
-                    "There is a 4 character limit for the string/residue name since the PDB/PSF "
-                    "files have a 4 character limitation and require and exact match in the conf file. "
-                    "Note: These strings must match the residue in the psf and psb files or it will fail. "
-                    "The name of the residues and their corresponding fugacity must specified "
-                    'for every residue in the system (i.e., {"residue_name" : fugacity}). '
-                    "Note: IF 2 KEYS WITH THE SAME STRING/RESIDUE ARE PROVIDED, ONE WILL BE AUTOMATICALLY "
-                    "OVERWRITTEN AND NO ERROR WILL BE THROWN IN THIS CONTROL FILE WRITER. "
-                    'Example 1 (system with only water):  {"H2O" : 1} . '
-                    'Example 2 (system with water and ethanol):  {"H2O" : 0.5, "ETH" : 10} ',
+        + "default = {} ".format(_get_default_variables_dict()["Fugacity"])
+        + "(i.e., the user must set this variable as there is no working default). "
+        "The fugacity in GOMC units of pressure, bar. "
+        "There is a 4 character limit for the string/residue name since the PDB/PSF "
+        "files have a 4 character limitation and require and exact match in the conf file. "
+        "Note: These strings must match the residue in the psf and psb files or it will fail. "
+        "The name of the residues and their corresponding fugacity must specified "
+        'for every residue in the system (i.e., {"residue_name" : fugacity}). '
+        "Note: IF 2 KEYS WITH THE SAME STRING/RESIDUE ARE PROVIDED, ONE WILL BE AUTOMATICALLY "
+        "OVERWRITTEN AND NO ERROR WILL BE THROWN IN THIS CONTROL FILE WRITER. "
+        'Example 1 (system with only water):  {"H2O" : 1} . '
+        'Example 2 (system with water and ethanol):  {"H2O" : 0.5, "ETH" : 10} ',
         # CBMC inputs
         "CBMC_First": "CBMC inputs (all ensembles): int (>= 0), default = {}, "
-                      "The number of CD-CBMC trials to choose the first atom position"
-                      "(Lennard-Jones trials for first seed growth)."
-                      "".format(_get_default_variables_dict()["CBMC_First"]),
+        "The number of CD-CBMC trials to choose the first atom position"
+        "(Lennard-Jones trials for first seed growth)."
+        "".format(_get_default_variables_dict()["CBMC_First"]),
         "CBMC_Nth": "CBMC inputs (all ensembles): int (>= 0), default = {},  "
-                    "The number of CD-CBMC trials to choose the later atom positions "
-                    "(Lennard-Jones trials for first seed growth)."
-                    "".format(_get_default_variables_dict()["CBMC_Nth"]),
+        "The number of CD-CBMC trials to choose the later atom positions "
+        "(Lennard-Jones trials for first seed growth)."
+        "".format(_get_default_variables_dict()["CBMC_Nth"]),
         "CBMC_Ang": "CBMC inputs (all ensembles): int (>= 0), default = {}, "
-                    "The number of CD-CBMC bending angle trials to perform for geometry "
-                    "(per the coupled-decoupled CBMC scheme)."
-                    "".format(_get_default_variables_dict()["CBMC_Ang"]),
+        "The number of CD-CBMC bending angle trials to perform for geometry "
+        "(per the coupled-decoupled CBMC scheme)."
+        "".format(_get_default_variables_dict()["CBMC_Ang"]),
         "CBMC_Dih": "CBMC inputs (all ensembles): int (>= 0), default = {}, "
-                    "The number of CD-CBMC dihedral angle trials to perform for geometry "
-                    "(per the coupled-decoupled CBMC scheme)."
-                    "".format(_get_default_variables_dict()["CBMC_Dih"]),
+        "The number of CD-CBMC dihedral angle trials to perform for geometry "
+        "(per the coupled-decoupled CBMC scheme)."
+        "".format(_get_default_variables_dict()["CBMC_Dih"]),
         # Control file (.conf file ) output controls/parameters
         "OutputName": "Output Frequency (all ensembles): str (NO SPACES), default = {}. "
-                      "The UNIQUE STRING NAME, WITH NO SPACES, which is used for the "
-                      "output block average, PDB, and PSF file names."
-                      "".format(_get_default_variables_dict()["OutputName"]),
+        "The UNIQUE STRING NAME, WITH NO SPACES, which is used for the "
+        "output block average, PDB, and PSF file names."
+        "".format(_get_default_variables_dict()["OutputName"]),
         "CoordinatesFreq": "PDB Output Frequency (all ensembles): list [bool , int (> 0)] or "
-                           "[Generate_data_bool , steps_per_data_output_int], "
-                           "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-                           "Controls output of PDB file (coordinates). "
-                           "If bool is True, this enables outputting the coordinate files at the "
-                           "integer frequency (set steps_per_data_output_int), "
-                           'while "False" disables outputting the coordinates.'
-                           "".format(_get_default_variables_dict()["CoordinatesFreq"],
-                                     _get_default_variables_dict()["CoordinatesFreq"][0],
-                                     _get_default_variables_dict()["CoordinatesFreq"][1],
-                                     ),
+        "[Generate_data_bool , steps_per_data_output_int], "
+        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+        "Controls output of PDB file (coordinates). "
+        "If bool is True, this enables outputting the coordinate files at the "
+        "integer frequency (set steps_per_data_output_int), "
+        'while "False" disables outputting the coordinates.'
+        "".format(
+            _get_default_variables_dict()["CoordinatesFreq"],
+            _get_default_variables_dict()["CoordinatesFreq"][0],
+            _get_default_variables_dict()["CoordinatesFreq"][1],
+        ),
         "DCDFreq": "DCD Output Frequency (all ensembles): list [bool , int (> 0)] or "
-                   "[Generate_data_bool , steps_per_data_output_int], "
-                   "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-                   "Controls output of DCD file (coordinates). "
-                   "If bool is True, this enables outputting the coordinate files at the "
-                   "integer frequency (set steps_per_data_output_int), "
-                   'while "False" disables outputting the coordinates.'
-                   "".format( _get_default_variables_dict()["DCDFreq"],
-                              _get_default_variables_dict()["DCDFreq"][0],
-                              _get_default_variables_dict()["DCDFreq"][1],
-                              ),
+        "[Generate_data_bool , steps_per_data_output_int], "
+        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+        "Controls output of DCD file (coordinates). "
+        "If bool is True, this enables outputting the coordinate files at the "
+        "integer frequency (set steps_per_data_output_int), "
+        'while "False" disables outputting the coordinates.'
+        "".format(
+            _get_default_variables_dict()["DCDFreq"],
+            _get_default_variables_dict()["DCDFreq"][0],
+            _get_default_variables_dict()["DCDFreq"][1],
+        ),
         "RestartFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-                       "[Generate_data_bool , steps_per_data_output_int], "
-                       "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-                       "This creates the PDB and PSF (coordinate and topology) files for restarting the system "
-                       "at the set steps_per_data_output_int (frequency) "
-                       "If bool is True, this enables outputting the PDB/PSF restart files at the "
-                       "integer frequency (set steps_per_data_output_int), "
-                       "while “false” disables outputting the PDB/PSF restart files. "
-                       "".format(_get_default_variables_dict()["RestartFreq"],
-                                 _get_default_variables_dict()["RestartFreq"][0],
-                                 _get_default_variables_dict()["RestartFreq"][1],
-                                 ),
+        "[Generate_data_bool , steps_per_data_output_int], "
+        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+        "This creates the PDB and PSF (coordinate and topology) files for restarting the system "
+        "at the set steps_per_data_output_int (frequency) "
+        "If bool is True, this enables outputting the PDB/PSF restart files at the "
+        "integer frequency (set steps_per_data_output_int), "
+        "while “false” disables outputting the PDB/PSF restart files. "
+        "".format(
+            _get_default_variables_dict()["RestartFreq"],
+            _get_default_variables_dict()["RestartFreq"][0],
+            _get_default_variables_dict()["RestartFreq"][1],
+        ),
         "CheckpointFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-                          "[Generate_data_bool , steps_per_data_output_int], "
-                          "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-                          "Controls the output of the last state of simulation at a specified step, in a "
-                          "binary file format (checkpoint.dat). Checkpoint file contains the following "
-                          "information in full precision: "
-                          "(1) Last simulation step that saved into checkpoint file "
-                          "(2) Simulation cell dimensions and angles "
-                          "(3) Maximum amount of displacement (Å), rotation (δ), and volume (Å^3) that is used in "
-                          "the Displacement, Rotation, MultiParticle, and Volume moves "
-                          "(4) Number of Monte Carlo move trial and acceptance "
-                          "(5) All molecule’s coordinates "
-                          "(6) Random number sequence "
-                          "If bool is True, this enables outputting the checkpoint file at the "
-                          "integer frequency (set steps_per_data_output_int), "
-                          'while "False" disables outputting the checkpoint file.'
-                          "".format(_get_default_variables_dict()["CheckpointFreq"],
-                                    _get_default_variables_dict()["CheckpointFreq"][0],
-                                    _get_default_variables_dict()["CheckpointFreq"][1],
-                                    ),
+        "[Generate_data_bool , steps_per_data_output_int], "
+        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+        "Controls the output of the last state of simulation at a specified step, in a "
+        "binary file format (checkpoint.dat). Checkpoint file contains the following "
+        "information in full precision: "
+        "(1) Last simulation step that saved into checkpoint file "
+        "(2) Simulation cell dimensions and angles "
+        "(3) Maximum amount of displacement (Å), rotation (δ), and volume (Å^3) that is used in "
+        "the Displacement, Rotation, MultiParticle, and Volume moves "
+        "(4) Number of Monte Carlo move trial and acceptance "
+        "(5) All molecule’s coordinates "
+        "(6) Random number sequence "
+        "If bool is True, this enables outputting the checkpoint file at the "
+        "integer frequency (set steps_per_data_output_int), "
+        'while "False" disables outputting the checkpoint file.'
+        "".format(
+            _get_default_variables_dict()["CheckpointFreq"],
+            _get_default_variables_dict()["CheckpointFreq"][0],
+            _get_default_variables_dict()["CheckpointFreq"][1],
+        ),
         "ConsoleFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-                       "[Generate_data_bool , steps_per_data_output_int], "
-                       "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-                       'Controls the output to the "console” or log file, which prints the '
-                       "acceptance statistics, and run timing info. In addition, instantaneously-selected"
-                       "thermodynamic properties will be output to this file.  If bool is True, "
-                       "this enables outputting the console data at the integer frequency "
-                       '(set steps_per_data_output_int), while "False" disables outputting the console '
-                       "data file. "
-                       "".format(_get_default_variables_dict()["ConsoleFreq"],
-                                 _get_default_variables_dict()["ConsoleFreq"][0],
-                                 _get_default_variables_dict()["ConsoleFreq"][1],
-                                 ),
+        "[Generate_data_bool , steps_per_data_output_int], "
+        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+        'Controls the output to the "console” or log file, which prints the '
+        "acceptance statistics, and run timing info. In addition, instantaneously-selected"
+        "thermodynamic properties will be output to this file.  If bool is True, "
+        "this enables outputting the console data at the integer frequency "
+        '(set steps_per_data_output_int), while "False" disables outputting the console '
+        "data file. "
+        "".format(
+            _get_default_variables_dict()["ConsoleFreq"],
+            _get_default_variables_dict()["ConsoleFreq"][0],
+            _get_default_variables_dict()["ConsoleFreq"][1],
+        ),
         "BlockAverageFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-                            "[Generate_data_bool , steps_per_data_output_int], "
-                            "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-                            "Controls the block averages output of selected thermodynamic properties. "
-                            "Block averages are averages of thermodynamic values of interest for chunks of the "
-                            "simulation (for post-processing of averages or std. dev. in those values)."
-                            "If bool is True, this enables outputting the block averaging data/file at the "
-                            "integer frequency (set steps_per_data_output_int), "
-                            'while "False" disables outputting the block averaging data/file.'
-                            "".format(_get_default_variables_dict()["BlockAverageFreq"],
-                                      _get_default_variables_dict()["BlockAverageFreq"][0],
-                                      _get_default_variables_dict()["BlockAverageFreq"][1],
-                                      ),
+        "[Generate_data_bool , steps_per_data_output_int], "
+        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+        "Controls the block averages output of selected thermodynamic properties. "
+        "Block averages are averages of thermodynamic values of interest for chunks of the "
+        "simulation (for post-processing of averages or std. dev. in those values)."
+        "If bool is True, this enables outputting the block averaging data/file at the "
+        "integer frequency (set steps_per_data_output_int), "
+        'while "False" disables outputting the block averaging data/file.'
+        "".format(
+            _get_default_variables_dict()["BlockAverageFreq"],
+            _get_default_variables_dict()["BlockAverageFreq"][0],
+            _get_default_variables_dict()["BlockAverageFreq"][1],
+        ),
         "HistogramFreq": "Output Frequency (all ensembles): list [bool , int (> 0)] or "
-                         "[Generate_data_bool , steps_per_data_output_int], "
-                         "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
-                         "Controls the histograms. Histograms are a binned listing of observation frequency "
-                         "for a specific thermodynamic variable. In the GOMC code, they also control the output "
-                         "of a file containing energy/molecule samples, "
-                         'which is only used for the "GCMC" ensemble simulations for histogram reweighting purposes.'
-                         "If bool is True, this enables outputting the data to the histogram data at the "
-                         "integer frequency (set steps_per_data_output_int), "
-                         'while "False" disables outputting the histogram data.'
-                         "".format(_get_default_variables_dict()["HistogramFreq"],
-                                   _get_default_variables_dict()["HistogramFreq"][0],
-                                   _get_default_variables_dict()["HistogramFreq"][1],
-                                   ),
+        "[Generate_data_bool , steps_per_data_output_int], "
+        "default = {} or [{} , set via formula based on the number of RunSteps or {} max]. "
+        "Controls the histograms. Histograms are a binned listing of observation frequency "
+        "for a specific thermodynamic variable. In the GOMC code, they also control the output "
+        "of a file containing energy/molecule samples, "
+        'which is only used for the "GCMC" ensemble simulations for histogram reweighting purposes.'
+        "If bool is True, this enables outputting the data to the histogram data at the "
+        "integer frequency (set steps_per_data_output_int), "
+        'while "False" disables outputting the histogram data.'
+        "".format(
+            _get_default_variables_dict()["HistogramFreq"],
+            _get_default_variables_dict()["HistogramFreq"][0],
+            _get_default_variables_dict()["HistogramFreq"][1],
+        ),
         # Histogram data
         "DistName": "Histogram Output (all ensembles): str (NO SPACES), default = {}. "
-                    "Short phrase which will be combined with RunNumber and RunLetter "
-                    "to use in the name of the binned histogram for molecule distribution."
-                    "".format(_get_default_variables_dict()["DistName"]),
+        "Short phrase which will be combined with RunNumber and RunLetter "
+        "to use in the name of the binned histogram for molecule distribution."
+        "".format(_get_default_variables_dict()["DistName"]),
         "HistName": "Histogram Output (all ensembles): str (NO SPACES), default = {}. "
-                    "Short phrase, which will be combined with RunNumber and RunLetter, "
-                    "to use in the name of the energy/molecule count sample file."
-                    "".format(_get_default_variables_dict()["HistName"]),
+        "Short phrase, which will be combined with RunNumber and RunLetter, "
+        "to use in the name of the energy/molecule count sample file."
+        "".format(_get_default_variables_dict()["HistName"]),
         "RunNumber": "Histogram Output (all ensembles): int  ( > 0 ), default = {}. "
-                     "Sets a number, which is a part of DistName and HistName file name."
-                     "".format(_get_default_variables_dict()["RunNumber"]),
+        "Sets a number, which is a part of DistName and HistName file name."
+        "".format(_get_default_variables_dict()["RunNumber"]),
         "RunLetter": "Histogram Output (all ensembles): str (1 alphabetic character only), default = {}. "
-                     "Sets a letter, which is a part of DistName and HistName file name."
-                     "".format(_get_default_variables_dict()["RunLetter"]),
+        "Sets a letter, which is a part of DistName and HistName file name."
+        "".format(_get_default_variables_dict()["RunLetter"]),
         "SampleFreq": "Histogram Output (all ensembles): int ( > 0 ), default = {}. "
-                      "The number of steps per histogram sample or frequency."
-                      "".format(_get_default_variables_dict()["SampleFreq"]),
+        "The number of steps per histogram sample or frequency."
+        "".format(_get_default_variables_dict()["SampleFreq"]),
         # Data output for the console and bulk properties calculations
         "OutEnergy": "Output Data (all ensembles): [bool, bool], default = {}.   "
-                     "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-                     "This outputs the energy data into the block averages and console output/log files."
-                     "".format(_get_default_variables_dict()["OutEnergy"]),
+        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+        "This outputs the energy data into the block averages and console output/log files."
+        "".format(_get_default_variables_dict()["OutEnergy"]),
         "OutPressure": "Output Data (all ensembles): [bool, bool], default = {}.   "
-                       "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-                       "This outputs the pressure data into the block averages and console output/log files."
-                       "".format(_get_default_variables_dict()["OutPressure"]),
+        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+        "This outputs the pressure data into the block averages and console output/log files."
+        "".format(_get_default_variables_dict()["OutPressure"]),
         "OutMolNumber": "Output Data (all ensembles): [bool, bool], default = {}.   "
-                        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-                        "This outputs the number of molecules data into the block averages and console "
-                        "output/log files."
-                        "".format(_get_default_variables_dict()["OutMolNumber"]),
+        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+        "This outputs the number of molecules data into the block averages and console "
+        "output/log files."
+        "".format(_get_default_variables_dict()["OutMolNumber"]),
         "OutDensity": "Output Data (all ensembles): [bool, bool], default = {}.   "
-                      "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-                      "This outputs the density data into the block averages and console output/log files."
-                      "".format(_get_default_variables_dict()["OutDensity"]),
+        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+        "This outputs the density data into the block averages and console output/log files."
+        "".format(_get_default_variables_dict()["OutDensity"]),
         "OutVolume": "Output Data (all ensembles): [bool, bool], default = {}.   "
-                     "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-                     "This outputs the volume data into the block averages and console output/log files."
-                     "".format(_get_default_variables_dict()["OutVolume"]),
+        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+        "This outputs the volume data into the block averages and console output/log files."
+        "".format(_get_default_variables_dict()["OutVolume"]),
         "OutSurfaceTension": "Output Data (all ensembles): [bool, bool], default = {}. "
-                             "The list provides the booleans to [block_averages_bool, console_output_bool]. "
-                             "This outputs the surface tension data into the block averages and console "
-                             "output/log files."
-                             "".format(_get_default_variables_dict()["OutSurfaceTension"]),
+        "The list provides the booleans to [block_averages_bool, console_output_bool]. "
+        "This outputs the surface tension data into the block averages and console "
+        "output/log files."
+        "".format(_get_default_variables_dict()["OutSurfaceTension"]),
         # free energy calculation in NVT and NPT ensembles.
         "FreeEnergyCalc": "Free Energy Calcs (NVT and NPT only): list [bool , int (> 0)] or "
-                          "[Generate_data_bool , steps_per_data_output_int], default = {}. "
-                          "bool = True enabling free energy calculation during the simulation, false disables "
-                          "the calculation. The int/step frequency sets the frequency of calculating the free energy."
-                          "".format(_get_default_variables_dict()["FreeEnergyCalc"]),
+        "[Generate_data_bool , steps_per_data_output_int], default = {}. "
+        "bool = True enabling free energy calculation during the simulation, false disables "
+        "the calculation. The int/step frequency sets the frequency of calculating the free energy."
+        "".format(_get_default_variables_dict()["FreeEnergyCalc"]),
         "MoleculeType": "Free Energy Calcs (NVT and NPT only): list [str , int (> 0)] or "
-                        '["residue_name" , residue_ID], '
-                        "The user must set this variable as there is no working default (default = {}). "
-                        'Note: ONLY 4 characters can be used for the string (i.e., "residue_name"). '
-                        "Sets the solute molecule kind (residue name) and molecule number (residue ID), "
-                        "which absolute solvation free will be calculated for."
-                        "".format(_get_default_variables_dict()["MoleculeType"]),
+        '["residue_name" , residue_ID], '
+        "The user must set this variable as there is no working default (default = {}). "
+        'Note: ONLY 4 characters can be used for the string (i.e., "residue_name"). '
+        "Sets the solute molecule kind (residue name) and molecule number (residue ID), "
+        "which absolute solvation free will be calculated for."
+        "".format(_get_default_variables_dict()["MoleculeType"]),
         "InitialState": "Free Energy Calcs (NVT and NPT only): int (>= 0), "
-                        "The user must set this variable as there is no working default (default = {}). "
-                        "The index of LambdaCoulomb and LambdaVDW vectors. Sets the index of the"
-                        "LambdaCoulomb and LambdaVDW vectors, to determine the simulation lambda value for"
-                        "VDW and Coulomb interactions. "
-                        "WARNING : This must an integer within the vector count of the LambdaVDW and LambdaCoulomb, "
-                        "in which the counting starts at 0.  "
-                        "".format(_get_default_variables_dict()["InitialState"]),
+        "The user must set this variable as there is no working default (default = {}). "
+        "The index of LambdaCoulomb and LambdaVDW vectors. Sets the index of the"
+        "LambdaCoulomb and LambdaVDW vectors, to determine the simulation lambda value for"
+        "VDW and Coulomb interactions. "
+        "WARNING : This must an integer within the vector count of the LambdaVDW and LambdaCoulomb, "
+        "in which the counting starts at 0.  "
+        "".format(_get_default_variables_dict()["InitialState"]),
         "LambdaVDW": "Free Energy Calcs (NVT and NPT only): list of floats (0 <= floats <= 1), "
-                     "The user must set this variable as there is no working default (default = {}). "
-                     "Lambda values for VDW interaction in ascending order. Sets the intermediate "
-                     "lambda states to which solute-solvent VDW interactions are scaled. "
-                     'WARNING : This list must be the same length as the "LambdaCoulomb" list length. '
-                     "WARNING : All lambda values must be stated in the ascending order, otherwise "
-                     "Example of ascending order 1: [0.1, 1.0,]  "
-                     "Example of ascending order 2: [0.1, 0.2, 0.4, 0.9] "
-                     "".format(_get_default_variables_dict()["LambdaVDW"]),
+        "The user must set this variable as there is no working default (default = {}). "
+        "Lambda values for VDW interaction in ascending order. Sets the intermediate "
+        "lambda states to which solute-solvent VDW interactions are scaled. "
+        'WARNING : This list must be the same length as the "LambdaCoulomb" list length. '
+        "WARNING : All lambda values must be stated in the ascending order, otherwise "
+        "Example of ascending order 1: [0.1, 1.0,]  "
+        "Example of ascending order 2: [0.1, 0.2, 0.4, 0.9] "
+        "".format(_get_default_variables_dict()["LambdaVDW"]),
         "LambdaCoulomb": "Free Energy Calcs (NVT and NPT only):  list of floats (0 <= floats <= 1), "
-                         "The user must set this variable as there is no working default (default = {}). "
-                         "Lambda values for Coulombic interaction in ascending order. Sets the intermediate "
-                         "lambda states to which solute-solvent Coulombic interactions are scaled. "
-                         'GOMC defauts to the "LambdaVDW" values for the Coulombic interaction '
-                         'if no "LambdaCoulomb" variable is set. '
-                         'WARNING : This list must be the same length as the "LambdaVDW" list length. '
-                         "WARNING : All lambda values must be stated in the ascending order, otherwise "
-                         "the program will terminate.  "
-                         "Example of ascending order 1: [0.1, 1.0,]  "
-                         "Example of ascending order 2: [0.1, 0.2, 0.4, 0.9] "
-                         "".format(_get_default_variables_dict()["LambdaCoulomb"]),
+        "The user must set this variable as there is no working default (default = {}). "
+        "Lambda values for Coulombic interaction in ascending order. Sets the intermediate "
+        "lambda states to which solute-solvent Coulombic interactions are scaled. "
+        'GOMC defauts to the "LambdaVDW" values for the Coulombic interaction '
+        'if no "LambdaCoulomb" variable is set. '
+        'WARNING : This list must be the same length as the "LambdaVDW" list length. '
+        "WARNING : All lambda values must be stated in the ascending order, otherwise "
+        "the program will terminate.  "
+        "Example of ascending order 1: [0.1, 1.0,]  "
+        "Example of ascending order 2: [0.1, 0.2, 0.4, 0.9] "
+        "".format(_get_default_variables_dict()["LambdaCoulomb"]),
         "ScaleCoulomb": "Free Energy Calcs (NVT and NPT only): bool, default = {}, "
-                        "Determines to scale the Coulombic interaction non-linearly (soft-core scheme) or not. "
-                        "True if the Coulombic interaction needs to be scaled non-linearly. "
-                        "False if the Coulombic interaction needs to be scaled linearly. "
-                        "".format(_get_default_variables_dict()["ScaleCoulomb"]),
+        "Determines to scale the Coulombic interaction non-linearly (soft-core scheme) or not. "
+        "True if the Coulombic interaction needs to be scaled non-linearly. "
+        "False if the Coulombic interaction needs to be scaled linearly. "
+        "".format(_get_default_variables_dict()["ScaleCoulomb"]),
         "ScalePower": "Free Energy Calcs (NVT and NPT only): int (>= 0), default = {}, "
-                      "The p value in the soft-core scaling scheme, where the distance between "
-                      "solute and solvent is scaled non-linearly."
-                      "".format(_get_default_variables_dict()["ScalePower"]),
+        "The p value in the soft-core scaling scheme, where the distance between "
+        "solute and solvent is scaled non-linearly."
+        "".format(_get_default_variables_dict()["ScalePower"]),
         "ScaleAlpha": "Free Energy Calcs (NVT and NPT only): int or float (>= 0), default = {}, "
-                      "The alpha value in the soft-core scaling scheme, where the distance "
-                      "between solute and solvent is scaled non-linearly."
-                      "".format(_get_default_variables_dict()["ScaleAlpha"]),
+        "The alpha value in the soft-core scaling scheme, where the distance "
+        "between solute and solvent is scaled non-linearly."
+        "".format(_get_default_variables_dict()["ScaleAlpha"]),
         "MinSigma": "Free Energy Calcs (NVT and NPT only): int or float (>= 0), default = {}, "
-                    "The minimum sigma value in the soft-core scaling scheme, where the "
-                    "distance between solute and solvent is scaled non-linearly."
-                    "".format(_get_default_variables_dict()["MinSigma"]),
+        "The minimum sigma value in the soft-core scaling scheme, where the "
+        "distance between solute and solvent is scaled non-linearly."
+        "".format(_get_default_variables_dict()["MinSigma"]),
         # moves without MEMC
         "DisFreq": "Std. MC moves (all ensembles)                     : "
-                   "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                   "Fractional percentage at which the displacement move will occur "
-                   "(i.e., fraction of displacement moves). Note: all of the move types"
-                   "are not available in for every ensemble. Note: all of the move fractions"
-                   "must sum to 1, or the control file writer will fail.  "
-                   "".format(_get_default_variables_dict()["DisFreq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which the displacement move will occur "
+        "(i.e., fraction of displacement moves). Note: all of the move types"
+        "are not available in for every ensemble. Note: all of the move fractions"
+        "must sum to 1, or the control file writer will fail.  "
+        "".format(_get_default_variables_dict()["DisFreq"]),
         "RotFreq": "Std. MC moves (all ensembles)                     : "
-                   "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                   "Fractional percentage at which the rotation move will occur "
-                   "(i.e., fraction of rotation moves). Note: all of the move types"
-                   "are not available in for every ensemble. Note: all of the move fractions"
-                   "must sum to 1, or the control file writer will fail.  "
-                   "".format(_get_default_variables_dict()["RotFreq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which the rotation move will occur "
+        "(i.e., fraction of rotation moves). Note: all of the move types"
+        "are not available in for every ensemble. Note: all of the move fractions"
+        "must sum to 1, or the control file writer will fail.  "
+        "".format(_get_default_variables_dict()["RotFreq"]),
         "IntraSwapFreq": "Std. MC moves (all ensembles)                     : "
-                         "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                         "Fractional percentage at which the molecule will be removed from a "
-                         "box and inserted into the same box using coupled-decoupled configurational-bias"
-                         "algorithm. (i.e., fraction of intra-molecule swap moves). Note: all of the move types"
-                         "are not available in for every ensemble. Note: all of the move fractions"
-                         "must sum to 1, or the control file writer will fail.  "
-                         "".format(_get_default_variables_dict()["IntraSwapFreq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which the molecule will be removed from a "
+        "box and inserted into the same box using coupled-decoupled configurational-bias"
+        "algorithm. (i.e., fraction of intra-molecule swap moves). Note: all of the move types"
+        "are not available in for every ensemble. Note: all of the move fractions"
+        "must sum to 1, or the control file writer will fail.  "
+        "".format(_get_default_variables_dict()["IntraSwapFreq"]),
         "SwapFreq": "Std. MC moves (only GEMC_NPT, GEMC_NVT, and GCMC) : "
-                    "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                    "For Gibbs and Grand Canonical (GC) ensemble runs only: Fractional "
-                    "percentage at which molecule swap move will occur using coupled-decoupled "
-                    "configurational-bias. (i.e., fraction of molecule swaps moves). Note: all of the move types"
-                    "are not available in for every ensemble. Note: all of the move fractions"
-                    "must sum to 1, or the control file writer will fail.  "
-                    "".format(_get_default_variables_dict()["SwapFreq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "For Gibbs and Grand Canonical (GC) ensemble runs only: Fractional "
+        "percentage at which molecule swap move will occur using coupled-decoupled "
+        "configurational-bias. (i.e., fraction of molecule swaps moves). Note: all of the move types"
+        "are not available in for every ensemble. Note: all of the move fractions"
+        "must sum to 1, or the control file writer will fail.  "
+        "".format(_get_default_variables_dict()["SwapFreq"]),
         "RegrowthFreq": "Std. MC moves (all ensembles)                     : "
-                        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                        "Fractional percentage at which part of the molecule will be "
-                        "deleted and then regrown using coupled- decoupled configurational-bias algorithm "
-                        "(i.e., fraction of molecular growth moves). Note: all of the move types"
-                        "are not available in for every ensemble. Note: all of the move fractions"
-                        "must sum to 1, or the control file writer will fail.  "
-                        "".format(_get_default_variables_dict()["RegrowthFreq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which part of the molecule will be "
+        "deleted and then regrown using coupled- decoupled configurational-bias algorithm "
+        "(i.e., fraction of molecular growth moves). Note: all of the move types"
+        "are not available in for every ensemble. Note: all of the move fractions"
+        "must sum to 1, or the control file writer will fail.  "
+        "".format(_get_default_variables_dict()["RegrowthFreq"]),
         "CrankShaftFreq": "Std. MC moves (all ensembles)                     : "
-                          "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                          "Fractional percentage at which crankshaft move will occur. "
-                          "In this move, two atoms that are forming angle or dihedral are selected randomly and "
-                          "form a shaft. Then any atoms or group that are within these two selected atoms, will "
-                          "rotate around the shaft to sample intra-molecular degree of freedom "
-                          "(i.e., fraction of crankshaft moves). Note: all of the move types"
-                          "are not available in for every ensemble. Note: all of the move fractions"
-                          "must sum to 1, or the control file writer will fail. "
-                          "".format(_get_default_variables_dict()["CrankShaftFreq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which crankshaft move will occur. "
+        "In this move, two atoms that are forming angle or dihedral are selected randomly and "
+        "form a shaft. Then any atoms or group that are within these two selected atoms, will "
+        "rotate around the shaft to sample intra-molecular degree of freedom "
+        "(i.e., fraction of crankshaft moves). Note: all of the move types"
+        "are not available in for every ensemble. Note: all of the move fractions"
+        "must sum to 1, or the control file writer will fail. "
+        "".format(_get_default_variables_dict()["CrankShaftFreq"]),
         "VolFreq": "Std. MC moves (only  GEMC_NPT  and  NPT )         : "
-                   "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                   "Fractional percentage at  which a volume move will occur "
-                   "(i.e., fraction of Volume moves). "
-                   "Note: all of the move types are not available in for every ensemble. "
-                   "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-                   "".format(_get_default_variables_dict()["VolFreq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at  which a volume move will occur "
+        "(i.e., fraction of Volume moves). "
+        "Note: all of the move types are not available in for every ensemble. "
+        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+        "".format(_get_default_variables_dict()["VolFreq"]),
         "MultiParticleFreq": "Std. MC moves (all ensembles)                     : "
-                             "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                             "Fractional percentage at which multi-particle move will "
-                             "occur. In this move, all molecules in the selected simulation box will be rigidly "
-                             "rotated or displaced simultaneously, along the calculated torque or force "
-                             "respectively (i.e., fraction of multi-particle moves). Note: all of the move types"
-                             "are not available in for every ensemble. Note: all of the move fractions"
-                             "must sum to 1, or the control file writer will fail.  "
-                             "".format(_get_default_variables_dict()["MultiParticleFreq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which multi-particle move will "
+        "occur. In this move, all molecules in the selected simulation box will be rigidly "
+        "rotated or displaced simultaneously, along the calculated torque or force "
+        "respectively (i.e., fraction of multi-particle moves). Note: all of the move types"
+        "are not available in for every ensemble. Note: all of the move fractions"
+        "must sum to 1, or the control file writer will fail.  "
+        "".format(_get_default_variables_dict()["MultiParticleFreq"]),
         # MEMC moves
         "IntraMEMC-1Freq": "MEMC MC moves (all ensembles)                     : "
-                           "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                           "Fractional percentage at which specified number of small molecule kind will be "
-                           "exchanged with a specified large molecule kind in defined sub-volume within "
-                           "same simulation box.  This move need additional information such as "
-                           "ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, and ExchangeLargeKind."
-                           "Note: all of the move types are not available in for every ensemble."
-                           "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-                           "".format(_get_default_variables_dict()["IntraMEMC-1Freq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which specified number of small molecule kind will be "
+        "exchanged with a specified large molecule kind in defined sub-volume within "
+        "same simulation box.  This move need additional information such as "
+        "ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, and ExchangeLargeKind."
+        "Note: all of the move types are not available in for every ensemble."
+        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+        "".format(_get_default_variables_dict()["IntraMEMC-1Freq"]),
         "MEMC-1Freq": "MEMC MC moves (only GEMC_NPT, GEMC_NVT, and GCMC) : "
-                      "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                      "Fractional percentage at which specified number of small molecule kind will be exchanged "
-                      "with a specified large molecule kind in defined sub-volume, between simulation boxes. "
-                      "This move needs additional information such as ExchangeVolumeDim, ExchangeRatio, "
-                      "ExchangeSmallKind, and ExchangeLargeKind."
-                      "Note: all of the move types are not available in for every ensemble."
-                      "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-                      "".format(_get_default_variables_dict()["MEMC-1Freq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which specified number of small molecule kind will be exchanged "
+        "with a specified large molecule kind in defined sub-volume, between simulation boxes. "
+        "This move needs additional information such as ExchangeVolumeDim, ExchangeRatio, "
+        "ExchangeSmallKind, and ExchangeLargeKind."
+        "Note: all of the move types are not available in for every ensemble."
+        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+        "".format(_get_default_variables_dict()["MEMC-1Freq"]),
         "IntraMEMC-2Freq": "MEMC MC moves (all ensembles)                     : "
-                           "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                           "Fractional percentage at which specified number of small molecule kind "
-                           "will be exchanged with a specified large molecule kind in defined sub-volume "
-                           "within same simulation box. Backbone of small and large molecule kind will be "
-                           "used to insert the large molecule more efficiently. This move need additional "
-                           "information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
-                           "ExchangeLargeKind, SmallKindBackBone, and LargeKindBackBone. "
-                           "Note: all of the move types are not available in for every ensemble."
-                           "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-                           "".format(_get_default_variables_dict()["IntraMEMC-2Freq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which specified number of small molecule kind "
+        "will be exchanged with a specified large molecule kind in defined sub-volume "
+        "within same simulation box. Backbone of small and large molecule kind will be "
+        "used to insert the large molecule more efficiently. This move need additional "
+        "information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
+        "ExchangeLargeKind, SmallKindBackBone, and LargeKindBackBone. "
+        "Note: all of the move types are not available in for every ensemble."
+        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+        "".format(_get_default_variables_dict()["IntraMEMC-2Freq"]),
         "MEMC-2Freq": "MEMC MC moves (only GEMC_NPT, GEMC_NVT, and GCMC) : "
-                      "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                      "Fractional percentage at which specified number of small molecule kind will be "
-                      "exchanged with a specified large molecule kind in defined sub-volume, between"
-                      "simulation boxes. Backbone of small and large molecule kind will be used to insert "
-                      "the large molecule more efficiently. "
-                      "This move needs additional information such as ExchangeVolumeDim, ExchangeRatio, "
-                      "ExchangeSmallKind, ExchangeLargeKind, SmallKindBackBone, and LargeKindBackBone. "
-                      "Note: all of the move types are not available in for every ensemble."
-                      "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-                      "".format(_get_default_variables_dict()["MEMC-2Freq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which specified number of small molecule kind will be "
+        "exchanged with a specified large molecule kind in defined sub-volume, between"
+        "simulation boxes. Backbone of small and large molecule kind will be used to insert "
+        "the large molecule more efficiently. "
+        "This move needs additional information such as ExchangeVolumeDim, ExchangeRatio, "
+        "ExchangeSmallKind, ExchangeLargeKind, SmallKindBackBone, and LargeKindBackBone. "
+        "Note: all of the move types are not available in for every ensemble."
+        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+        "".format(_get_default_variables_dict()["MEMC-2Freq"]),
         "IntraMEMC-3Freq": "MEMC MC moves (all ensembles)                     : "
-                           "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                           "Fractional percentage at which specified number of small molecule kind will be "
-                           "exchanged with a specified large molecule kind in defined sub-volume within same "
-                           "simulation box. Specified atom of the large molecule kind will be used to insert "
-                           "the large molecule using coupled-decoupled configurational-bias. This move needs "
-                           "additional information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
-                           "ExchangeLargeKind, and LargeKindBackBone. "
-                           "Note: all of the move types are not available in for every ensemble."
-                           "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-                           "".format(_get_default_variables_dict()["IntraMEMC-3Freq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which specified number of small molecule kind will be "
+        "exchanged with a specified large molecule kind in defined sub-volume within same "
+        "simulation box. Specified atom of the large molecule kind will be used to insert "
+        "the large molecule using coupled-decoupled configurational-bias. This move needs "
+        "additional information such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, "
+        "ExchangeLargeKind, and LargeKindBackBone. "
+        "Note: all of the move types are not available in for every ensemble."
+        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+        "".format(_get_default_variables_dict()["IntraMEMC-3Freq"]),
         "MEMC-3Freq": "MEMC MC moves (only GEMC_NPT, GEMC_NVT, and GCMC) : "
-                      "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
-                      "Fractional percentage at which specified number of small molecule kind will be exchanged "
-                      "with a specified large molecule kind in defined sub-volume, between simulation boxes. "
-                      "Specified atom of the large molecule kind will be used to insert the large molecule "
-                      "using coupled-decoupled configurational-bias. This move need additional information "
-                      "such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, ExchangeLargeKind, "
-                      "and LargeKindBackBone. "
-                      "Note: all of the move types are not available in for every ensemble."
-                      "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
-                      "".format(_get_default_variables_dict()["MEMC-3Freq"]),
+        "int or float (0 <= value <= 1), default are specific for each ensemble {}. "
+        "Fractional percentage at which specified number of small molecule kind will be exchanged "
+        "with a specified large molecule kind in defined sub-volume, between simulation boxes. "
+        "Specified atom of the large molecule kind will be used to insert the large molecule "
+        "using coupled-decoupled configurational-bias. This move need additional information "
+        "such as ExchangeVolumeDim, ExchangeRatio, ExchangeSmallKind, ExchangeLargeKind, "
+        "and LargeKindBackBone. "
+        "Note: all of the move types are not available in for every ensemble."
+        "Note: all of the move fractions must sum to 1, or the control file writer will fail. "
+        "".format(_get_default_variables_dict()["MEMC-3Freq"]),
         # MEMC move parameters
         "ExchangeVolumeDim": "MEMC parameters (all ensembles)                   : "
-                             "list of 3 floats or integers "
-                             "[int or float (> 0), int or float (> 0), int or float (> 0)]"
-                             " or [X-dimension, Y-dimension, Z-dimension)], default = {}. "
-                             "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, the exchange "
-                             "subvolume must be defined. The exchange sub-volume is defined as an orthogonal box "
-                             "with x, y, and z-dimensions, where small molecule/molecules kind will be selected "
-                             "from to be exchanged with a large molecule kind. "
-                             "Note: Currently, the X and Y dimension cannot be set independently (X = Y = max(X, Y)). "
-                             "Note: A heuristic for setting good values of the x, y, and z-dimensions is to use "
-                             "the geometric size of the large molecule plus 1-2 Å in each dimension. "
-                             "Note: In case of exchanging 1 small molecule kind with 1 large molecule kind in "
-                             "IntraMEMC-2, IntraMEMC-3, MEMC-2, MEMC-3 Monte Carlo moves, the sub-volume "
-                             "dimension has no effect on acceptance rate. "
-                             "".format(_get_default_variables_dict()["ExchangeVolumeDim"]),
+        "list of 3 floats or integers "
+        "[int or float (> 0), int or float (> 0), int or float (> 0)]"
+        " or [X-dimension, Y-dimension, Z-dimension)], default = {}. "
+        "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, the exchange "
+        "subvolume must be defined. The exchange sub-volume is defined as an orthogonal box "
+        "with x, y, and z-dimensions, where small molecule/molecules kind will be selected "
+        "from to be exchanged with a large molecule kind. "
+        "Note: Currently, the X and Y dimension cannot be set independently (X = Y = max(X, Y)). "
+        "Note: A heuristic for setting good values of the x, y, and z-dimensions is to use "
+        "the geometric size of the large molecule plus 1-2 Å in each dimension. "
+        "Note: In case of exchanging 1 small molecule kind with 1 large molecule kind in "
+        "IntraMEMC-2, IntraMEMC-3, MEMC-2, MEMC-3 Monte Carlo moves, the sub-volume "
+        "dimension has no effect on acceptance rate. "
+        "".format(_get_default_variables_dict()["ExchangeVolumeDim"]),
         "MEMC_DataInput": "MEMC parameters (availablity based on selelection): nested lists, "
-                          + "default = {}.  ".format(_get_default_variables_dict()["MEMC_DataInput"]
-                                                     )
-                          + "Enter data as a list with some sub-lists as follows: "
-                            "[[ExchangeRatio_int (> 0), ExchangeLargeKind_str, "
-                            "[LargeKindBackBone_atom_1_str_or_NONE, LargeKindBackBone_atom_2_str_or_NONE ], "
-                            "ExchangeSmallKind_str, "
-                            "[SmallKindBackBone_atom_1_str_or_NONE, SmallKindBackBone_atom_2_str_or_NONE ]], ..., "
-                            "[ExchangeRatio_int (> 0), ExchangeLargeKind_str, "
-                            "[LargeKindBackBone_atom_1_str_or_NONE, LargeKindBackBone_atom_2_str_or_NONE ], "
-                            "ExchangeSmallKind_str, "
-                            "[SmallKindBackBone_atom_1_str_or_NONE, SmallKindBackBone_atom_2_str_or_NONE ]. "
-                            "NOTE: CURRENTLY ALL THESE INPUTS NEED TO BE SPECIFIED, REGARDLESS OF THE MEMC TYPE "
-                            "SELECTION. IF THE SmallKindBackBone or LargeKindBackBone IS NOT REQUIRED FOR THE "
-                            "MEMC TYPE, None CAN BE USED IN PLACE OF A STRING. "
-                            "Note: These strings must match the residue in the psf and psb files or it will fail. "
-                            "It is recommended that the user print the Charmm object psf and pdb files "
-                            "and review the residue names that match the atom name before using the in "
-                            "the  MEMC_DataInput variable input."
-                            "Note: see the below data explanations for the ExchangeRatio, ExchangeSmallKind, "
-                            "ExchangeLargeKind, LargeKindBackBone, SmallKindBackBone. "
-                            "Example 1 (MEMC-1) : [ [1, 'WAT', [None, None], 'wat', [None, None]] , "
-                            "[1, 'WAT', [None, None], 'wat', [None, None]] . "
-                            "Example 2 (MEMC-2): [ [1, 'WAT', ['O1', 'H1'], 'wat', ['O1', 'H1' ]] , "
-                            "[1, 'WAT', ['H1', 'H2'], 'wat', ['H1', 'H2' ]] . "
-                            "Example 3 (MEMC-3) : [ [2, 'WAT', 'O1', 'H1'], 'wat', [None, None]] , "
-                            "[2, 'WAT', ['H1', 'H2'], 'wat', [None, None]] .\n"
-                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeRatio     = MEMC parameters (all ensembles): "
-                            "int (> 0), default = None. The Ratio of exchanging "
-                            "small molecule/molecules with 1 large molecule. "
-                            "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, "
-                            "the exchange ratio must be defined. "
-                            "The exchange ratio defines how many small molecule will be "
-                            "exchanged with 1 large molecule. For each large-small molecule pairs, "
-                            "one exchange ratio must be defined. \n"
-                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeSmallKind = MEMC parameters (all ensembles): "
-                            "str, default = None. The small molecule "
-                            "kind (resname) to be exchanged. "
-                            "Note: ONLY 4 characters can be used for the strings. "
-                            "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, "
-                            "the small molecule kind to be exchanged with a large molecule "
-                            "kind must be defined. Multiple small molecule kind can be specified.  \n"
-                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeLargeKind = MEMC parameters (all ensembles): "
-                            "str, default = None. The large molecule "
-                            "kind (resname) to be exchanged. "
-                            "Note: ONLY 4 characters can be used for the strings. "
-                            "To use all variations of MEMC and Intra-MEMC Monte Carlo moves, "
-                            "the large molecule kind to be exchanged with small molecule "
-                            "kind must be defined. Multiple large molecule kind can be specified. \n"
-                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- LargeKindBackBone = MEMC parameters (all ensembles): "
-                            "list [str, str] or [None, None], default = None "
-                            "Note: ONLY 4 characters can be used for the strings. "
-                            "The [None, None] values can only be used if that MEMC type does not require them. "
-                            "The strings for the the atom name 1 and atom name 2 that belong to the large "
-                            "molecule’s backbone (i.e., [str_for_atom_name_1, str_for_atom_name_2]) "
-                            "To use MEMC-2, MEMC-3, IntraMEMC-2, and IntraMEMC-3 Monte Carlo moves, the "
-                            "large molecule backbone must be defined. The backbone of the molecule is defined "
-                            "as a vector that connects two atoms belong to the large molecule. The large "
-                            "molecule backbone will be used to align the sub-volume in MEMC-2 and IntraMEMC-2 "
-                            "moves, while in MEMC-3 and IntraMEMC-3 moves, it uses the atom name to start "
-                            "growing the large molecule using coupled-decoupled configurational-bias. For "
-                            "each large-small molecule pairs, two atom names must be defined. "
-                            "Note: all atom names in the molecule must be unique. "
-                            "Note: In MEMC-3 and IntraMEMC-3 Monte Carlo moves, both atom names must be same, "
-                            "otherwise program will be terminated. "
-                            "Note: If the large molecule has only one atom (mono atomic molecules), "
-                            "same atom name must be used for str_for_atom_name_1 and str_for_atom_name_2 "
-                            "of the LargeKindBackBone.  \n"
-                            "\t\t\t\t\t\t\t\t\t\t\t\t\t --- SmallKindBackBone = MEMC parameters (all ensembles): "
-                            " list [str, str] or [None, None], default = None "
-                            "Note: ONLY 4 characters can be used for the strings. "
-                            "The [None, None] values can only be used if that MEMC type does not require them."
-                            "The strings for the the atom name 1 and atom name 2 that belong to the small "
-                            "molecule’s backbone (i.e., [str_for_atom_name_1, str_for_atom_name_2]) "
-                            "To use MEMC-2, and IntraMEMC-2 Monte Carlo moves, the small molecule backbone "
-                            "must be defined. The backbone of the molecule is defined as a vector that "
-                            "connects two atoms belong to the small molecule and will be used to align the "
-                            "sub-volume. For each large-small molecule pairs, two atom names must be defined. "
-                            "Note: all atom names in the molecule must be unique. "
-                            "Note: If the small molecule has only one atom (mono atomic molecules), same atom "
-                            "name must be used str_for_atom_name_1 and str_for_atom_name_2 "
-                            "of the SmallKindBackBone. ",
+        + "default = {}.  ".format(
+            _get_default_variables_dict()["MEMC_DataInput"]
+        )
+        + "Enter data as a list with some sub-lists as follows: "
+        "[[ExchangeRatio_int (> 0), ExchangeLargeKind_str, "
+        "[LargeKindBackBone_atom_1_str_or_NONE, LargeKindBackBone_atom_2_str_or_NONE ], "
+        "ExchangeSmallKind_str, "
+        "[SmallKindBackBone_atom_1_str_or_NONE, SmallKindBackBone_atom_2_str_or_NONE ]], ..., "
+        "[ExchangeRatio_int (> 0), ExchangeLargeKind_str, "
+        "[LargeKindBackBone_atom_1_str_or_NONE, LargeKindBackBone_atom_2_str_or_NONE ], "
+        "ExchangeSmallKind_str, "
+        "[SmallKindBackBone_atom_1_str_or_NONE, SmallKindBackBone_atom_2_str_or_NONE ]. "
+        "NOTE: CURRENTLY ALL THESE INPUTS NEED TO BE SPECIFIED, REGARDLESS OF THE MEMC TYPE "
+        "SELECTION. IF THE SmallKindBackBone or LargeKindBackBone IS NOT REQUIRED FOR THE "
+        "MEMC TYPE, None CAN BE USED IN PLACE OF A STRING. "
+        "Note: These strings must match the residue in the psf and psb files or it will fail. "
+        "It is recommended that the user print the Charmm object psf and pdb files "
+        "and review the residue names that match the atom name before using the in "
+        "the  MEMC_DataInput variable input."
+        "Note: see the below data explanations for the ExchangeRatio, ExchangeSmallKind, "
+        "ExchangeLargeKind, LargeKindBackBone, SmallKindBackBone. "
+        "Example 1 (MEMC-1) : [ [1, 'WAT', [None, None], 'wat', [None, None]] , "
+        "[1, 'WAT', [None, None], 'wat', [None, None]] . "
+        "Example 2 (MEMC-2): [ [1, 'WAT', ['O1', 'H1'], 'wat', ['O1', 'H1' ]] , "
+        "[1, 'WAT', ['H1', 'H2'], 'wat', ['H1', 'H2' ]] . "
+        "Example 3 (MEMC-3) : [ [2, 'WAT', 'O1', 'H1'], 'wat', [None, None]] , "
+        "[2, 'WAT', ['H1', 'H2'], 'wat', [None, None]] .\n"
+        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeRatio     = MEMC parameters (all ensembles): "
+        "int (> 0), default = None. The Ratio of exchanging "
+        "small molecule/molecules with 1 large molecule. "
+        "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, "
+        "the exchange ratio must be defined. "
+        "The exchange ratio defines how many small molecule will be "
+        "exchanged with 1 large molecule. For each large-small molecule pairs, "
+        "one exchange ratio must be defined. \n"
+        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeSmallKind = MEMC parameters (all ensembles): "
+        "str, default = None. The small molecule "
+        "kind (resname) to be exchanged. "
+        "Note: ONLY 4 characters can be used for the strings. "
+        "To use all variation of MEMC and Intra-MEMC Monte Carlo moves, "
+        "the small molecule kind to be exchanged with a large molecule "
+        "kind must be defined. Multiple small molecule kind can be specified.  \n"
+        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- ExchangeLargeKind = MEMC parameters (all ensembles): "
+        "str, default = None. The large molecule "
+        "kind (resname) to be exchanged. "
+        "Note: ONLY 4 characters can be used for the strings. "
+        "To use all variations of MEMC and Intra-MEMC Monte Carlo moves, "
+        "the large molecule kind to be exchanged with small molecule "
+        "kind must be defined. Multiple large molecule kind can be specified. \n"
+        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- LargeKindBackBone = MEMC parameters (all ensembles): "
+        "list [str, str] or [None, None], default = None "
+        "Note: ONLY 4 characters can be used for the strings. "
+        "The [None, None] values can only be used if that MEMC type does not require them. "
+        "The strings for the the atom name 1 and atom name 2 that belong to the large "
+        "molecule’s backbone (i.e., [str_for_atom_name_1, str_for_atom_name_2]) "
+        "To use MEMC-2, MEMC-3, IntraMEMC-2, and IntraMEMC-3 Monte Carlo moves, the "
+        "large molecule backbone must be defined. The backbone of the molecule is defined "
+        "as a vector that connects two atoms belong to the large molecule. The large "
+        "molecule backbone will be used to align the sub-volume in MEMC-2 and IntraMEMC-2 "
+        "moves, while in MEMC-3 and IntraMEMC-3 moves, it uses the atom name to start "
+        "growing the large molecule using coupled-decoupled configurational-bias. For "
+        "each large-small molecule pairs, two atom names must be defined. "
+        "Note: all atom names in the molecule must be unique. "
+        "Note: In MEMC-3 and IntraMEMC-3 Monte Carlo moves, both atom names must be same, "
+        "otherwise program will be terminated. "
+        "Note: If the large molecule has only one atom (mono atomic molecules), "
+        "same atom name must be used for str_for_atom_name_1 and str_for_atom_name_2 "
+        "of the LargeKindBackBone.  \n"
+        "\t\t\t\t\t\t\t\t\t\t\t\t\t --- SmallKindBackBone = MEMC parameters (all ensembles): "
+        " list [str, str] or [None, None], default = None "
+        "Note: ONLY 4 characters can be used for the strings. "
+        "The [None, None] values can only be used if that MEMC type does not require them."
+        "The strings for the the atom name 1 and atom name 2 that belong to the small "
+        "molecule’s backbone (i.e., [str_for_atom_name_1, str_for_atom_name_2]) "
+        "To use MEMC-2, and IntraMEMC-2 Monte Carlo moves, the small molecule backbone "
+        "must be defined. The backbone of the molecule is defined as a vector that "
+        "connects two atoms belong to the small molecule and will be used to align the "
+        "sub-volume. For each large-small molecule pairs, two atom names must be defined. "
+        "Note: all atom names in the molecule must be unique. "
+        "Note: If the small molecule has only one atom (mono atomic molecules), same atom "
+        "name must be used str_for_atom_name_1 and str_for_atom_name_2 "
+        "of the SmallKindBackBone. ",
         # ******************************************************************************************************
         # Definitions in this function are copied to a large extent from the GOMC manual release version 2.60 (end)
         # insert citation here:
@@ -866,7 +875,10 @@ def _get_default_variables_dict():
         # Control file (.conf file ) output controls/parameters
         "OutputName": "Output_data",
         "CoordinatesFreq": [True, 1000000],
-        "DCDFreq": [False, 1000000],  # set to False until this is in the new official GOMC software release
+        "DCDFreq": [
+            False,
+            1000000,
+        ],  # set to False until this is in the new official GOMC software release
         "RestartFreq": [True, 1000000],
         "CheckpointFreq": [True, 1000000],
         "ConsoleFreq": [True, 10000],
@@ -2172,53 +2184,78 @@ class GOMCControl:
 
         # check if the binary restart files are provided correctly
         if self.Restart is True and self.ensemble_type in ["NVT", "NPT"]:
-            if (self.binCoordinates_box_0 is not None \
-                    or self.extendedSystem_box_0 is not None) \
-                    and (self.binCoordinates_box_0 is None \
-                         or self.extendedSystem_box_0 is None):
-                print_error_message = 'ERROR: To restart a simulation with the binary files both the coor and ' \
-                                      'xsc files for box 0 must be provided.'
+            if (
+                self.binCoordinates_box_0 is not None
+                or self.extendedSystem_box_0 is not None
+            ) and (
+                self.binCoordinates_box_0 is None
+                or self.extendedSystem_box_0 is None
+            ):
+                print_error_message = (
+                    "ERROR: To restart a simulation with the binary files both the coor and "
+                    "xsc files for box 0 must be provided."
+                )
                 raise ValueError(print_error_message)
 
-            elif self.binVelocities_box_0 is not None \
-                    and (self.binCoordinates_box_0 is None \
-                    or self.extendedSystem_box_0 is None):
-                print_error_message = 'ERROR: To restart a "NVT", "NPT" simulation with the ' \
-                                      'velocity binary files, the velocity files for box 0 ' \
-                                      'must be provided.'
+            elif self.binVelocities_box_0 is not None and (
+                self.binCoordinates_box_0 is None
+                or self.extendedSystem_box_0 is None
+            ):
+                print_error_message = (
+                    'ERROR: To restart a "NVT", "NPT" simulation with the '
+                    "velocity binary files, the velocity files for box 0 "
+                    "must be provided."
+                )
                 raise ValueError(print_error_message)
 
-        if self.Restart is True and self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]:
-            if (self.binCoordinates_box_0 is not None \
-                or self.extendedSystem_box_0 is not None \
-                or self.binCoordinates_box_1 is not None \
-                or self.extendedSystem_box_1 is not None) \
-                    and (self.binCoordinates_box_0 is None \
-                         or self.extendedSystem_box_0 is None \
-                         or self.binCoordinates_box_1 is None \
-                         or self.extendedSystem_box_1 is None):
-                print_error_message = 'ERROR: To restart a simulation with the binary files both the coor and ' \
-                                      'xsc files for box 0 and box 1 must be provided.'
+        if self.Restart is True and self.ensemble_type in [
+            "GEMC_NPT",
+            "GEMC_NVT",
+            "GCMC",
+        ]:
+            if (
+                self.binCoordinates_box_0 is not None
+                or self.extendedSystem_box_0 is not None
+                or self.binCoordinates_box_1 is not None
+                or self.extendedSystem_box_1 is not None
+            ) and (
+                self.binCoordinates_box_0 is None
+                or self.extendedSystem_box_0 is None
+                or self.binCoordinates_box_1 is None
+                or self.extendedSystem_box_1 is None
+            ):
+                print_error_message = (
+                    "ERROR: To restart a simulation with the binary files both the coor and "
+                    "xsc files for box 0 and box 1 must be provided."
+                )
                 raise ValueError(print_error_message)
 
-            elif (self.binVelocities_box_0 is not None \
-                        or self.binVelocities_box_1 is not None) \
-                    and (self.binVelocities_box_0 is None \
-                         or self.binVelocities_box_1 is None):
-                print_error_message = 'ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the ' \
-                                      'velocity binary files, both the velocity files for box 0 and box 1 ' \
-                                      'must be provided.'
+            elif (
+                self.binVelocities_box_0 is not None
+                or self.binVelocities_box_1 is not None
+            ) and (
+                self.binVelocities_box_0 is None
+                or self.binVelocities_box_1 is None
+            ):
+                print_error_message = (
+                    'ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the '
+                    "velocity binary files, both the velocity files for box 0 and box 1 "
+                    "must be provided."
+                )
                 raise ValueError(print_error_message)
 
-            if self.binCoordinates_box_0 is None \
-                or self.extendedSystem_box_0 is None \
-                or self.binCoordinates_box_1 is None \
-                or self.extendedSystem_box_1 is None:
-                print_error_message = 'ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the ' \
-                                      'velocity binary files, both the coor and xsc files files for box 0 ' \
-                                      'and box 1 must be provided.'
+            if (
+                self.binCoordinates_box_0 is None
+                or self.extendedSystem_box_0 is None
+                or self.binCoordinates_box_1 is None
+                or self.extendedSystem_box_1 is None
+            ):
+                print_error_message = (
+                    'ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the '
+                    "velocity binary files, both the coor and xsc files files for box 0 "
+                    "and box 1 must be provided."
+                )
                 raise ValueError(print_error_message)
-
 
         self.RunSteps = RunSteps
         self.Temperature = Temperature
@@ -2227,20 +2264,24 @@ class GOMCControl:
             not isinstance(self.ff_psf_pdb_file_directory, str)
             and self.ff_psf_pdb_file_directory is not None
         ):
-            _check_if_string_and_extension('ff_psf_pdb_file_directory',
-                                           self.ff_psf_pdb_file_directory,
-                                           'force field, pdb, and psf',
-                                           expected_file_extension=None)
+            _check_if_string_and_extension(
+                "ff_psf_pdb_file_directory",
+                self.ff_psf_pdb_file_directory,
+                "force field, pdb, and psf",
+                expected_file_extension=None,
+            )
 
         if (
             charmm_object.ff_filename is not None
             and isinstance(charmm_object.ff_filename, str) is True
         ):
             if Parameters is not None:
-                _check_if_string_and_extension('Parameters',
-                                               Parameters,
-                                               'force field',
-                                               expected_file_extension=['.inp', '.par'])
+                _check_if_string_and_extension(
+                    "Parameters",
+                    Parameters,
+                    "force field",
+                    expected_file_extension=[".inp", ".par"],
+                )
                 self.ff_filename = Parameters
             elif self.ff_psf_pdb_file_directory is None:
                 self.ff_filename = charmm_object.ff_filename
@@ -2275,14 +2316,18 @@ class GOMCControl:
             and isinstance(charmm_object.filename_box_0, str) is True
         ):
             if Coordinates_box_0 is not None:
-                _check_if_string_and_extension('Coordinates_box_0',
-                                               Coordinates_box_0,
-                                               'pdb',
-                                               expected_file_extension=['.pdb'])
-                _check_if_string_and_extension('Structure_box_0',
-                                               Structure_box_0,
-                                               'psf',
-                                               expected_file_extension=['.psf'])
+                _check_if_string_and_extension(
+                    "Coordinates_box_0",
+                    Coordinates_box_0,
+                    "pdb",
+                    expected_file_extension=[".pdb"],
+                )
+                _check_if_string_and_extension(
+                    "Structure_box_0",
+                    Structure_box_0,
+                    "psf",
+                    expected_file_extension=[".psf"],
+                )
                 self.Coordinates_box_0 = Coordinates_box_0
                 self.Structures_box_0 = Structure_box_0
             elif self.ff_psf_pdb_file_directory is None:
@@ -2312,16 +2357,22 @@ class GOMCControl:
             )
 
             # Box 0 restarting files with increased accuracy (coor, xsc) and a velocity passing input
-            if self.binCoordinates_box_0 is not None \
-                    and self.extendedSystem_box_0 is not None:
-                _check_if_string_and_extension('binCoordinates_box_0',
-                                               self.binCoordinates_box_0,
-                                               'coor',
-                                               expected_file_extension=['.coor'])
-                _check_if_string_and_extension('Structure_box_0',
-                                               self.extendedSystem_box_0,
-                                               'xsc',
-                                               expected_file_extension=['.xsc'])
+            if (
+                self.binCoordinates_box_0 is not None
+                and self.extendedSystem_box_0 is not None
+            ):
+                _check_if_string_and_extension(
+                    "binCoordinates_box_0",
+                    self.binCoordinates_box_0,
+                    "coor",
+                    expected_file_extension=[".coor"],
+                )
+                _check_if_string_and_extension(
+                    "Structure_box_0",
+                    self.extendedSystem_box_0,
+                    "xsc",
+                    expected_file_extension=[".xsc"],
+                )
                 _check_if_input_files_exist(
                     self.binCoordinates_box_0,
                     "box 0 coor file",
@@ -2334,10 +2385,12 @@ class GOMCControl:
                 )
 
             if self.binVelocities_box_0 is not None:
-                _check_if_string_and_extension('binVelocities_box_0',
-                                               self.binVelocities_box_0,
-                                               'velocity',
-                                               expected_file_extension=['.vel'])
+                _check_if_string_and_extension(
+                    "binVelocities_box_0",
+                    self.binVelocities_box_0,
+                    "velocity",
+                    expected_file_extension=[".vel"],
+                )
                 _check_if_input_files_exist(
                     self.binVelocities_box_0,
                     "box 0 velocity file",
@@ -2349,14 +2402,18 @@ class GOMCControl:
             and isinstance(charmm_object.filename_box_1, str) is True
         ):
             if Coordinates_box_1 is not None:
-                _check_if_string_and_extension('Coordinates_box_1',
-                                               Coordinates_box_1,
-                                               'pdb',
-                                               expected_file_extension=['.pdb'])
-                _check_if_string_and_extension('Structure_box_1',
-                                               Structure_box_1,
-                                               'psf',
-                                               expected_file_extension=['.psf'])
+                _check_if_string_and_extension(
+                    "Coordinates_box_1",
+                    Coordinates_box_1,
+                    "pdb",
+                    expected_file_extension=[".pdb"],
+                )
+                _check_if_string_and_extension(
+                    "Structure_box_1",
+                    Structure_box_1,
+                    "psf",
+                    expected_file_extension=[".psf"],
+                )
                 self.Coordinates_box_1 = Coordinates_box_1
                 self.Structures_box_1 = Structure_box_1
             elif self.ff_psf_pdb_file_directory is None:
@@ -2386,16 +2443,22 @@ class GOMCControl:
             )
 
             # Box 1 restarting files with increased accuracy (coor, xsc) and a velocity passing input
-            if self.binCoordinates_box_1 is not None \
-                    and self.extendedSystem_box_1 is not None:
-                _check_if_string_and_extension('binCoordinates_box_1',
-                                               self.binCoordinates_box_1,
-                                               'coor',
-                                               expected_file_extension=['.coor'])
-                _check_if_string_and_extension('Structure_box_1',
-                                               self.extendedSystem_box_1,
-                                               'xsc',
-                                               expected_file_extension=['.xsc'])
+            if (
+                self.binCoordinates_box_1 is not None
+                and self.extendedSystem_box_1 is not None
+            ):
+                _check_if_string_and_extension(
+                    "binCoordinates_box_1",
+                    self.binCoordinates_box_1,
+                    "coor",
+                    expected_file_extension=[".coor"],
+                )
+                _check_if_string_and_extension(
+                    "Structure_box_1",
+                    self.extendedSystem_box_1,
+                    "xsc",
+                    expected_file_extension=[".xsc"],
+                )
                 _check_if_input_files_exist(
                     self.binCoordinates_box_1,
                     "box 1 coor file",
@@ -2408,10 +2471,12 @@ class GOMCControl:
                 )
 
             if self.binVelocities_box_1 is not None:
-                _check_if_string_and_extension('binVelocities_box_1',
-                                               self.binVelocities_box_1,
-                                               'velocity',
-                                               expected_file_extension=['.vel'])
+                _check_if_string_and_extension(
+                    "binVelocities_box_1",
+                    self.binVelocities_box_1,
+                    "velocity",
+                    expected_file_extension=[".vel"],
+                )
                 _check_if_input_files_exist(
                     self.binVelocities_box_1,
                     "box 0 velocity file",
@@ -4865,37 +4930,57 @@ class GOMCControl:
                 "{:25s} {}\n".format("Structure 1", self.Structures_box_1)
             )
 
-        if self.Restart is True and self.binCoordinates_box_0 is not None \
-                and self.extendedSystem_box_0 is not None \
-                and self.ensemble_type in ["NVT", "NPT", "GEMC_NPT", "GEMC_NVT", "GCMC"]:
+        if (
+            self.Restart is True
+            and self.binCoordinates_box_0 is not None
+            and self.extendedSystem_box_0 is not None
+            and self.ensemble_type
+            in ["NVT", "NPT", "GEMC_NPT", "GEMC_NVT", "GCMC"]
+        ):
             data_control_file.write(" \n")
             data_control_file.write("####################################\n")
-            data_control_file.write("# INPUT BINARY FILES FOR RESTARTING (COORDINATE, XSC, VELOCITY FILES)\n")
+            data_control_file.write(
+                "# INPUT BINARY FILES FOR RESTARTING (COORDINATE, XSC, VELOCITY FILES)\n"
+            )
             data_control_file.write("####################################\n")
             data_control_file.write(
-                "{:25s} {}\n".format("binCoordinates   0", self.binCoordinates_box_0)
+                "{:25s} {}\n".format(
+                    "binCoordinates   0", self.binCoordinates_box_0
+                )
             )
             data_control_file.write(
-                "{:25s} {}\n".format("extendedSystem 	0", self.extendedSystem_box_0)
+                "{:25s} {}\n".format(
+                    "extendedSystem 	0", self.extendedSystem_box_0
+                )
             )
             if self.binVelocities_box_0 is not None:
                 data_control_file.write(
-                    "{:25s} {}\n".format("binVelocities   	0", self.binVelocities_box_0)
+                    "{:25s} {}\n".format(
+                        "binVelocities   	0", self.binVelocities_box_0
+                    )
                 )
             data_control_file.write(" \n")
 
-            if self.binCoordinates_box_1 is not None \
-                    and self.extendedSystem_box_1 is not None \
-                    and self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]:
+            if (
+                self.binCoordinates_box_1 is not None
+                and self.extendedSystem_box_1 is not None
+                and self.ensemble_type in ["GEMC_NPT", "GEMC_NVT", "GCMC"]
+            ):
                 data_control_file.write(
-                    "{:25s} {}\n".format("binCoordinates   1", self.binCoordinates_box_1)
+                    "{:25s} {}\n".format(
+                        "binCoordinates   1", self.binCoordinates_box_1
+                    )
                 )
                 data_control_file.write(
-                    "{:25s} {}\n".format("extendedSystem 	1", self.extendedSystem_box_1)
+                    "{:25s} {}\n".format(
+                        "extendedSystem 	1", self.extendedSystem_box_1
+                    )
                 )
                 if self.binVelocities_box_1 is not None:
                     data_control_file.write(
-                        "{:25s} {}\n".format("binVelocities   	1", self.binVelocities_box_1)
+                        "{:25s} {}\n".format(
+                            "binVelocities   	1", self.binVelocities_box_1
+                        )
                     )
 
         data_control_file.write(" \n")
@@ -6391,11 +6476,12 @@ def _check_if_input_files_exist(
         )
         raise ValueError(print_error_message)
 
+
 def _check_if_string_and_extension(
-        file_directory_and_name,
-        file_directory_and_name_variable,
-        type_of_file,
-        expected_file_extension=None,
+    file_directory_and_name,
+    file_directory_and_name_variable,
+    type_of_file,
+    expected_file_extension=None,
 ):
     """
     Checks to see GOMC FF, pdb, and psf files exist
@@ -6419,9 +6505,13 @@ def _check_if_string_and_extension(
     If the variable is a string and has the wrong extension  : raise TypeError
     """
     if (
-        not isinstance(file_directory_and_name_variable, str) and file_directory_and_name_variable is not None
+        not isinstance(file_directory_and_name_variable, str)
+        and file_directory_and_name_variable is not None
     ):
-        print('file_directory_and_name_variable =' +str(file_directory_and_name_variable))
+        print(
+            "file_directory_and_name_variable ="
+            + str(file_directory_and_name_variable)
+        )
         print_error_message = (
             r"ERROR: The {} variable for directly entering the "
             r"{} file directory and name is a {} and not a string.".format(
@@ -6433,21 +6523,21 @@ def _check_if_string_and_extension(
         raise TypeError(print_error_message)
 
     if expected_file_extension is not None:
-        acutal_file_extension = os.path.splitext(file_directory_and_name_variable)[-1]
+        acutal_file_extension = os.path.splitext(
+            file_directory_and_name_variable
+        )[-1]
         if acutal_file_extension not in expected_file_extension:
-            print_error_message = (
-                r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
-                r''.format(
-                    file_directory_and_name,
-                    expected_file_extension,
-                    acutal_file_extension,
-                )
+            print_error_message = r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". ' r"".format(
+                file_directory_and_name,
+                expected_file_extension,
+                acutal_file_extension,
             )
             raise TypeError(print_error_message)
 
+
 def _check_if_bool(
-        variable_as_a_string,
-        variable,
+    variable_as_a_string,
+    variable,
 ):
     """
     Checks to see if the variable is a boolean.
@@ -6465,9 +6555,12 @@ def _check_if_bool(
     If the variable is not a bool : raise TypeError
     """
     if not isinstance(variable, bool):
-        print_error_message = 'ERROR: The {} input is {} and needs to be a boolean (i.e., True or False).' \
-                              ''.format(variable_as_a_string, type(variable))
+        print_error_message = (
+            "ERROR: The {} input is {} and needs to be a boolean (i.e., True or False)."
+            "".format(variable_as_a_string, type(variable))
+        )
         raise TypeError(print_error_message)
+
 
 # user callable function to write the GOMC control file
 def write_gomc_control_file(

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -2193,13 +2193,13 @@ class GOMCControl:
                 raise ValueError(print_error_message)
 
             elif (
-                    self.binVelocities_box_0 is not None
-                    or self.binVelocities_box_1 is not None
+                self.binVelocities_box_0 is not None
+                or self.binVelocities_box_1 is not None
             ) and (
-                    self.binCoordinates_box_0 is None
-                    or self.extendedSystem_box_0 is None
-                    or self.binCoordinates_box_1 is None
-                    or self.extendedSystem_box_1 is None
+                self.binCoordinates_box_0 is None
+                or self.extendedSystem_box_0 is None
+                or self.binCoordinates_box_1 is None
+                or self.extendedSystem_box_1 is None
             ):
                 print_error_message = (
                     'ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the '

--- a/mbuild/formats/gomc_conf_writer.py
+++ b/mbuild/formats/gomc_conf_writer.py
@@ -6699,7 +6699,7 @@ def write_gomc_control_file(
     # *******************************************************************
 
     Attributes
-        ----------
+    ----------
         input_error : bool
             This error is typically incurred from an error in the user input values.
             However, it could also be due to a bug, provided the user is inputting

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -124,7 +124,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "SampleFreq",
                 "OutEnergy",
                 "OutPressure",
-                "OutMolNumber",
+                "OutMolNum",
                 "OutDensity",
                 "OutVolume",
                 "OutSurfaceTension",
@@ -205,7 +205,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "SampleFreq",
                 "OutEnergy",
                 "OutPressure",
-                "OutMolNumber",
+                "OutMolNum",
                 "OutDensity",
                 "OutVolume",
                 "OutSurfaceTension",
@@ -288,7 +288,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "SampleFreq",
                 "OutEnergy",
                 "OutPressure",
-                "OutMolNumber",
+                "OutMolNum",
                 "OutDensity",
                 "OutVolume",
                 "OutSurfaceTension",
@@ -602,7 +602,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "SampleFreq": False,
                 "OutEnergy": False,
                 "OutPressure": False,
-                "OutMolNumber": False,
+                "OutMolNum": False,
                 "OutDensity": False,
                 "OutVolume": False,
                 "OutSurfaceTension": False,
@@ -914,8 +914,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     assert split_line[1] == "True"
                     assert split_line[2] == "True"
 
-                elif line.startswith("OutMolNumber "):
-                    variables_read_dict["OutMolNumber"] = True
+                elif line.startswith("OutMolNum "):
+                    variables_read_dict["OutMolNum"] = True
                     split_line = line.split()
                     assert split_line[1] == "True"
                     assert split_line[2] == "True"
@@ -999,7 +999,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "SampleFreq": True,
             "OutEnergy": True,
             "OutPressure": True,
-            "OutMolNumber": True,
+            "OutMolNum": True,
             "OutDensity": True,
             "OutVolume": True,
             "OutSurfaceTension": True,
@@ -2004,7 +2004,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 ],
                 "OutEnergy": [False, False],
                 "OutPressure": [False, False],
-                "OutMolNumber": [False, False],
+                "OutMolNum": [False, False],
                 "OutDensity": [False, False],
                 "OutVolume": [False, False],
                 "OutSurfaceTension": [True, True],
@@ -2081,7 +2081,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "SampleFreq": False,
                 "OutEnergy": False,
                 "OutPressure": False,
-                "OutMolNumber": False,
+                "OutMolNum": False,
                 "OutDensity": False,
                 "OutVolume": False,
                 "OutSurfaceTension": False,
@@ -2460,8 +2460,8 @@ class TestGOMCControlFileWriter(BaseTest):
                     assert split_line[1] == "False"
                     assert split_line[2] == "False"
 
-                elif line.startswith("OutMolNumber "):
-                    variables_read_dict["OutMolNumber"] = True
+                elif line.startswith("OutMolNum "):
+                    variables_read_dict["OutMolNum"] = True
                     split_line = line.split()
                     assert split_line[1] == "False"
                     assert split_line[2] == "False"
@@ -2556,7 +2556,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "SampleFreq": True,
             "OutEnergy": True,
             "OutPressure": True,
-            "OutMolNumber": True,
+            "OutMolNum": True,
             "OutDensity": True,
             "OutVolume": True,
             "OutSurfaceTension": True,
@@ -3356,7 +3356,7 @@ class TestGOMCControlFileWriter(BaseTest):
             match=r"ERROR: The following input variables have "
             r"bad values \(check spelling and for empty spaces in the keys or that "
             r"the values are in the correct form with the acceptable values\)"
-            r": \['OutMolNumber'\]",
+            r": \['OutMolNum'\]",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -3365,7 +3365,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 10,
                 300,
                 check_input_files_exist=False,
-                input_variables_dict={"OutMolNumber": "s"},
+                input_variables_dict={"OutMolNum": "s"},
             )
 
         with pytest.raises(
@@ -4714,7 +4714,7 @@ class TestGOMCControlFileWriter(BaseTest):
             match=r"ERROR: The following input variables have "
             r"bad values \(check spelling and for empty spaces in the keys or that "
             r"the values are in the correct form with the acceptable values\)"
-            r": \['OutMolNumber'\]",
+            r": \['OutMolNum'\]",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -4723,7 +4723,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 10,
                 300,
                 check_input_files_exist=False,
-                input_variables_dict={"OutMolNumber": []},
+                input_variables_dict={"OutMolNum": []},
             )
 
         with pytest.raises(

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -1,8 +1,9 @@
+import os
+
 import pytest
 
 import mbuild as mb
 import mbuild.formats.gomc_conf_writer as gomc_control
-import os
 from mbuild.formats.charmm_writer import Charmm
 from mbuild.lattice import load_cif
 from mbuild.tests.base_test import BaseTest
@@ -21,289 +22,303 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_get_required_data(self):
         value = gomc_control._get_required_data(description=False)
-        assert value.sort() == [
-            "charmm_object",
-            "ensemble_type",
-            "RunSteps",
-            "Temperature",
-            "ff_psf_pdb_file_directory",
-            "check_input_files_exist",
-            "Restart",
-            "RestartCheckpoint",
-            "Parameters",
-            "Coordinates_box_0",
-            "override_psf_box_0",
-            "Coordinates_box_1",
-            "Structure_box_1",
-            "binCoordinates_box_0",
-            "extendedSystem_box_0",
-            "binVelocities_box_0",
-            "binCoordinates_box_1",
-            "extendedSystem_box_1",
-            "binVelocities_box_1",
-        ].sort()
+        assert (
+            value.sort()
+            == [
+                "charmm_object",
+                "ensemble_type",
+                "RunSteps",
+                "Temperature",
+                "ff_psf_pdb_file_directory",
+                "check_input_files_exist",
+                "Restart",
+                "RestartCheckpoint",
+                "Parameters",
+                "Coordinates_box_0",
+                "override_psf_box_0",
+                "Coordinates_box_1",
+                "Structure_box_1",
+                "binCoordinates_box_0",
+                "extendedSystem_box_0",
+                "binVelocities_box_0",
+                "binCoordinates_box_1",
+                "extendedSystem_box_1",
+                "binVelocities_box_1",
+            ].sort()
+        )
 
         value = gomc_control._get_required_data(description=True)
-        assert gomc_control.dict_keys_to_list(value).sort() == [
-            "charmm_object",
-            "ensemble_type",
-            "RunSteps",
-            "Temperature",
-            "ff_psf_pdb_file_directory",
-            "Restart",
-            "RestartCheckpoint"
-            "check_input_files_exist",
-            "Parameters",
-            "Coordinate_box_0",
-            "Structure_box_0",
-            "Coordinate_box_1",
-            "Structure_box_1",
-            "binCoordinates_box_0",
-            "extendedSystem_box_0",
-            "binVelocities_box_0",
-            "binCoordinates_box_1",
-            "extendedSystem_box_1",
-            "binVelocities_box_1",
-        ].sort()
+        assert (
+            gomc_control.dict_keys_to_list(value).sort()
+            == [
+                "charmm_object",
+                "ensemble_type",
+                "RunSteps",
+                "Temperature",
+                "ff_psf_pdb_file_directory",
+                "Restart",
+                "RestartCheckpoint" "check_input_files_exist",
+                "Parameters",
+                "Coordinate_box_0",
+                "Structure_box_0",
+                "Coordinate_box_1",
+                "Structure_box_1",
+                "binCoordinates_box_0",
+                "extendedSystem_box_0",
+                "binVelocities_box_0",
+                "binCoordinates_box_1",
+                "extendedSystem_box_1",
+                "binVelocities_box_1",
+            ].sort()
+        )
 
     def test_get_all_possible_input_variable(self):
         value = gomc_control._get_all_possible_input_variables(
             description=False
         )
-        assert value.sort() == [
-            "PRNG",
-            "ParaTypeCHARMM",
-            "ParaTypeMie",
-            "ParaTypeMARTINI",
-            "RcutCoulomb_box_0",
-            "RcutCoulomb_box_1",
-            "Pressure",
-            "Rcut",
-            "RcutLow",
-            "LRC",
-            "Exclude",
-            "Potential",
-            "Rswitch",
-            "ElectroStatic",
-            "Ewald",
-            "CachedFourier",
-            "Tolerance",
-            "Dielectric",
-            "PressureCalc",
-            "EqSteps",
-            "AdjSteps",
-            "VDWGeometricSigma",
-            "useConstantArea",
-            "FixVolBox0",
-            "ChemPot",
-            "Fugacity",
-            "CBMC_First",
-            "CBMC_Nth",
-            "CBMC_Ang",
-            "CBMC_Dih",
-            "OutputName",
-            "CoordinatesFreq",
-            "DCDFreq",
-            "RestartFreq",
-            "CheckpointFreq",
-            "ConsoleFreq",
-            "BlockAverageFreq",
-            "HistogramFreq",
-            "DistName",
-            "HistName",
-            "RunNumber",
-            "RunLetter",
-            "SampleFreq",
-            "OutEnergy",
-            "OutPressure",
-            "OutMolNumber",
-            "OutDensity",
-            "OutVolume",
-            "OutSurfaceTension",
-            "FreeEnergyCalc",
-            "MoleculeType",
-            "InitialState",
-            "LambdaVDW",
-            "LambdaCoulomb",
-            "ScaleCoulomb",
-            "ScalePower",
-            "ScaleAlpha",
-            "MinSigma",
-            "DisFreq",
-            "RotFreq",
-            "IntraSwapFreq",
-            "SwapFreq",
-            "RegrowthFreq",
-            "CrankShaftFreq",
-            "VolFreq",
-            "MultiParticleFreq",
-            "IntraMEMC-1Freq",
-            "MEMC-1Freq",
-            "IntraMEMC-2Freq",
-            "MEMC-2Freq",
-            "IntraMEMC-3Freq",
-            "MEMC-3Freq",
-            "ExchangeVolumeDim",
-            "MEMC_DataInput",
-        ].sort()
+        assert (
+            value.sort()
+            == [
+                "PRNG",
+                "ParaTypeCHARMM",
+                "ParaTypeMie",
+                "ParaTypeMARTINI",
+                "RcutCoulomb_box_0",
+                "RcutCoulomb_box_1",
+                "Pressure",
+                "Rcut",
+                "RcutLow",
+                "LRC",
+                "Exclude",
+                "Potential",
+                "Rswitch",
+                "ElectroStatic",
+                "Ewald",
+                "CachedFourier",
+                "Tolerance",
+                "Dielectric",
+                "PressureCalc",
+                "EqSteps",
+                "AdjSteps",
+                "VDWGeometricSigma",
+                "useConstantArea",
+                "FixVolBox0",
+                "ChemPot",
+                "Fugacity",
+                "CBMC_First",
+                "CBMC_Nth",
+                "CBMC_Ang",
+                "CBMC_Dih",
+                "OutputName",
+                "CoordinatesFreq",
+                "DCDFreq",
+                "RestartFreq",
+                "CheckpointFreq",
+                "ConsoleFreq",
+                "BlockAverageFreq",
+                "HistogramFreq",
+                "DistName",
+                "HistName",
+                "RunNumber",
+                "RunLetter",
+                "SampleFreq",
+                "OutEnergy",
+                "OutPressure",
+                "OutMolNumber",
+                "OutDensity",
+                "OutVolume",
+                "OutSurfaceTension",
+                "FreeEnergyCalc",
+                "MoleculeType",
+                "InitialState",
+                "LambdaVDW",
+                "LambdaCoulomb",
+                "ScaleCoulomb",
+                "ScalePower",
+                "ScaleAlpha",
+                "MinSigma",
+                "DisFreq",
+                "RotFreq",
+                "IntraSwapFreq",
+                "SwapFreq",
+                "RegrowthFreq",
+                "CrankShaftFreq",
+                "VolFreq",
+                "MultiParticleFreq",
+                "IntraMEMC-1Freq",
+                "MEMC-1Freq",
+                "IntraMEMC-2Freq",
+                "MEMC-2Freq",
+                "IntraMEMC-3Freq",
+                "MEMC-3Freq",
+                "ExchangeVolumeDim",
+                "MEMC_DataInput",
+            ].sort()
+        )
 
         value = gomc_control._get_all_possible_input_variables(description=True)
-        assert gomc_control.dict_keys_to_list(value).sort() == [
-            "PRNG",
-            "ParaTypeCHARMM",
-            "ParaTypeMie",
-            "ParaTypeMARTINI",
-            "RcutCoulomb_box_0",
-            "RcutCoulomb_box_1",
-            "Pressure",
-            "Rcut",
-            "RcutLow",
-            "LRC",
-            "Exclude",
-            "Potential",
-            "Rswitch",
-            "ElectroStatic",
-            "Ewald",
-            "CachedFourier",
-            "Tolerance",
-            "Dielectric",
-            "PressureCalc",
-            "EqSteps",
-            "AdjSteps",
-            "VDWGeometricSigma",
-            "useConstantArea",
-            "FixVolBox0",
-            "ChemPot",
-            "Fugacity",
-            "CBMC_First",
-            "CBMC_Nth",
-            "CBMC_Ang",
-            "CBMC_Dih",
-            "OutputName",
-            "CoordinatesFreq",
-            "DCDFreq",
-            "RestartFreq",
-            "CheckpointFreq",
-            "ConsoleFreq",
-            "BlockAverageFreq",
-            "HistogramFreq",
-            "DistName",
-            "HistName",
-            "RunNumber",
-            "RunLetter",
-            "SampleFreq",
-            "OutEnergy",
-            "OutPressure",
-            "OutMolNumber",
-            "OutDensity",
-            "OutVolume",
-            "OutSurfaceTension",
-            "FreeEnergyCalc",
-            "MoleculeType",
-            "InitialState",
-            "LambdaVDW",
-            "LambdaCoulomb",
-            "ScaleCoulomb",
-            "ScalePower",
-            "ScaleAlpha",
-            "MinSigma",
-            "DisFreq",
-            "RotFreq",
-            "IntraSwapFreq",
-            "SwapFreq",
-            "RegrowthFreq",
-            "CrankShaftFreq",
-            "VolFreq",
-            "MultiParticleFreq",
-            "IntraMEMC-1Freq",
-            "MEMC-1Freq",
-            "IntraMEMC-2Freq",
-            "MEMC-2Freq",
-            "IntraMEMC-3Freq",
-            "MEMC-3Freq",
-            "ExchangeVolumeDim",
-            "MEMC_DataInput",
-        ].sort()
+        assert (
+            gomc_control.dict_keys_to_list(value).sort()
+            == [
+                "PRNG",
+                "ParaTypeCHARMM",
+                "ParaTypeMie",
+                "ParaTypeMARTINI",
+                "RcutCoulomb_box_0",
+                "RcutCoulomb_box_1",
+                "Pressure",
+                "Rcut",
+                "RcutLow",
+                "LRC",
+                "Exclude",
+                "Potential",
+                "Rswitch",
+                "ElectroStatic",
+                "Ewald",
+                "CachedFourier",
+                "Tolerance",
+                "Dielectric",
+                "PressureCalc",
+                "EqSteps",
+                "AdjSteps",
+                "VDWGeometricSigma",
+                "useConstantArea",
+                "FixVolBox0",
+                "ChemPot",
+                "Fugacity",
+                "CBMC_First",
+                "CBMC_Nth",
+                "CBMC_Ang",
+                "CBMC_Dih",
+                "OutputName",
+                "CoordinatesFreq",
+                "DCDFreq",
+                "RestartFreq",
+                "CheckpointFreq",
+                "ConsoleFreq",
+                "BlockAverageFreq",
+                "HistogramFreq",
+                "DistName",
+                "HistName",
+                "RunNumber",
+                "RunLetter",
+                "SampleFreq",
+                "OutEnergy",
+                "OutPressure",
+                "OutMolNumber",
+                "OutDensity",
+                "OutVolume",
+                "OutSurfaceTension",
+                "FreeEnergyCalc",
+                "MoleculeType",
+                "InitialState",
+                "LambdaVDW",
+                "LambdaCoulomb",
+                "ScaleCoulomb",
+                "ScalePower",
+                "ScaleAlpha",
+                "MinSigma",
+                "DisFreq",
+                "RotFreq",
+                "IntraSwapFreq",
+                "SwapFreq",
+                "RegrowthFreq",
+                "CrankShaftFreq",
+                "VolFreq",
+                "MultiParticleFreq",
+                "IntraMEMC-1Freq",
+                "MEMC-1Freq",
+                "IntraMEMC-2Freq",
+                "MEMC-2Freq",
+                "IntraMEMC-3Freq",
+                "MEMC-3Freq",
+                "ExchangeVolumeDim",
+                "MEMC_DataInput",
+            ].sort()
+        )
 
     def test_get_default_variables_dict(self):
         value = gomc_control._get_default_variables_dict()
-        assert gomc_control.dict_keys_to_list(value).sort() == [
-            "PRNG",
-            "ParaTypeCHARMM",
-            "ParaTypeMie",
-            "ParaTypeMARTINI",
-            "RcutCoulomb_box_0",
-            "RcutCoulomb_box_1",
-            "Pressure",
-            "Rcut",
-            "RcutLow",
-            "LRC",
-            "Exclude",
-            "coul_1_4_scaling",
-            "Potential",
-            "Rswitch",
-            "ElectroStatic",
-            "Ewald",
-            "CachedFourier",
-            "Tolerance",
-            "Dielectric",
-            "PressureCalc",
-            "EqSteps",
-            "AdjSteps",
-            "VDWGeometricSigma",
-            "useConstantArea",
-            "FixVolBox0",
-            "ChemPot",
-            "Fugacity",
-            "CBMC_First",
-            "CBMC_Nth",
-            "CBMC_Ang",
-            "CBMC_Dih",
-            "OutputName",
-            "CoordinatesFreq",
-            "DCDFreq",
-            "RestartFreq",
-            "CheckpointFreq",
-            "ConsoleFreq",
-            "BlockAverageFreq",
-            "HistogramFreq",
-            "DistName",
-            "HistName",
-            "RunNumber",
-            "RunLetter",
-            "SampleFreq",
-            "OutEnergy",
-            "OutPressure",
-            "OutMolNumber",
-            "OutDensity",
-            "OutVolume",
-            "OutSurfaceTension",
-            "FreeEnergyCalc",
-            "MoleculeType",
-            "InitialState",
-            "LambdaVDW",
-            "LambdaCoulomb",
-            "ScaleCoulomb",
-            "ScalePower",
-            "ScaleAlpha",
-            "MinSigma",
-            "ExchangeVolumeDim",
-            "MEMC_DataInput",
-            "DisFreq",
-            "RotFreq",
-            "IntraSwapFreq",
-            "SwapFreq",
-            "RegrowthFreq",
-            "CrankShaftFreq",
-            "VolFreq",
-            "MultiParticleFreq",
-            "IntraMEMC-1Freq",
-            "MEMC-1Freq",
-            "IntraMEMC-2Freq",
-            "MEMC-2Freq",
-            "IntraMEMC-3Freq",
-            "MEMC-3Freq",
-        ].sort()
+        assert (
+            gomc_control.dict_keys_to_list(value).sort()
+            == [
+                "PRNG",
+                "ParaTypeCHARMM",
+                "ParaTypeMie",
+                "ParaTypeMARTINI",
+                "RcutCoulomb_box_0",
+                "RcutCoulomb_box_1",
+                "Pressure",
+                "Rcut",
+                "RcutLow",
+                "LRC",
+                "Exclude",
+                "coul_1_4_scaling",
+                "Potential",
+                "Rswitch",
+                "ElectroStatic",
+                "Ewald",
+                "CachedFourier",
+                "Tolerance",
+                "Dielectric",
+                "PressureCalc",
+                "EqSteps",
+                "AdjSteps",
+                "VDWGeometricSigma",
+                "useConstantArea",
+                "FixVolBox0",
+                "ChemPot",
+                "Fugacity",
+                "CBMC_First",
+                "CBMC_Nth",
+                "CBMC_Ang",
+                "CBMC_Dih",
+                "OutputName",
+                "CoordinatesFreq",
+                "DCDFreq",
+                "RestartFreq",
+                "CheckpointFreq",
+                "ConsoleFreq",
+                "BlockAverageFreq",
+                "HistogramFreq",
+                "DistName",
+                "HistName",
+                "RunNumber",
+                "RunLetter",
+                "SampleFreq",
+                "OutEnergy",
+                "OutPressure",
+                "OutMolNumber",
+                "OutDensity",
+                "OutVolume",
+                "OutSurfaceTension",
+                "FreeEnergyCalc",
+                "MoleculeType",
+                "InitialState",
+                "LambdaVDW",
+                "LambdaCoulomb",
+                "ScaleCoulomb",
+                "ScalePower",
+                "ScaleAlpha",
+                "MinSigma",
+                "ExchangeVolumeDim",
+                "MEMC_DataInput",
+                "DisFreq",
+                "RotFreq",
+                "IntraSwapFreq",
+                "SwapFreq",
+                "RegrowthFreq",
+                "CrankShaftFreq",
+                "VolFreq",
+                "MultiParticleFreq",
+                "IntraMEMC-1Freq",
+                "MEMC-1Freq",
+                "IntraMEMC-2Freq",
+                "MEMC-2Freq",
+                "IntraMEMC-3Freq",
+                "MEMC-3Freq",
+            ].sort()
+        )
 
     def test_print_ensemble_info(self):
 
@@ -393,7 +408,7 @@ class TestGOMCControlFileWriter(BaseTest):
             10,
             300,
             check_input_files_exist=False,
-            Restart=False
+            Restart=False,
         )
 
         with open("test_save_basic_NVT.conf", "r") as fp:
@@ -8936,8 +8951,8 @@ class TestGOMCControlFileWriter(BaseTest):
         # test the failure of the ff_psf_pdb_file_directory variable is not None or a string
         with pytest.raises(
             TypeError,
-            match= f"ERROR: The {'ff_psf_pdb_file_directory'} variable for directly entering the "
-                   f"{'force field, pdb, and psf'} file directory and name is a {type(['x'])} and not a string."
+            match=f"ERROR: The {'ff_psf_pdb_file_directory'} variable for directly entering the "
+            f"{'force field, pdb, and psf'} file directory and name is a {type(['x'])} and not a string.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9292,8 +9307,8 @@ class TestGOMCControlFileWriter(BaseTest):
         restart_input = "XXXXX"
         with pytest.raises(
             TypeError,
-            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
-                  ''.format("Restart", type(restart_input)),
+            match=r"ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\)."
+            "".format("Restart", type(restart_input)),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9302,14 +9317,14 @@ class TestGOMCControlFileWriter(BaseTest):
                 100,
                 300,
                 check_input_files_exist=False,
-                Restart=restart_input
+                Restart=restart_input,
             )
 
         restart_checkpoint_input = "XXXXX"
         with pytest.raises(
             TypeError,
-            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
-                  ''.format("RestartCheckpoint", type(restart_checkpoint_input)),
+            match=r"ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\)."
+            "".format("RestartCheckpoint", type(restart_checkpoint_input)),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9324,18 +9339,19 @@ class TestGOMCControlFileWriter(BaseTest):
         check_input_files_exist_input = "XXXXX"
         with pytest.raises(
             TypeError,
-            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
-                  ''.format("check_input_files_exist", type(check_input_files_exist_input)),
+            match=r"ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\)."
+            "".format(
+                "check_input_files_exist", type(check_input_files_exist_input)
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
-                'check_input_files_exist_error',
+                "check_input_files_exist_error",
                 "NVT",
                 100,
                 300,
                 check_input_files_exist="XXXXX",
             )
-
 
     def test_restarting_dcd_and_binary_files_NVT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
@@ -9365,9 +9381,10 @@ class TestGOMCControlFileWriter(BaseTest):
             binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
             extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
             binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
-            input_variables_dict={"VDWGeometricSigma": True,
-                                  "DCDFreq": [True, 1000],
-                                  }
+            input_variables_dict={
+                "VDWGeometricSigma": True,
+                "DCDFreq": [True, 1000],
+            },
         )
 
         with open("test_restarting_dcd_and_binary_files_NVT.conf", "r") as fp:
@@ -9398,37 +9415,45 @@ class TestGOMCControlFileWriter(BaseTest):
                     assert split_line[1] == "True"
                     assert split_line[2] == "1000"
 
-
                 elif line.startswith("Coordinates 0"):
                     variables_read_dict["Coordinates_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files/NVT_toluene_box_0.pdb"
-
+                    assert (
+                        split_line[2] == "../test_files/NVT_toluene_box_0.pdb"
+                    )
 
                 elif line.startswith("Structure 0"):
                     variables_read_dict["Structure_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files/NVT_toluene_box_0.psf"
+                    assert (
+                        split_line[2] == "../test_files/NVT_toluene_box_0.psf"
+                    )
 
                 elif line.startswith("binCoordinates   0 "):
                     variables_read_dict["binCoordinates_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files/NVT_toluene_box_0.coor"
+                    assert (
+                        split_line[2] == "../test_files/NVT_toluene_box_0.coor"
+                    )
 
                 elif line.startswith("extendedSystem 	0 "):
                     variables_read_dict["extendedSystem_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files/NVT_toluene_box_0.xsc"
+                    assert (
+                        split_line[2] == "../test_files/NVT_toluene_box_0.xsc"
+                    )
 
                 elif line.startswith("binVelocities   	0"):
                     variables_read_dict["binVelocities_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files/NVT_toluene_box_0.vel"
+                    assert (
+                        split_line[2] == "../test_files/NVT_toluene_box_0.vel"
+                    )
 
         assert variables_read_dict == {
             "Restart": True,
@@ -9457,8 +9482,8 @@ class TestGOMCControlFileWriter(BaseTest):
         )
         with pytest.raises(
             ValueError,
-            match='ERROR: To restart a simulation with the binary files both the coor '
-                  'and xsc files for box 0 must be provided.',
+            match="ERROR: To restart a simulation with the binary files both the coor "
+            "and xsc files for box 0 must be provided.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9471,15 +9496,16 @@ class TestGOMCControlFileWriter(BaseTest):
                 binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
                 extendedSystem_box_0=None,
                 binVelocities_box_0=None,
-                input_variables_dict={"VDWGeometricSigma": True,
-                                      "DCDFreq": [True, 1000],
-                                      }
+                input_variables_dict={
+                    "VDWGeometricSigma": True,
+                    "DCDFreq": [True, 1000],
+                },
             )
 
         with pytest.raises(
-                ValueError,
-                match='ERROR: To restart a simulation with the binary files both the coor and '
-                      'xsc files for box 0 must be provided.',
+            ValueError,
+            match="ERROR: To restart a simulation with the binary files both the coor and "
+            "xsc files for box 0 must be provided.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9492,16 +9518,17 @@ class TestGOMCControlFileWriter(BaseTest):
                 binCoordinates_box_0=None,
                 extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
                 binVelocities_box_0=None,
-                input_variables_dict={"VDWGeometricSigma": True,
-                                      "DCDFreq": [True, 1000],
-                                      }
+                input_variables_dict={
+                    "VDWGeometricSigma": True,
+                    "DCDFreq": [True, 1000],
+                },
             )
 
         with pytest.raises(
-                ValueError,
-                match='ERROR: To restart a "NVT", "NPT" simulation with the ' 
-                      'velocity binary files, the velocity files for box 0 ' 
-                      'must be provided.',
+            ValueError,
+            match='ERROR: To restart a "NVT", "NPT" simulation with the '
+            "velocity binary files, the velocity files for box 0 "
+            "must be provided.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9514,12 +9541,15 @@ class TestGOMCControlFileWriter(BaseTest):
                 binCoordinates_box_0=None,
                 extendedSystem_box_0=None,
                 binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
-                input_variables_dict={"VDWGeometricSigma": True,
-                                      "DCDFreq": [True, 1000],
-                                      }
+                input_variables_dict={
+                    "VDWGeometricSigma": True,
+                    "DCDFreq": [True, 1000],
+                },
             )
 
-    def test_failures_restarting_dcd_and_binary_files_GEMC_NVT(self, ethane_gomc):
+    def test_failures_restarting_dcd_and_binary_files_GEMC_NVT(
+        self, ethane_gomc
+    ):
         test_box_ethane_gomc = mb.fill_box(
             compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
         )
@@ -9539,8 +9569,8 @@ class TestGOMCControlFileWriter(BaseTest):
 
         with pytest.raises(
             ValueError,
-            match='ERROR: To restart a simulation with the binary files both the coor and ' \
-                  'xsc files for box 0 and box 1 must be provided.',
+            match="ERROR: To restart a simulation with the binary files both the coor and "
+            "xsc files for box 0 and box 1 must be provided.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9556,15 +9586,16 @@ class TestGOMCControlFileWriter(BaseTest):
                 binCoordinates_box_1="../test_files/NVT_toluene_box_1.coor",
                 extendedSystem_box_1=None,
                 binVelocities_box_1=None,
-                input_variables_dict={"VDWGeometricSigma": True,
-                                      "DCDFreq": [True, 1000],
-                                      }
+                input_variables_dict={
+                    "VDWGeometricSigma": True,
+                    "DCDFreq": [True, 1000],
+                },
             )
 
         with pytest.raises(
-                ValueError,
-                match='ERROR: To restart a simulation with the binary files both the coor and ' \
-                      'xsc files for box 0 and box 1 must be provided.',
+            ValueError,
+            match="ERROR: To restart a simulation with the binary files both the coor and "
+            "xsc files for box 0 and box 1 must be provided.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9580,16 +9611,17 @@ class TestGOMCControlFileWriter(BaseTest):
                 binCoordinates_box_1=None,
                 extendedSystem_box_1="../test_files/NVT_toluene_box_0.xsc",
                 binVelocities_box_1=None,
-                input_variables_dict={"VDWGeometricSigma": True,
-                                      "DCDFreq": [True, 1000],
-                                      }
+                input_variables_dict={
+                    "VDWGeometricSigma": True,
+                    "DCDFreq": [True, 1000],
+                },
             )
 
         with pytest.raises(
-                ValueError,
-                match='ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the ' \
-                      'velocity binary files, both the velocity files for box 0 and box 1 ' \
-                      'must be provided.',
+            ValueError,
+            match='ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the '
+            "velocity binary files, both the velocity files for box 0 and box 1 "
+            "must be provided.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9605,19 +9637,21 @@ class TestGOMCControlFileWriter(BaseTest):
                 binCoordinates_box_1="../test_files/NVT_toluene_box_1.coor",
                 extendedSystem_box_1="../test_files/NVT_toluene_box_1.xsc",
                 binVelocities_box_1=None,
-                input_variables_dict={"VDWGeometricSigma": True,
-                                      "DCDFreq": [True, 1000],
-                                      }
+                input_variables_dict={
+                    "VDWGeometricSigma": True,
+                    "DCDFreq": [True, 1000],
+                },
             )
 
         test_box_0_pdb = "XXXX"
         with pytest.raises(
-                TypeError,
-                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
-                      r''.format('Coordinates_box_0',
-                                 "\['.pdb'\]",
-                                 os.path.splitext(test_box_0_pdb)[-1],
-                                 )
+            TypeError,
+            match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+            r"".format(
+                "Coordinates_box_0",
+                "\['.pdb'\]",
+                os.path.splitext(test_box_0_pdb)[-1],
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9634,12 +9668,13 @@ class TestGOMCControlFileWriter(BaseTest):
 
         test_box_1_pdb = "XXXX"
         with pytest.raises(
-                TypeError,
-                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
-                      r''.format('Coordinates_box_1',
-                                 "\['.pdb'\]",
-                                 os.path.splitext(test_box_1_pdb)[-1],
-                                 )
+            TypeError,
+            match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+            r"".format(
+                "Coordinates_box_1",
+                "\['.pdb'\]",
+                os.path.splitext(test_box_1_pdb)[-1],
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9656,12 +9691,13 @@ class TestGOMCControlFileWriter(BaseTest):
 
         test_box_0_psf = "XXXX"
         with pytest.raises(
-                TypeError,
-                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
-                      r''.format('Structure_box_0',
-                                 "\['.psf'\]",
-                                 os.path.splitext(test_box_0_psf)[-1],
-                                 )
+            TypeError,
+            match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+            r"".format(
+                "Structure_box_0",
+                "\['.psf'\]",
+                os.path.splitext(test_box_0_psf)[-1],
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9678,12 +9714,13 @@ class TestGOMCControlFileWriter(BaseTest):
 
         test_box_1_psf = "XXXX"
         with pytest.raises(
-                TypeError,
-                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
-                      r''.format('Structure_box_1',
-                                 "\['.psf'\]",
-                                 os.path.splitext(test_box_1_psf)[-1],
-                                 )
+            TypeError,
+            match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+            r"".format(
+                "Structure_box_1",
+                "\['.psf'\]",
+                os.path.splitext(test_box_1_psf)[-1],
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -2,6 +2,7 @@ import pytest
 
 import mbuild as mb
 import mbuild.formats.gomc_conf_writer as gomc_control
+import os
 from mbuild.formats.charmm_writer import Charmm
 from mbuild.lattice import load_cif
 from mbuild.tests.base_test import BaseTest
@@ -20,54 +21,56 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_get_required_data(self):
         value = gomc_control._get_required_data(description=False)
-        assert value == [
+        assert value.sort() == [
             "charmm_object",
             "ensemble_type",
             "RunSteps",
             "Temperature",
             "ff_psf_pdb_file_directory",
-            "override_check_input_files_exist",
-            "override_ff_directory_filename",
-            "override_box_0_pdb_directory_filename",
-            "override_box_0_psf_directory_filename",
-            "override_box_1_pdb_directory_filename",
-            "override_box_1_psf_directory_filename",
-            "box_0_restart_coor_directory_filename",
-            "box_0_restart_xsc_directory_filename",
-            "box_0_restart_velocity_directory_filename",
-            "box_1_restart_coor_directory_filename",
-            "box_1_restart_xsc_directory_filename",
-            "box_1_restart_velocity_directory_filename",
-        ]
+            "check_input_files_exist",
+            "Restart",
+            "RestartCheckpoint",
+            "Parameters",
+            "Coordinates_box_0",
+            "override_psf_box_0",
+            "Coordinates_box_1",
+            "Structure_box_1",
+            "binCoordinates_box_0",
+            "extendedSystem_box_0",
+            "binVelocities_box_0",
+            "binCoordinates_box_1",
+            "extendedSystem_box_1",
+            "binVelocities_box_1",
+        ].sort()
 
         value = gomc_control._get_required_data(description=True)
-        assert gomc_control.dict_keys_to_list(value) == [
+        assert gomc_control.dict_keys_to_list(value).sort() == [
             "charmm_object",
             "ensemble_type",
             "RunSteps",
             "Temperature",
             "ff_psf_pdb_file_directory",
-            "override_check_input_files_exist",
-            "override_ff_directory_filename",
-            "override_box_0_pdb_directory_filename",
-            "override_box_0_psf_directory_filename",
-            "override_box_1_pdb_directory_filename",
-            "override_box_1_psf_directory_filename",
-            "box_0_restart_coor_directory_filename",
-            "box_0_restart_xsc_directory_filename",
-            "box_0_restart_velocity_directory_filename",
-            "box_1_restart_coor_directory_filename",
-            "box_1_restart_xsc_directory_filename",
-            "box_1_restart_velocity_directory_filename",
-        ]
+            "Restart",
+            "RestartCheckpoint"
+            "check_input_files_exist",
+            "Parameters",
+            "Coordinate_box_0",
+            "Structure_box_0",
+            "Coordinate_box_1",
+            "Structure_box_1",
+            "binCoordinates_box_0",
+            "extendedSystem_box_0",
+            "binVelocities_box_0",
+            "binCoordinates_box_1",
+            "extendedSystem_box_1",
+            "binVelocities_box_1",
+        ].sort()
 
     def test_get_all_possible_input_variable(self):
         value = gomc_control._get_all_possible_input_variables(
             description=False
         )
-        assert value == [
-            "Restart",
-            "RestartCheckpoint",
+        assert value.sort() == [
             "PRNG",
             "ParaTypeCHARMM",
             "ParaTypeMie",
@@ -142,12 +145,10 @@ class TestGOMCControlFileWriter(BaseTest):
             "MEMC-3Freq",
             "ExchangeVolumeDim",
             "MEMC_DataInput",
-        ]
+        ].sort()
 
         value = gomc_control._get_all_possible_input_variables(description=True)
-        assert gomc_control.dict_keys_to_list(value) == [
-            "Restart",
-            "RestartCheckpoint",
+        assert gomc_control.dict_keys_to_list(value).sort() == [
             "PRNG",
             "ParaTypeCHARMM",
             "ParaTypeMie",
@@ -222,13 +223,11 @@ class TestGOMCControlFileWriter(BaseTest):
             "MEMC-3Freq",
             "ExchangeVolumeDim",
             "MEMC_DataInput",
-        ]
+        ].sort()
 
     def test_get_default_variables_dict(self):
         value = gomc_control._get_default_variables_dict()
-        assert gomc_control.dict_keys_to_list(value) == [
-            "Restart",
-            "RestartCheckpoint",
+        assert gomc_control.dict_keys_to_list(value).sort() == [
             "PRNG",
             "ParaTypeCHARMM",
             "ParaTypeMie",
@@ -304,7 +303,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "MEMC-2Freq",
             "IntraMEMC-3Freq",
             "MEMC-3Freq",
-        ]
+        ].sort()
 
     def test_print_ensemble_info(self):
 
@@ -393,7 +392,8 @@ class TestGOMCControlFileWriter(BaseTest):
             "NVT",
             10,
             300,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
+            Restart=False
         )
 
         with open("test_save_basic_NVT.conf", "r") as fp:
@@ -875,7 +875,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "NPT",
             1000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
         )
 
         with open("test_save_basic_NPT.conf", "r") as fp:
@@ -1148,7 +1148,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GCMC",
             100000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
             input_variables_dict={
                 "ChemPot": {"ETH": -4000},
                 "VDWGeometricSigma": True,
@@ -1488,7 +1488,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             1000000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
         )
 
         with open("test_save_basic_GEMC_NVT.conf", "r") as fp:
@@ -1619,7 +1619,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NPT",
             1000000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
             input_variables_dict={
                 "Pressure": 10,
                 "useConstantArea": True,
@@ -1793,9 +1793,9 @@ class TestGOMCControlFileWriter(BaseTest):
             "NVT",
             100000,
             300,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
+            Restart=False,
             input_variables_dict={
-                "Restart": True,
                 "PRNG": 123,
                 "ParaTypeCHARMM": True,
                 "ParaTypeMARTINI": False,
@@ -1932,7 +1932,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 if line.startswith("Restart "):
                     variables_read_dict["Restart"] = True
                     split_line = line.split()
-                    assert split_line[1] == "True"
+                    assert split_line[1] == "False"
 
                 elif line.startswith("PRNG "):
                     variables_read_dict["PRNG"] = True
@@ -2428,7 +2428,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10],
                     "MoleculeType": ["ETH", 1],
@@ -2448,7 +2448,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10],
                     "MoleculeType": ["ETH", 1],
@@ -2477,40 +2477,6 @@ class TestGOMCControlFileWriter(BaseTest):
             match=r"ERROR: The following input variables have "
             r"bad values \(check spelling and for empty spaces in the keys or that "
             r"the values are in the correct form with the acceptable values\)"
-            r": \['Restart'\]",
-        ):
-            gomc_control.write_gomc_control_file(
-                charmm,
-                "test_save_NVT_bad_variables_part_1.conf",
-                "NVT",
-                10,
-                300,
-                override_check_input_files_exist=True,
-                input_variables_dict={"Restart": "s"},
-            )
-
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: The following input variables have "
-            r"bad values \(check spelling and for empty spaces in the keys or that "
-            r"the values are in the correct form with the acceptable values\)"
-            r": \['RestartCheckpoint'\]",
-        ):
-            gomc_control.write_gomc_control_file(
-                charmm,
-                "test_save_NVT_bad_variables_part_1.conf",
-                "NVT",
-                10,
-                300,
-                override_check_input_files_exist=True,
-                input_variables_dict={"RestartCheckpoint": "s"},
-            )
-
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: The following input variables have "
-            r"bad values \(check spelling and for empty spaces in the keys or that "
-            r"the values are in the correct form with the acceptable values\)"
             r": \['PRNG'\]",
         ):
             gomc_control.write_gomc_control_file(
@@ -2519,7 +2485,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PRNG": [1]},
             )
 
@@ -2536,7 +2502,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeCHARMM": "s"},
             )
 
@@ -2553,7 +2519,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeMie": "s"},
             )
 
@@ -2570,7 +2536,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeMARTINI": "s"},
             )
 
@@ -2587,7 +2553,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_0": "s"},
             )
 
@@ -2606,7 +2572,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_1": "s"},
             )
 
@@ -2623,7 +2589,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Pressure": "s"},
             )
 
@@ -2640,7 +2606,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Rcut": "s"},
             )
 
@@ -2657,7 +2623,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutLow": "s"},
             )
 
@@ -2674,7 +2640,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"LRC": "s"},
             )
 
@@ -2691,7 +2657,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Exclude": "s"},
             )
 
@@ -2708,7 +2674,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Potential": "s"},
             )
 
@@ -2725,7 +2691,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Rswitch": "s"},
             )
 
@@ -2742,7 +2708,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ElectroStatic": "s"},
             )
 
@@ -2759,7 +2725,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Ewald": "s"},
             )
 
@@ -2776,7 +2742,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CachedFourier": "s"},
             )
 
@@ -2793,7 +2759,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Tolerance": "s"},
             )
 
@@ -2810,7 +2776,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Dielectric": "s"},
             )
 
@@ -2827,7 +2793,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": "s"},
             )
 
@@ -2844,7 +2810,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"EqSteps": "s"},
             )
 
@@ -2861,7 +2827,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"EqSteps": "s"},
             )
 
@@ -2878,7 +2844,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"useConstantArea": "s"},
             )
 
@@ -2897,7 +2863,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ChemPot": "s"},
             )
 
@@ -2916,7 +2882,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Fugacity": "s"},
             )
 
@@ -2933,7 +2899,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_First": "s"},
             )
 
@@ -2950,7 +2916,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Nth": "s"},
             )
 
@@ -2967,7 +2933,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Ang": "s"},
             )
 
@@ -2984,7 +2950,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Dih": "s"},
             )
 
@@ -3001,7 +2967,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutputName": 1},
             )
 
@@ -3018,7 +2984,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CoordinatesFreq": "s"},
             )
 
@@ -3035,7 +3001,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RestartFreq": "s"},
             )
 
@@ -3052,7 +3018,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CheckpointFreq": "s"},
             )
 
@@ -3069,7 +3035,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ConsoleFreq": "s"},
             )
 
@@ -3086,7 +3052,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"BlockAverageFreq": "s"},
             )
 
@@ -3103,7 +3069,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"HistogramFreq": "s"},
             )
 
@@ -3120,7 +3086,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DistName": 1},
             )
 
@@ -3137,7 +3103,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"HistName": 1},
             )
 
@@ -3154,7 +3120,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RunNumber": "s"},
             )
 
@@ -3171,7 +3137,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RunLetter": 1},
             )
 
@@ -3188,7 +3154,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"SampleFreq": "s"},
             )
 
@@ -3205,7 +3171,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": "s"},
             )
 
@@ -3222,7 +3188,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutPressure": "s"},
             )
 
@@ -3239,7 +3205,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutMolNumber": "s"},
             )
 
@@ -3256,7 +3222,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutDensity": "s"},
             )
 
@@ -3273,7 +3239,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutVolume": "s"},
             )
 
@@ -3290,7 +3256,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutSurfaceTension": "s"},
             )
 
@@ -3307,7 +3273,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": "s",
                     "MoleculeType": ["ETH", 1],
@@ -3330,7 +3296,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", "s"],
@@ -3353,7 +3319,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [["ETH"], 1],
@@ -3376,7 +3342,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"ETH": "1"}, 1],
@@ -3399,7 +3365,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3422,7 +3388,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3445,7 +3411,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3467,7 +3433,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"FreeEnergyCalc": [True, 10000]},
             )
 
@@ -3484,7 +3450,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScaleCoulomb": "s"},
             )
 
@@ -3501,7 +3467,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScalePower": "s"},
             )
 
@@ -3518,7 +3484,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScaleAlpha": "s"},
             )
 
@@ -3535,7 +3501,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MinSigma": "s"},
             )
 
@@ -3552,7 +3518,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": "s"},
             )
 
@@ -3569,7 +3535,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC_DataInput": "s"},
             )
 
@@ -3586,7 +3552,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DisFreq": "s"},
             )
 
@@ -3603,7 +3569,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RotFreq": "s"},
             )
 
@@ -3620,7 +3586,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraSwapFreq": "s"},
             )
 
@@ -3637,7 +3603,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"SwapFreq": "s"},
             )
 
@@ -3654,7 +3620,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RegrowthFreq": "s"},
             )
 
@@ -3671,7 +3637,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CrankShaftFreq": "s"},
             )
 
@@ -3688,7 +3654,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"VolFreq": "s"},
             )
 
@@ -3705,7 +3671,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MultiParticleFreq": "s"},
             )
 
@@ -3722,7 +3688,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-1Freq": "s"},
             )
 
@@ -3739,7 +3705,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-1Freq": "s"},
             )
 
@@ -3756,7 +3722,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-2Freq": "s"},
             )
 
@@ -3773,7 +3739,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-2Freq": "s"},
             )
 
@@ -3790,7 +3756,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-3Freq": "s"},
             )
 
@@ -3807,7 +3773,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-3Freq": "s"},
             )
 
@@ -3826,7 +3792,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"XXXXXX": "s"},
             )
 
@@ -3850,40 +3816,6 @@ class TestGOMCControlFileWriter(BaseTest):
             match=r"ERROR: The following input variables have "
             r"bad values \(check spelling and for empty spaces in the keys or that "
             r"the values are in the correct form with the acceptable values\)"
-            r": \['Restart'\]",
-        ):
-            gomc_control.write_gomc_control_file(
-                charmm,
-                "test_save_NVT_bad_variables_part_2.conf",
-                "NVT",
-                10,
-                300,
-                override_check_input_files_exist=True,
-                input_variables_dict={"Restart": []},
-            )
-
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: The following input variables have "
-            r"bad values \(check spelling and for empty spaces in the keys or that "
-            r"the values are in the correct form with the acceptable values\)"
-            r": \['RestartCheckpoint'\]",
-        ):
-            gomc_control.write_gomc_control_file(
-                charmm,
-                "test_save_NVT_bad_variables_part_2.conf",
-                "NVT",
-                10,
-                300,
-                override_check_input_files_exist=True,
-                input_variables_dict={"RestartCheckpoint": []},
-            )
-
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: The following input variables have "
-            r"bad values \(check spelling and for empty spaces in the keys or that "
-            r"the values are in the correct form with the acceptable values\)"
             r": \['PRNG'\]",
         ):
             gomc_control.write_gomc_control_file(
@@ -3892,7 +3824,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PRNG": []},
             )
 
@@ -3909,7 +3841,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeCHARMM": []},
             )
 
@@ -3926,7 +3858,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeMie": []},
             )
 
@@ -3943,7 +3875,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeMARTINI": []},
             )
 
@@ -3960,7 +3892,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_0": []},
             )
 
@@ -3979,7 +3911,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_1": []},
             )
 
@@ -3996,7 +3928,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Pressure": []},
             )
 
@@ -4013,7 +3945,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Rcut": []},
             )
 
@@ -4030,7 +3962,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutLow": []},
             )
 
@@ -4047,7 +3979,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"LRC": []},
             )
 
@@ -4064,7 +3996,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Exclude": []},
             )
 
@@ -4081,7 +4013,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Potential": []},
             )
 
@@ -4098,7 +4030,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Rswitch": []},
             )
 
@@ -4115,7 +4047,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ElectroStatic": []},
             )
 
@@ -4132,7 +4064,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Ewald": []},
             )
 
@@ -4149,7 +4081,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CachedFourier": []},
             )
 
@@ -4166,7 +4098,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Tolerance": []},
             )
 
@@ -4183,7 +4115,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Dielectric": []},
             )
 
@@ -4200,7 +4132,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": []},
             )
 
@@ -4217,7 +4149,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"EqSteps": []},
             )
 
@@ -4234,7 +4166,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"AdjSteps": []},
             )
 
@@ -4251,7 +4183,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"useConstantArea": []},
             )
 
@@ -4270,7 +4202,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"FixVolBox0": []},
             )
 
@@ -4289,7 +4221,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ChemPot": []},
             )
 
@@ -4308,7 +4240,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Fugacity": []},
             )
 
@@ -4325,7 +4257,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_First": []},
             )
 
@@ -4342,7 +4274,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Nth": []},
             )
 
@@ -4359,7 +4291,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Ang": []},
             )
 
@@ -4376,7 +4308,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Dih": []},
             )
 
@@ -4393,7 +4325,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutputName": []},
             )
 
@@ -4410,7 +4342,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CoordinatesFreq": []},
             )
 
@@ -4427,7 +4359,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RestartFreq": []},
             )
 
@@ -4444,7 +4376,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CheckpointFreq": []},
             )
 
@@ -4461,7 +4393,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ConsoleFreq": []},
             )
 
@@ -4478,7 +4410,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"BlockAverageFreq": []},
             )
 
@@ -4495,7 +4427,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"HistogramFreq": []},
             )
 
@@ -4512,7 +4444,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DistName": []},
             )
 
@@ -4529,7 +4461,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"HistName": []},
             )
 
@@ -4546,7 +4478,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RunNumber": []},
             )
 
@@ -4563,7 +4495,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RunLetter": []},
             )
 
@@ -4580,7 +4512,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"SampleFreq": []},
             )
 
@@ -4597,7 +4529,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": []},
             )
 
@@ -4614,7 +4546,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutPressure": []},
             )
 
@@ -4631,7 +4563,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutMolNumber": []},
             )
 
@@ -4648,7 +4580,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutDensity": []},
             )
 
@@ -4665,7 +4597,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutVolume": []},
             )
 
@@ -4682,7 +4614,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutSurfaceTension": []},
             )
 
@@ -4699,7 +4631,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [],
                     "MoleculeType": ["ETH", 1],
@@ -4722,7 +4654,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", []],
@@ -4745,7 +4677,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [["ETH"], 1],
@@ -4768,7 +4700,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"ETH": "1"}, 1],
@@ -4791,7 +4723,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4814,7 +4746,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4837,7 +4769,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4859,7 +4791,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"FreeEnergyCalc": [True, 10000]},
             )
 
@@ -4876,7 +4808,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScaleCoulomb": []},
             )
 
@@ -4893,7 +4825,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScalePower": []},
             )
 
@@ -4910,7 +4842,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScaleAlpha": []},
             )
 
@@ -4927,7 +4859,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MinSigma": []},
             )
 
@@ -4944,7 +4876,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": []},
             )
 
@@ -4961,7 +4893,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC_DataInput": []},
             )
 
@@ -4978,7 +4910,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DisFreq": []},
             )
 
@@ -4995,7 +4927,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DisFreq": []},
             )
 
@@ -5012,7 +4944,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraSwapFreq": []},
             )
 
@@ -5029,7 +4961,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraSwapFreq": []},
             )
 
@@ -5046,7 +4978,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RegrowthFreq": []},
             )
 
@@ -5063,7 +4995,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CrankShaftFreq": []},
             )
 
@@ -5080,7 +5012,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"VolFreq": []},
             )
 
@@ -5097,7 +5029,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MultiParticleFreq": []},
             )
 
@@ -5114,7 +5046,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-1Freq": []},
             )
 
@@ -5131,7 +5063,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-1Freq": []},
             )
 
@@ -5148,7 +5080,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-2Freq": []},
             )
 
@@ -5165,7 +5097,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-2Freq": []},
             )
 
@@ -5182,7 +5114,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-3Freq": []},
             )
 
@@ -5199,7 +5131,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-3Freq": []},
             )
 
@@ -5218,7 +5150,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"XXXXXX": []},
             )
 
@@ -5244,7 +5176,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, 10000]},
             )
         except:
@@ -5259,7 +5191,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [False, 10000]},
             )
         except:
@@ -5280,7 +5212,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [1, 10000]},
             )
 
@@ -5291,7 +5223,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, 10000]},
             )
         except:
@@ -5306,7 +5238,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [False, 10000]},
             )
         except:
@@ -5327,7 +5259,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [1, 10000]},
             )
 
@@ -5344,7 +5276,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": ["", 10000]},
             )
 
@@ -5361,7 +5293,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [["x"], 10000]},
             )
 
@@ -5378,7 +5310,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [{"s": 1}, 10000]},
             )
 
@@ -5395,7 +5327,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, 1.0]},
             )
 
@@ -5412,7 +5344,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, "x"]},
             )
 
@@ -5429,7 +5361,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, ["x"]]},
             )
 
@@ -5446,7 +5378,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, {"s": 1}]},
             )
 
@@ -5463,7 +5395,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [1, True]},
             )
 
@@ -5489,7 +5421,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, True]},
             )
         except:
@@ -5504,7 +5436,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [False, True]},
             )
         except:
@@ -5519,7 +5451,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [False, False]},
             )
         except:
@@ -5534,7 +5466,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, True]},
             )
         except:
@@ -5549,7 +5481,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [False, True]},
             )
         except:
@@ -5564,7 +5496,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [False, False]},
             )
         except:
@@ -5585,7 +5517,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [1, True]},
             )
 
@@ -5602,7 +5534,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": ["", True]},
             )
 
@@ -5619,7 +5551,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [["x"], True]},
             )
 
@@ -5636,7 +5568,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [{"s": 1}, True]},
             )
 
@@ -5653,7 +5585,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, 1.0]},
             )
 
@@ -5670,7 +5602,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, "x"]},
             )
 
@@ -5687,7 +5619,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, ["x"]]},
             )
 
@@ -5704,7 +5636,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, {"s": 1}]},
             )
 
@@ -5730,7 +5662,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -5752,7 +5684,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5773,7 +5705,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -5795,7 +5727,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5821,7 +5753,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
@@ -5842,7 +5774,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "InitialState": 1,
@@ -5863,7 +5795,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5884,7 +5816,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5900,7 +5832,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5927,7 +5859,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [1, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5950,7 +5882,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": ["1", 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5973,7 +5905,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [["1"], 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5996,7 +5928,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [{"a": "1"}, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6013,7 +5945,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6040,7 +5972,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 1.0],
                     "MoleculeType": ["ETO", 1],
@@ -6063,7 +5995,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, "1"],
                     "MoleculeType": ["ETO", 1],
@@ -6086,7 +6018,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, ["1"]],
                     "MoleculeType": ["ETO", 1],
@@ -6109,7 +6041,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, {"a": "1"}],
                     "MoleculeType": ["ETO", 1],
@@ -6132,7 +6064,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000, "s"],
                     "MoleculeType": ["ETO", 1],
@@ -6156,7 +6088,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [1, 1],
@@ -6179,7 +6111,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [[1], 1],
@@ -6202,7 +6134,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"a": "1"}, 1],
@@ -6225,7 +6157,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", "1"],
@@ -6248,7 +6180,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", ["1"]],
@@ -6271,7 +6203,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", {"a": "1"}],
@@ -6294,7 +6226,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETOa", 1],
@@ -6318,7 +6250,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6341,7 +6273,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6364,7 +6296,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6387,7 +6319,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6411,7 +6343,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6434,7 +6366,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6457,7 +6389,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6481,7 +6413,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6504,7 +6436,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6527,7 +6459,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6548,7 +6480,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6568,7 +6500,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6622,7 +6554,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_1": "s"},
             )
 
@@ -6639,7 +6571,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"FixVolBox0": "s"},
             )
 
@@ -6657,7 +6589,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-1Freq": 1},
             )
 
@@ -6668,7 +6600,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": [1.0, 1.0, 1.0]},
             )
         except:
@@ -6683,7 +6615,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": [1, 1, 1]},
             )
         except:
@@ -6704,7 +6636,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": ["s", 1.0, 1.0]},
             )
 
@@ -6721,7 +6653,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": [1.0, [1.0], 1.0]},
             )
 
@@ -6738,7 +6670,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "ExchangeVolumeDim": [1.0, 1.0, {"a": 1.0}]
                 },
@@ -6752,7 +6684,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6785,7 +6717,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "O1"]]
@@ -6818,7 +6750,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C2", "C1"], "ETO", ["O1", "C1"]]
@@ -6857,7 +6789,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "O1"], "ETO", ["C1", "C2"]]
@@ -6892,7 +6824,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["O1", "C1"], "ETO", ["C2", "C1"]]
@@ -6927,7 +6859,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1.0, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6962,7 +6894,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         ["s", "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6997,7 +6929,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [[1], "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7032,7 +6964,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [{"a": "1"}, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7067,7 +6999,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETHa", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7102,7 +7034,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, 1, ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7137,7 +7069,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, [1], ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7172,7 +7104,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", [1, "C2"], "ETO", ["C1", "C2"]]
@@ -7207,7 +7139,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", [[1], "C2"], "ETO", ["C1", "C2"]]
@@ -7242,7 +7174,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", 1], "ETO", ["C1", "C2"]]
@@ -7277,7 +7209,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", [1]], "ETO", ["C1", "C2"]]
@@ -7312,7 +7244,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], 1, ["C1", "C2"]]
@@ -7347,7 +7279,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], [1], ["C1", "C2"]]
@@ -7382,7 +7314,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", [1, "C2"]]
@@ -7417,7 +7349,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", [[1], "C2"]]
@@ -7452,7 +7384,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", 1]]
@@ -7487,7 +7419,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", [1]]]
@@ -7523,7 +7455,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "IntraMEMC-1Freq": 0.20,
                     "MEMC-1Freq": 0.20,
@@ -7548,7 +7480,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ChemPot": "s"},
             )
 
@@ -7565,7 +7497,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Fugacity": "s"},
             )
 
@@ -7577,7 +7509,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7620,7 +7552,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7649,7 +7581,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7691,7 +7623,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7719,7 +7651,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7762,7 +7694,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7791,7 +7723,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7834,7 +7766,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7863,7 +7795,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7906,7 +7838,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7936,7 +7868,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7969,7 +7901,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8002,7 +7934,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8043,7 +7975,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8066,7 +7998,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8089,7 +8021,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8111,7 +8043,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8134,7 +8066,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "Fugacity": {"ETH": 0, "XXX": 1.0},
@@ -8154,7 +8086,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "Fugacity": {"XXX": 0, "ETO": 1.0},
@@ -8174,7 +8106,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {1: -4000, "ETO": -8000},
@@ -8194,7 +8126,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"XXX": -4000, "ETO": -8000},
@@ -8214,7 +8146,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": -4000, "XXX": -8000},
@@ -8234,7 +8166,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": "40", "ETO": -8000},
@@ -8254,7 +8186,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": ["40"], "ETO": -8000},
@@ -8274,7 +8206,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8308,7 +8240,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8345,7 +8277,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8380,7 +8312,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8415,7 +8347,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8450,7 +8382,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8485,7 +8417,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8520,7 +8452,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8550,7 +8482,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8584,7 +8516,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8618,7 +8550,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8653,7 +8585,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]],
@@ -8728,7 +8660,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
@@ -8745,7 +8677,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the GCMC with only 1 box in the Charmm object
@@ -8762,7 +8694,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the NVT with 2 boxes in the Charmm object
@@ -8779,7 +8711,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the NPT with 2 boxes in the Charmm object
@@ -8795,7 +8727,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
     def test_save_non_othoganol_writer(self):
@@ -8832,7 +8764,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             100000,
             300,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
         )
 
         with open("test_save_non_othoganol_writer.conf", "r") as fp:
@@ -8966,7 +8898,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
@@ -8983,7 +8915,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
     def test_adjustment_steps_and_ff_psf_pdb_file_directory(self, ethane_gomc):
@@ -9013,7 +8945,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 ff_psf_pdb_file_directory=["x"],
             )
 
@@ -9023,7 +8955,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             100000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
             ff_psf_pdb_file_directory=changed_file_path,
             input_variables_dict={
                 "PressureCalc": [True, 1],
@@ -9205,7 +9137,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
     def test_check_required_gomc_files_pdb_exist_GEMC_NPT(self, ethane_gomc):
@@ -9238,7 +9170,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
     def test_check_required_gomc_files_psf_exist_GEMC_NPT(self, ethane_gomc):
@@ -9272,7 +9204,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
     def test_check_required_gomc_files_pdb_exist_NVT(self, ethane_gomc):
@@ -9305,7 +9237,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
     def test_check_required_gomc_files_psf_exist_NVT(self, ethane_gomc):
@@ -9339,10 +9271,73 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
-    def test_gomc_restarting_dcd_and_binary_files_NVT(self, ethane_gomc):
+    def test_check_restart_bool(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        restart_input = "XXXXX"
+        with pytest.raises(
+            TypeError,
+            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
+                  ''.format("Restart", type(restart_input)),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_checkpoint_error",
+                "NVT",
+                100,
+                300,
+                check_input_files_exist=False,
+                Restart=restart_input
+            )
+
+        restart_checkpoint_input = "XXXXX"
+        with pytest.raises(
+            TypeError,
+            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
+                  ''.format("RestartCheckpoint", type(restart_checkpoint_input)),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_checkpoint_error",
+                "NVT",
+                100,
+                300,
+                check_input_files_exist=False,
+                RestartCheckpoint="XXXXX",
+            )
+
+        check_input_files_exist_input = "XXXXX"
+        with pytest.raises(
+            TypeError,
+            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
+                  ''.format("check_input_files_exist", type(check_input_files_exist_input)),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                'check_input_files_exist_error',
+                "NVT",
+                100,
+                300,
+                check_input_files_exist="XXXXX",
+            )
+
+
+    def test_restarting_dcd_and_binary_files_NVT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
             compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
         )
@@ -9363,25 +9358,24 @@ class TestGOMCControlFileWriter(BaseTest):
             "NVT",
             1000,
             300,
-            override_check_input_files_exist=True,
-            ff_psf_pdb_file_directory=None,
-            override_ff_directory_filename="../NVT_toluene_FF.inp",
-            override_box_0_pdb_directory_filename="../test_files/NVT_toluene_box_0.pdb",
-            override_box_0_psf_directory_filename="../test_files/NVT_toluene_box_0.psf",
-            box_0_restart_coor_directory_filename="../test_files/NVT_toluene_box_0.coor",
-            box_0_restart_xsc_directory_filename="../test_files/NVT_toluene_box_0.xsc",
-            box_0_restart_velocity_directory_filename="../test_files/NVT_toluene_box_0.vel",
-            input_variables_dict={"Restart": True,
-                                  "VDWGeometricSigma": True,
+            Restart=True,
+            check_input_files_exist=False,
+            Coordinates_box_0="../test_files/NVT_toluene_box_0.pdb",
+            Structure_box_0="../test_files/NVT_toluene_box_0.psf",
+            binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+            extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+            binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
+            input_variables_dict={"VDWGeometricSigma": True,
                                   "DCDFreq": [True, 1000],
                                   }
         )
 
         with open("test_restarting_dcd_and_binary_files_NVT.conf", "r") as fp:
             variables_read_dict = {
-                "Restart": False,
                 "VDWGeometricSigma": False,
                 "DCDFreq": False,
+                "Coordinates_box_0": False,
+                "Structure_box_0": False,
                 "binCoordinates_box_0": False,
                 "extendedSystem_box_0": False,
                 "binVelocities_box_0": False,
@@ -9403,6 +9397,20 @@ class TestGOMCControlFileWriter(BaseTest):
                     split_line = line.split()
                     assert split_line[1] == "True"
                     assert split_line[2] == "1000"
+
+
+                elif line.startswith("Coordinates 0"):
+                    variables_read_dict["Coordinates_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "../test_files/NVT_toluene_box_0.pdb"
+
+
+                elif line.startswith("Structure 0"):
+                    variables_read_dict["Structure_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "../test_files/NVT_toluene_box_0.psf"
 
                 elif line.startswith("binCoordinates   0 "):
                     variables_read_dict["binCoordinates_box_0"] = True
@@ -9426,7 +9434,266 @@ class TestGOMCControlFileWriter(BaseTest):
             "Restart": True,
             "VDWGeometricSigma": True,
             "DCDFreq": True,
+            "Coordinates_box_0": True,
+            "Structure_box_0": True,
             "binCoordinates_box_0": True,
             "extendedSystem_box_0": True,
             "binVelocities_box_0": True,
         }
+
+    def test_failures_restarting_dcd_and_binary_files_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+        with pytest.raises(
+            ValueError,
+            match='ERROR: To restart a simulation with the binary files both the coor '
+                  'and xsc files for box 0 must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                extendedSystem_box_0=None,
+                binVelocities_box_0=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match='ERROR: To restart a simulation with the binary files both the coor and '
+                      'xsc files for box 0 must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0=None,
+                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_0=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match='ERROR: To restart a "NVT", "NPT" simulation with the ' 
+                      'velocity binary files, the velocity files for box 0 ' 
+                      'must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0=None,
+                extendedSystem_box_0=None,
+                binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+    def test_failures_restarting_dcd_and_binary_files_GEMC_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=test_box_ethane_gomc,
+            filename_box_1="ethane_box_1",
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+        charmm.write_inp()
+        charmm.write_pdb()
+        charmm.write_psf()
+
+        with pytest.raises(
+            ValueError,
+            match='ERROR: To restart a simulation with the binary files both the coor and ' \
+                  'xsc files for box 0 and box 1 must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_0=None,
+                binCoordinates_box_1="../test_files/NVT_toluene_box_1.coor",
+                extendedSystem_box_1=None,
+                binVelocities_box_1=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match='ERROR: To restart a simulation with the binary files both the coor and ' \
+                      'xsc files for box 0 and box 1 must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_0=None,
+                binCoordinates_box_1=None,
+                extendedSystem_box_1="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_1=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match='ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the ' \
+                      'velocity binary files, both the velocity files for box 0 and box 1 ' \
+                      'must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
+                binCoordinates_box_1="../test_files/NVT_toluene_box_1.coor",
+                extendedSystem_box_1="../test_files/NVT_toluene_box_1.xsc",
+                binVelocities_box_1=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        test_box_0_pdb = "XXXX"
+        with pytest.raises(
+                TypeError,
+                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                      r''.format('Coordinates_box_0',
+                                 "\['.pdb'\]",
+                                 os.path.splitext(test_box_0_pdb)[-1],
+                                 )
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                check_input_files_exist=True,
+                Coordinates_box_0=test_box_0_pdb,
+                Structure_box_0="ethane_box_0.psf",
+                Coordinates_box_1="ethane_box_0.pdb",
+                Structure_box_1="ethane_box_1.psf",
+            )
+
+        test_box_1_pdb = "XXXX"
+        with pytest.raises(
+                TypeError,
+                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                      r''.format('Coordinates_box_1',
+                                 "\['.pdb'\]",
+                                 os.path.splitext(test_box_1_pdb)[-1],
+                                 )
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                check_input_files_exist=True,
+                Coordinates_box_0="ethane_box_0.pdb",
+                Structure_box_0="ethane_box_0.psf",
+                Coordinates_box_1=test_box_1_pdb,
+                Structure_box_1="ethane_box_1.psf",
+            )
+
+        test_box_0_psf = "XXXX"
+        with pytest.raises(
+                TypeError,
+                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                      r''.format('Structure_box_0',
+                                 "\['.psf'\]",
+                                 os.path.splitext(test_box_0_psf)[-1],
+                                 )
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                check_input_files_exist=True,
+                Coordinates_box_0="ethane_box_0.pdb",
+                Structure_box_0=test_box_0_psf,
+                Coordinates_box_1="ethane_box_1.pdb",
+                Structure_box_1="ethane_box_1.psf",
+            )
+
+        test_box_1_psf = "XXXX"
+        with pytest.raises(
+                TypeError,
+                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                      r''.format('Structure_box_1',
+                                 "\['.psf'\]",
+                                 os.path.splitext(test_box_1_psf)[-1],
+                                 )
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                check_input_files_exist=True,
+                Coordinates_box_0="ethane_box_0.pdb",
+                Structure_box_0="ethane_box_0.psf",
+                Coordinates_box_1="ethane_box_1.pdb",
+                Structure_box_1=test_box_1_psf,
+            )

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -2,6 +2,7 @@ import pytest
 
 import mbuild as mb
 import mbuild.formats.gomc_conf_writer as gomc_control
+import os
 from mbuild.formats.charmm_writer import Charmm
 from mbuild.lattice import load_cif
 from mbuild.tests.base_test import BaseTest
@@ -20,42 +21,56 @@ class TestGOMCControlFileWriter(BaseTest):
 
     def test_get_required_data(self):
         value = gomc_control._get_required_data(description=False)
-        assert value == [
+        assert value.sort() == [
             "charmm_object",
             "ensemble_type",
             "RunSteps",
             "Temperature",
             "ff_psf_pdb_file_directory",
-            "override_check_input_files_exist",
-            "override_ff_directory_filename",
-            "override_box_0_pdb_directory_filename",
-            "override_box_0_psf_directory_filename",
-            "override_box_1_pdb_directory_filename",
-            "override_box_1_psf_directory_filename",
-        ]
+            "check_input_files_exist",
+            "Restart",
+            "RestartCheckpoint",
+            "Parameters",
+            "Coordinates_box_0",
+            "override_psf_box_0",
+            "Coordinates_box_1",
+            "Structure_box_1",
+            "binCoordinates_box_0",
+            "extendedSystem_box_0",
+            "binVelocities_box_0",
+            "binCoordinates_box_1",
+            "extendedSystem_box_1",
+            "binVelocities_box_1",
+        ].sort()
 
         value = gomc_control._get_required_data(description=True)
-        assert gomc_control.dict_keys_to_list(value) == [
+        assert gomc_control.dict_keys_to_list(value).sort() == [
             "charmm_object",
             "ensemble_type",
             "RunSteps",
             "Temperature",
             "ff_psf_pdb_file_directory",
-            "override_check_input_files_exist",
-            "override_ff_directory_filename",
-            "override_box_0_pdb_directory_filename",
-            "override_box_0_psf_directory_filename",
-            "override_box_1_pdb_directory_filename",
-            "override_box_1_psf_directory_filename",
-        ]
+            "Restart",
+            "RestartCheckpoint"
+            "check_input_files_exist",
+            "Parameters",
+            "Coordinate_box_0",
+            "Structure_box_0",
+            "Coordinate_box_1",
+            "Structure_box_1",
+            "binCoordinates_box_0",
+            "extendedSystem_box_0",
+            "binVelocities_box_0",
+            "binCoordinates_box_1",
+            "extendedSystem_box_1",
+            "binVelocities_box_1",
+        ].sort()
 
     def test_get_all_possible_input_variable(self):
         value = gomc_control._get_all_possible_input_variables(
             description=False
         )
-        assert value == [
-            "Restart",
-            "RestartCheckpoint",
+        assert value.sort() == [
             "PRNG",
             "ParaTypeCHARMM",
             "ParaTypeMie",
@@ -88,6 +103,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "CBMC_Dih",
             "OutputName",
             "CoordinatesFreq",
+            "DCDFreq",
             "RestartFreq",
             "CheckpointFreq",
             "ConsoleFreq",
@@ -129,12 +145,10 @@ class TestGOMCControlFileWriter(BaseTest):
             "MEMC-3Freq",
             "ExchangeVolumeDim",
             "MEMC_DataInput",
-        ]
+        ].sort()
 
         value = gomc_control._get_all_possible_input_variables(description=True)
-        assert gomc_control.dict_keys_to_list(value) == [
-            "Restart",
-            "RestartCheckpoint",
+        assert gomc_control.dict_keys_to_list(value).sort() == [
             "PRNG",
             "ParaTypeCHARMM",
             "ParaTypeMie",
@@ -167,6 +181,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "CBMC_Dih",
             "OutputName",
             "CoordinatesFreq",
+            "DCDFreq",
             "RestartFreq",
             "CheckpointFreq",
             "ConsoleFreq",
@@ -208,13 +223,11 @@ class TestGOMCControlFileWriter(BaseTest):
             "MEMC-3Freq",
             "ExchangeVolumeDim",
             "MEMC_DataInput",
-        ]
+        ].sort()
 
     def test_get_default_variables_dict(self):
         value = gomc_control._get_default_variables_dict()
-        assert gomc_control.dict_keys_to_list(value) == [
-            "Restart",
-            "RestartCheckpoint",
+        assert gomc_control.dict_keys_to_list(value).sort() == [
             "PRNG",
             "ParaTypeCHARMM",
             "ParaTypeMie",
@@ -248,6 +261,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "CBMC_Dih",
             "OutputName",
             "CoordinatesFreq",
+            "DCDFreq",
             "RestartFreq",
             "CheckpointFreq",
             "ConsoleFreq",
@@ -289,7 +303,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "MEMC-2Freq",
             "IntraMEMC-3Freq",
             "MEMC-3Freq",
-        ]
+        ].sort()
 
     def test_print_ensemble_info(self):
 
@@ -378,7 +392,8 @@ class TestGOMCControlFileWriter(BaseTest):
             "NVT",
             10,
             300,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
+            Restart=False
         )
 
         with open("test_save_basic_NVT.conf", "r") as fp:
@@ -860,7 +875,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "NPT",
             1000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
         )
 
         with open("test_save_basic_NPT.conf", "r") as fp:
@@ -1133,7 +1148,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GCMC",
             100000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
             input_variables_dict={
                 "ChemPot": {"ETH": -4000},
                 "VDWGeometricSigma": True,
@@ -1473,7 +1488,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             1000000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
         )
 
         with open("test_save_basic_GEMC_NVT.conf", "r") as fp:
@@ -1604,7 +1619,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NPT",
             1000000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
             input_variables_dict={
                 "Pressure": 10,
                 "useConstantArea": True,
@@ -1778,9 +1793,9 @@ class TestGOMCControlFileWriter(BaseTest):
             "NVT",
             100000,
             300,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
+            Restart=False,
             input_variables_dict={
-                "Restart": True,
                 "PRNG": 123,
                 "ParaTypeCHARMM": True,
                 "ParaTypeMARTINI": False,
@@ -1917,7 +1932,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 if line.startswith("Restart "):
                     variables_read_dict["Restart"] = True
                     split_line = line.split()
-                    assert split_line[1] == "True"
+                    assert split_line[1] == "False"
 
                 elif line.startswith("PRNG "):
                     variables_read_dict["PRNG"] = True
@@ -2413,7 +2428,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10],
                     "MoleculeType": ["ETH", 1],
@@ -2433,7 +2448,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10],
                     "MoleculeType": ["ETH", 1],
@@ -2462,40 +2477,6 @@ class TestGOMCControlFileWriter(BaseTest):
             match=r"ERROR: The following input variables have "
             r"bad values \(check spelling and for empty spaces in the keys or that "
             r"the values are in the correct form with the acceptable values\)"
-            r": \['Restart'\]",
-        ):
-            gomc_control.write_gomc_control_file(
-                charmm,
-                "test_save_NVT_bad_variables_part_1.conf",
-                "NVT",
-                10,
-                300,
-                override_check_input_files_exist=True,
-                input_variables_dict={"Restart": "s"},
-            )
-
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: The following input variables have "
-            r"bad values \(check spelling and for empty spaces in the keys or that "
-            r"the values are in the correct form with the acceptable values\)"
-            r": \['RestartCheckpoint'\]",
-        ):
-            gomc_control.write_gomc_control_file(
-                charmm,
-                "test_save_NVT_bad_variables_part_1.conf",
-                "NVT",
-                10,
-                300,
-                override_check_input_files_exist=True,
-                input_variables_dict={"RestartCheckpoint": "s"},
-            )
-
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: The following input variables have "
-            r"bad values \(check spelling and for empty spaces in the keys or that "
-            r"the values are in the correct form with the acceptable values\)"
             r": \['PRNG'\]",
         ):
             gomc_control.write_gomc_control_file(
@@ -2504,7 +2485,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PRNG": [1]},
             )
 
@@ -2521,7 +2502,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeCHARMM": "s"},
             )
 
@@ -2538,7 +2519,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeMie": "s"},
             )
 
@@ -2555,7 +2536,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeMARTINI": "s"},
             )
 
@@ -2572,7 +2553,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_0": "s"},
             )
 
@@ -2591,7 +2572,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_1": "s"},
             )
 
@@ -2608,7 +2589,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Pressure": "s"},
             )
 
@@ -2625,7 +2606,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Rcut": "s"},
             )
 
@@ -2642,7 +2623,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutLow": "s"},
             )
 
@@ -2659,7 +2640,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"LRC": "s"},
             )
 
@@ -2676,7 +2657,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Exclude": "s"},
             )
 
@@ -2693,7 +2674,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Potential": "s"},
             )
 
@@ -2710,7 +2691,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Rswitch": "s"},
             )
 
@@ -2727,7 +2708,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ElectroStatic": "s"},
             )
 
@@ -2744,7 +2725,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Ewald": "s"},
             )
 
@@ -2761,7 +2742,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CachedFourier": "s"},
             )
 
@@ -2778,7 +2759,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Tolerance": "s"},
             )
 
@@ -2795,7 +2776,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Dielectric": "s"},
             )
 
@@ -2812,7 +2793,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": "s"},
             )
 
@@ -2829,7 +2810,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"EqSteps": "s"},
             )
 
@@ -2846,7 +2827,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"EqSteps": "s"},
             )
 
@@ -2863,7 +2844,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"useConstantArea": "s"},
             )
 
@@ -2882,7 +2863,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ChemPot": "s"},
             )
 
@@ -2901,7 +2882,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Fugacity": "s"},
             )
 
@@ -2918,7 +2899,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_First": "s"},
             )
 
@@ -2935,7 +2916,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Nth": "s"},
             )
 
@@ -2952,7 +2933,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Ang": "s"},
             )
 
@@ -2969,7 +2950,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Dih": "s"},
             )
 
@@ -2986,7 +2967,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutputName": 1},
             )
 
@@ -3003,7 +2984,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CoordinatesFreq": "s"},
             )
 
@@ -3020,7 +3001,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RestartFreq": "s"},
             )
 
@@ -3037,7 +3018,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CheckpointFreq": "s"},
             )
 
@@ -3054,7 +3035,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ConsoleFreq": "s"},
             )
 
@@ -3071,7 +3052,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"BlockAverageFreq": "s"},
             )
 
@@ -3088,7 +3069,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"HistogramFreq": "s"},
             )
 
@@ -3105,7 +3086,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DistName": 1},
             )
 
@@ -3122,7 +3103,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"HistName": 1},
             )
 
@@ -3139,7 +3120,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RunNumber": "s"},
             )
 
@@ -3156,7 +3137,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RunLetter": 1},
             )
 
@@ -3173,7 +3154,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"SampleFreq": "s"},
             )
 
@@ -3190,7 +3171,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": "s"},
             )
 
@@ -3207,7 +3188,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutPressure": "s"},
             )
 
@@ -3224,7 +3205,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutMolNumber": "s"},
             )
 
@@ -3241,7 +3222,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutDensity": "s"},
             )
 
@@ -3258,7 +3239,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutVolume": "s"},
             )
 
@@ -3275,7 +3256,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutSurfaceTension": "s"},
             )
 
@@ -3292,7 +3273,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": "s",
                     "MoleculeType": ["ETH", 1],
@@ -3315,7 +3296,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", "s"],
@@ -3338,7 +3319,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [["ETH"], 1],
@@ -3361,7 +3342,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"ETH": "1"}, 1],
@@ -3384,7 +3365,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3407,7 +3388,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3430,7 +3411,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3452,7 +3433,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"FreeEnergyCalc": [True, 10000]},
             )
 
@@ -3469,7 +3450,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScaleCoulomb": "s"},
             )
 
@@ -3486,7 +3467,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScalePower": "s"},
             )
 
@@ -3503,7 +3484,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScaleAlpha": "s"},
             )
 
@@ -3520,7 +3501,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MinSigma": "s"},
             )
 
@@ -3537,7 +3518,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": "s"},
             )
 
@@ -3554,7 +3535,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC_DataInput": "s"},
             )
 
@@ -3571,7 +3552,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DisFreq": "s"},
             )
 
@@ -3588,7 +3569,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RotFreq": "s"},
             )
 
@@ -3605,7 +3586,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraSwapFreq": "s"},
             )
 
@@ -3622,7 +3603,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"SwapFreq": "s"},
             )
 
@@ -3639,7 +3620,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RegrowthFreq": "s"},
             )
 
@@ -3656,7 +3637,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CrankShaftFreq": "s"},
             )
 
@@ -3673,7 +3654,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"VolFreq": "s"},
             )
 
@@ -3690,7 +3671,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MultiParticleFreq": "s"},
             )
 
@@ -3707,7 +3688,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-1Freq": "s"},
             )
 
@@ -3724,7 +3705,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-1Freq": "s"},
             )
 
@@ -3741,7 +3722,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-2Freq": "s"},
             )
 
@@ -3758,7 +3739,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-2Freq": "s"},
             )
 
@@ -3775,7 +3756,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-3Freq": "s"},
             )
 
@@ -3792,7 +3773,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-3Freq": "s"},
             )
 
@@ -3811,7 +3792,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"XXXXXX": "s"},
             )
 
@@ -3835,40 +3816,6 @@ class TestGOMCControlFileWriter(BaseTest):
             match=r"ERROR: The following input variables have "
             r"bad values \(check spelling and for empty spaces in the keys or that "
             r"the values are in the correct form with the acceptable values\)"
-            r": \['Restart'\]",
-        ):
-            gomc_control.write_gomc_control_file(
-                charmm,
-                "test_save_NVT_bad_variables_part_2.conf",
-                "NVT",
-                10,
-                300,
-                override_check_input_files_exist=True,
-                input_variables_dict={"Restart": []},
-            )
-
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: The following input variables have "
-            r"bad values \(check spelling and for empty spaces in the keys or that "
-            r"the values are in the correct form with the acceptable values\)"
-            r": \['RestartCheckpoint'\]",
-        ):
-            gomc_control.write_gomc_control_file(
-                charmm,
-                "test_save_NVT_bad_variables_part_2.conf",
-                "NVT",
-                10,
-                300,
-                override_check_input_files_exist=True,
-                input_variables_dict={"RestartCheckpoint": []},
-            )
-
-        with pytest.raises(
-            ValueError,
-            match=r"ERROR: The following input variables have "
-            r"bad values \(check spelling and for empty spaces in the keys or that "
-            r"the values are in the correct form with the acceptable values\)"
             r": \['PRNG'\]",
         ):
             gomc_control.write_gomc_control_file(
@@ -3877,7 +3824,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PRNG": []},
             )
 
@@ -3894,7 +3841,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeCHARMM": []},
             )
 
@@ -3911,7 +3858,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeMie": []},
             )
 
@@ -3928,7 +3875,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ParaTypeMARTINI": []},
             )
 
@@ -3945,7 +3892,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_0": []},
             )
 
@@ -3964,7 +3911,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_1": []},
             )
 
@@ -3981,7 +3928,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Pressure": []},
             )
 
@@ -3998,7 +3945,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Rcut": []},
             )
 
@@ -4015,7 +3962,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutLow": []},
             )
 
@@ -4032,7 +3979,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"LRC": []},
             )
 
@@ -4049,7 +3996,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Exclude": []},
             )
 
@@ -4066,7 +4013,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Potential": []},
             )
 
@@ -4083,7 +4030,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Rswitch": []},
             )
 
@@ -4100,7 +4047,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ElectroStatic": []},
             )
 
@@ -4117,7 +4064,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Ewald": []},
             )
 
@@ -4134,7 +4081,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CachedFourier": []},
             )
 
@@ -4151,7 +4098,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Tolerance": []},
             )
 
@@ -4168,7 +4115,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Dielectric": []},
             )
 
@@ -4185,7 +4132,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": []},
             )
 
@@ -4202,7 +4149,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"EqSteps": []},
             )
 
@@ -4219,7 +4166,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"AdjSteps": []},
             )
 
@@ -4236,7 +4183,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"useConstantArea": []},
             )
 
@@ -4255,7 +4202,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"FixVolBox0": []},
             )
 
@@ -4274,7 +4221,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ChemPot": []},
             )
 
@@ -4293,7 +4240,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Fugacity": []},
             )
 
@@ -4310,7 +4257,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_First": []},
             )
 
@@ -4327,7 +4274,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Nth": []},
             )
 
@@ -4344,7 +4291,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Ang": []},
             )
 
@@ -4361,7 +4308,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CBMC_Dih": []},
             )
 
@@ -4378,7 +4325,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutputName": []},
             )
 
@@ -4395,7 +4342,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CoordinatesFreq": []},
             )
 
@@ -4412,7 +4359,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RestartFreq": []},
             )
 
@@ -4429,7 +4376,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CheckpointFreq": []},
             )
 
@@ -4446,7 +4393,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ConsoleFreq": []},
             )
 
@@ -4463,7 +4410,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"BlockAverageFreq": []},
             )
 
@@ -4480,7 +4427,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"HistogramFreq": []},
             )
 
@@ -4497,7 +4444,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DistName": []},
             )
 
@@ -4514,7 +4461,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"HistName": []},
             )
 
@@ -4531,7 +4478,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RunNumber": []},
             )
 
@@ -4548,7 +4495,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RunLetter": []},
             )
 
@@ -4565,7 +4512,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"SampleFreq": []},
             )
 
@@ -4582,7 +4529,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": []},
             )
 
@@ -4599,7 +4546,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutPressure": []},
             )
 
@@ -4616,7 +4563,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutMolNumber": []},
             )
 
@@ -4633,7 +4580,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutDensity": []},
             )
 
@@ -4650,7 +4597,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutVolume": []},
             )
 
@@ -4667,7 +4614,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutSurfaceTension": []},
             )
 
@@ -4684,7 +4631,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [],
                     "MoleculeType": ["ETH", 1],
@@ -4707,7 +4654,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", []],
@@ -4730,7 +4677,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [["ETH"], 1],
@@ -4753,7 +4700,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"ETH": "1"}, 1],
@@ -4776,7 +4723,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4799,7 +4746,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4822,7 +4769,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4844,7 +4791,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"FreeEnergyCalc": [True, 10000]},
             )
 
@@ -4861,7 +4808,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScaleCoulomb": []},
             )
 
@@ -4878,7 +4825,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScalePower": []},
             )
 
@@ -4895,7 +4842,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ScaleAlpha": []},
             )
 
@@ -4912,7 +4859,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MinSigma": []},
             )
 
@@ -4929,7 +4876,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": []},
             )
 
@@ -4946,7 +4893,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC_DataInput": []},
             )
 
@@ -4963,7 +4910,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DisFreq": []},
             )
 
@@ -4980,7 +4927,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"DisFreq": []},
             )
 
@@ -4997,7 +4944,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraSwapFreq": []},
             )
 
@@ -5014,7 +4961,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraSwapFreq": []},
             )
 
@@ -5031,7 +4978,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RegrowthFreq": []},
             )
 
@@ -5048,7 +4995,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"CrankShaftFreq": []},
             )
 
@@ -5065,7 +5012,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"VolFreq": []},
             )
 
@@ -5082,7 +5029,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MultiParticleFreq": []},
             )
 
@@ -5099,7 +5046,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-1Freq": []},
             )
 
@@ -5116,7 +5063,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-1Freq": []},
             )
 
@@ -5133,7 +5080,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-2Freq": []},
             )
 
@@ -5150,7 +5097,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-2Freq": []},
             )
 
@@ -5167,7 +5114,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"IntraMEMC-3Freq": []},
             )
 
@@ -5184,7 +5131,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-3Freq": []},
             )
 
@@ -5203,7 +5150,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"XXXXXX": []},
             )
 
@@ -5229,7 +5176,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, 10000]},
             )
         except:
@@ -5244,7 +5191,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [False, 10000]},
             )
         except:
@@ -5265,7 +5212,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [1, 10000]},
             )
 
@@ -5276,7 +5223,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, 10000]},
             )
         except:
@@ -5291,7 +5238,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [False, 10000]},
             )
         except:
@@ -5312,7 +5259,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [1, 10000]},
             )
 
@@ -5329,7 +5276,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": ["", 10000]},
             )
 
@@ -5346,7 +5293,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [["x"], 10000]},
             )
 
@@ -5363,7 +5310,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [{"s": 1}, 10000]},
             )
 
@@ -5380,7 +5327,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, 1.0]},
             )
 
@@ -5397,7 +5344,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, "x"]},
             )
 
@@ -5414,7 +5361,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, ["x"]]},
             )
 
@@ -5431,7 +5378,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [True, {"s": 1}]},
             )
 
@@ -5448,7 +5395,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"PressureCalc": [1, True]},
             )
 
@@ -5474,7 +5421,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, True]},
             )
         except:
@@ -5489,7 +5436,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [False, True]},
             )
         except:
@@ -5504,7 +5451,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [False, False]},
             )
         except:
@@ -5519,7 +5466,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, True]},
             )
         except:
@@ -5534,7 +5481,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [False, True]},
             )
         except:
@@ -5549,7 +5496,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [False, False]},
             )
         except:
@@ -5570,7 +5517,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [1, True]},
             )
 
@@ -5587,7 +5534,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": ["", True]},
             )
 
@@ -5604,7 +5551,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [["x"], True]},
             )
 
@@ -5621,7 +5568,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [{"s": 1}, True]},
             )
 
@@ -5638,7 +5585,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, 1.0]},
             )
 
@@ -5655,7 +5602,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, "x"]},
             )
 
@@ -5672,7 +5619,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, ["x"]]},
             )
 
@@ -5689,7 +5636,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"OutEnergy": [True, {"s": 1}]},
             )
 
@@ -5715,7 +5662,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -5737,7 +5684,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5758,7 +5705,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -5780,7 +5727,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5806,7 +5753,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
@@ -5827,7 +5774,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "InitialState": 1,
@@ -5848,7 +5795,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5869,7 +5816,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5885,7 +5832,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5912,7 +5859,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [1, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5935,7 +5882,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": ["1", 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5958,7 +5905,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [["1"], 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5981,7 +5928,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [{"a": "1"}, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5998,7 +5945,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6025,7 +5972,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 1.0],
                     "MoleculeType": ["ETO", 1],
@@ -6048,7 +5995,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, "1"],
                     "MoleculeType": ["ETO", 1],
@@ -6071,7 +6018,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, ["1"]],
                     "MoleculeType": ["ETO", 1],
@@ -6094,7 +6041,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, {"a": "1"}],
                     "MoleculeType": ["ETO", 1],
@@ -6117,7 +6064,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000, "s"],
                     "MoleculeType": ["ETO", 1],
@@ -6141,7 +6088,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [1, 1],
@@ -6164,7 +6111,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [[1], 1],
@@ -6187,7 +6134,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"a": "1"}, 1],
@@ -6210,7 +6157,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", "1"],
@@ -6233,7 +6180,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", ["1"]],
@@ -6256,7 +6203,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", {"a": "1"}],
@@ -6279,7 +6226,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETOa", 1],
@@ -6303,7 +6250,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6326,7 +6273,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6349,7 +6296,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6372,7 +6319,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6396,7 +6343,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6419,7 +6366,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6442,7 +6389,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6466,7 +6413,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6489,7 +6436,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6512,7 +6459,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6533,7 +6480,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6553,7 +6500,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6607,7 +6554,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"RcutCoulomb_box_1": "s"},
             )
 
@@ -6624,7 +6571,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"FixVolBox0": "s"},
             )
 
@@ -6642,7 +6589,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"MEMC-1Freq": 1},
             )
 
@@ -6653,7 +6600,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": [1.0, 1.0, 1.0]},
             )
         except:
@@ -6668,7 +6615,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": [1, 1, 1]},
             )
         except:
@@ -6689,7 +6636,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": ["s", 1.0, 1.0]},
             )
 
@@ -6706,7 +6653,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ExchangeVolumeDim": [1.0, [1.0], 1.0]},
             )
 
@@ -6723,7 +6670,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "ExchangeVolumeDim": [1.0, 1.0, {"a": 1.0}]
                 },
@@ -6737,7 +6684,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6770,7 +6717,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "O1"]]
@@ -6803,7 +6750,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C2", "C1"], "ETO", ["O1", "C1"]]
@@ -6842,7 +6789,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "O1"], "ETO", ["C1", "C2"]]
@@ -6877,7 +6824,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["O1", "C1"], "ETO", ["C2", "C1"]]
@@ -6912,7 +6859,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1.0, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6947,7 +6894,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         ["s", "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6982,7 +6929,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [[1], "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7017,7 +6964,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [{"a": "1"}, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7052,7 +6999,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETHa", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7087,7 +7034,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, 1, ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7122,7 +7069,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, [1], ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7157,7 +7104,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", [1, "C2"], "ETO", ["C1", "C2"]]
@@ -7192,7 +7139,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", [[1], "C2"], "ETO", ["C1", "C2"]]
@@ -7227,7 +7174,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", 1], "ETO", ["C1", "C2"]]
@@ -7262,7 +7209,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", [1]], "ETO", ["C1", "C2"]]
@@ -7297,7 +7244,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], 1, ["C1", "C2"]]
@@ -7332,7 +7279,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], [1], ["C1", "C2"]]
@@ -7367,7 +7314,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", [1, "C2"]]
@@ -7402,7 +7349,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", [[1], "C2"]]
@@ -7437,7 +7384,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", 1]]
@@ -7472,7 +7419,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", [1]]]
@@ -7508,7 +7455,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "IntraMEMC-1Freq": 0.20,
                     "MEMC-1Freq": 0.20,
@@ -7533,7 +7480,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"ChemPot": "s"},
             )
 
@@ -7550,7 +7497,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={"Fugacity": "s"},
             )
 
@@ -7562,7 +7509,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7605,7 +7552,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7634,7 +7581,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7676,7 +7623,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7704,7 +7651,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7747,7 +7694,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7776,7 +7723,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7819,7 +7766,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7848,7 +7795,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7891,7 +7838,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7921,7 +7868,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7954,7 +7901,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7987,7 +7934,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8028,7 +7975,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8051,7 +7998,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8074,7 +8021,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8096,7 +8043,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8119,7 +8066,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "Fugacity": {"ETH": 0, "XXX": 1.0},
@@ -8139,7 +8086,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "Fugacity": {"XXX": 0, "ETO": 1.0},
@@ -8159,7 +8106,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {1: -4000, "ETO": -8000},
@@ -8179,7 +8126,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"XXX": -4000, "ETO": -8000},
@@ -8199,7 +8146,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": -4000, "XXX": -8000},
@@ -8219,7 +8166,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": "40", "ETO": -8000},
@@ -8239,7 +8186,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": ["40"], "ETO": -8000},
@@ -8259,7 +8206,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8293,7 +8240,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8330,7 +8277,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8365,7 +8312,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8400,7 +8347,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8435,7 +8382,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8470,7 +8417,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8505,7 +8452,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8535,7 +8482,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8569,7 +8516,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8603,7 +8550,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8638,7 +8585,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]],
@@ -8713,7 +8660,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
@@ -8730,7 +8677,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the GCMC with only 1 box in the Charmm object
@@ -8747,7 +8694,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the NVT with 2 boxes in the Charmm object
@@ -8764,7 +8711,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the NPT with 2 boxes in the Charmm object
@@ -8780,7 +8727,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
     def test_save_non_othoganol_writer(self):
@@ -8817,7 +8764,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             100000,
             300,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
         )
 
         with open("test_save_non_othoganol_writer.conf", "r") as fp:
@@ -8951,7 +8898,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
         # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
@@ -8968,7 +8915,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
             )
 
     def test_adjustment_steps_and_ff_psf_pdb_file_directory(self, ethane_gomc):
@@ -8998,7 +8945,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=True,
+                check_input_files_exist=False,
                 ff_psf_pdb_file_directory=["x"],
             )
 
@@ -9008,7 +8955,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             100000,
             500,
-            override_check_input_files_exist=True,
+            check_input_files_exist=False,
             ff_psf_pdb_file_directory=changed_file_path,
             input_variables_dict={
                 "PressureCalc": [True, 1],
@@ -9190,7 +9137,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
     def test_check_required_gomc_files_pdb_exist_GEMC_NPT(self, ethane_gomc):
@@ -9223,7 +9170,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
     def test_check_required_gomc_files_psf_exist_GEMC_NPT(self, ethane_gomc):
@@ -9257,7 +9204,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
     def test_check_required_gomc_files_pdb_exist_NVT(self, ethane_gomc):
@@ -9290,7 +9237,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
             )
 
     def test_check_required_gomc_files_psf_exist_NVT(self, ethane_gomc):
@@ -9324,5 +9271,429 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
-                override_check_input_files_exist=False,
+                check_input_files_exist=True,
+            )
+
+    def test_check_restart_bool(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        restart_input = "XXXXX"
+        with pytest.raises(
+            TypeError,
+            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
+                  ''.format("Restart", type(restart_input)),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_checkpoint_error",
+                "NVT",
+                100,
+                300,
+                check_input_files_exist=False,
+                Restart=restart_input
+            )
+
+        restart_checkpoint_input = "XXXXX"
+        with pytest.raises(
+            TypeError,
+            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
+                  ''.format("RestartCheckpoint", type(restart_checkpoint_input)),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_checkpoint_error",
+                "NVT",
+                100,
+                300,
+                check_input_files_exist=False,
+                RestartCheckpoint="XXXXX",
+            )
+
+        check_input_files_exist_input = "XXXXX"
+        with pytest.raises(
+            TypeError,
+            match=r'ERROR: The {} input is {} and needs to be a boolean \(i.e., True or False\).' 
+                  ''.format("check_input_files_exist", type(check_input_files_exist_input)),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                'check_input_files_exist_error',
+                "NVT",
+                100,
+                300,
+                check_input_files_exist="XXXXX",
+            )
+
+
+    def test_restarting_dcd_and_binary_files_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_restarting_dcd_and_binary_files_NVT",
+            "NVT",
+            1000,
+            300,
+            Restart=True,
+            check_input_files_exist=False,
+            Coordinates_box_0="../test_files/NVT_toluene_box_0.pdb",
+            Structure_box_0="../test_files/NVT_toluene_box_0.psf",
+            binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+            extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+            binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
+            input_variables_dict={"VDWGeometricSigma": True,
+                                  "DCDFreq": [True, 1000],
+                                  }
+        )
+
+        with open("test_restarting_dcd_and_binary_files_NVT.conf", "r") as fp:
+            variables_read_dict = {
+                "VDWGeometricSigma": False,
+                "DCDFreq": False,
+                "Coordinates_box_0": False,
+                "Structure_box_0": False,
+                "binCoordinates_box_0": False,
+                "extendedSystem_box_0": False,
+                "binVelocities_box_0": False,
+            }
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith("Restart "):
+                    variables_read_dict["Restart"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                elif line.startswith("VDWGeometricSigma "):
+                    variables_read_dict["VDWGeometricSigma"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                elif line.startswith("DCDFreq "):
+                    variables_read_dict["DCDFreq"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+                    assert split_line[2] == "1000"
+
+
+                elif line.startswith("Coordinates 0"):
+                    variables_read_dict["Coordinates_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "../test_files/NVT_toluene_box_0.pdb"
+
+
+                elif line.startswith("Structure 0"):
+                    variables_read_dict["Structure_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "../test_files/NVT_toluene_box_0.psf"
+
+                elif line.startswith("binCoordinates   0 "):
+                    variables_read_dict["binCoordinates_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "../test_files/NVT_toluene_box_0.coor"
+
+                elif line.startswith("extendedSystem 	0 "):
+                    variables_read_dict["extendedSystem_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "../test_files/NVT_toluene_box_0.xsc"
+
+                elif line.startswith("binVelocities   	0"):
+                    variables_read_dict["binVelocities_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert split_line[2] == "../test_files/NVT_toluene_box_0.vel"
+
+        assert variables_read_dict == {
+            "Restart": True,
+            "VDWGeometricSigma": True,
+            "DCDFreq": True,
+            "Coordinates_box_0": True,
+            "Structure_box_0": True,
+            "binCoordinates_box_0": True,
+            "extendedSystem_box_0": True,
+            "binVelocities_box_0": True,
+        }
+
+    def test_failures_restarting_dcd_and_binary_files_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+        with pytest.raises(
+            ValueError,
+            match='ERROR: To restart a simulation with the binary files both the coor '
+                  'and xsc files for box 0 must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                extendedSystem_box_0=None,
+                binVelocities_box_0=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match='ERROR: To restart a simulation with the binary files both the coor and '
+                      'xsc files for box 0 must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0=None,
+                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_0=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match='ERROR: To restart a "NVT", "NPT" simulation with the ' 
+                      'velocity binary files, the velocity files for box 0 ' 
+                      'must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0=None,
+                extendedSystem_box_0=None,
+                binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+    def test_failures_restarting_dcd_and_binary_files_GEMC_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=test_box_ethane_gomc,
+            filename_box_1="ethane_box_1",
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+        charmm.write_inp()
+        charmm.write_pdb()
+        charmm.write_psf()
+
+        with pytest.raises(
+            ValueError,
+            match='ERROR: To restart a simulation with the binary files both the coor and ' \
+                  'xsc files for box 0 and box 1 must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_0=None,
+                binCoordinates_box_1="../test_files/NVT_toluene_box_1.coor",
+                extendedSystem_box_1=None,
+                binVelocities_box_1=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match='ERROR: To restart a simulation with the binary files both the coor and ' \
+                      'xsc files for box 0 and box 1 must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_0=None,
+                binCoordinates_box_1=None,
+                extendedSystem_box_1="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_1=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        with pytest.raises(
+                ValueError,
+                match='ERROR: To restart a "GEMC_NPT", "GEMC_NVT", "GCMC" simulation with the ' \
+                      'velocity binary files, both the velocity files for box 0 and box 1 ' \
+                      'must be provided.',
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                Restart=True,
+                check_input_files_exist=False,
+                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
+                binCoordinates_box_1="../test_files/NVT_toluene_box_1.coor",
+                extendedSystem_box_1="../test_files/NVT_toluene_box_1.xsc",
+                binVelocities_box_1=None,
+                input_variables_dict={"VDWGeometricSigma": True,
+                                      "DCDFreq": [True, 1000],
+                                      }
+            )
+
+        test_box_0_pdb = "XXXX"
+        with pytest.raises(
+                TypeError,
+                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                      r''.format('Coordinates_box_0',
+                                 "\['.pdb'\]",
+                                 os.path.splitext(test_box_0_pdb)[-1],
+                                 )
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                check_input_files_exist=True,
+                Coordinates_box_0=test_box_0_pdb,
+                Structure_box_0="ethane_box_0.psf",
+                Coordinates_box_1="ethane_box_0.pdb",
+                Structure_box_1="ethane_box_1.psf",
+            )
+
+        test_box_1_pdb = "XXXX"
+        with pytest.raises(
+                TypeError,
+                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                      r''.format('Coordinates_box_1',
+                                 "\['.pdb'\]",
+                                 os.path.splitext(test_box_1_pdb)[-1],
+                                 )
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                check_input_files_exist=True,
+                Coordinates_box_0="ethane_box_0.pdb",
+                Structure_box_0="ethane_box_0.psf",
+                Coordinates_box_1=test_box_1_pdb,
+                Structure_box_1="ethane_box_1.psf",
+            )
+
+        test_box_0_psf = "XXXX"
+        with pytest.raises(
+                TypeError,
+                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                      r''.format('Structure_box_0',
+                                 "\['.psf'\]",
+                                 os.path.splitext(test_box_0_psf)[-1],
+                                 )
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                check_input_files_exist=True,
+                Coordinates_box_0="ethane_box_0.pdb",
+                Structure_box_0=test_box_0_psf,
+                Coordinates_box_1="ethane_box_1.pdb",
+                Structure_box_1="ethane_box_1.psf",
+            )
+
+        test_box_1_psf = "XXXX"
+        with pytest.raises(
+                TypeError,
+                match=r'ERROR: The {} variable expects a file extension of {}, but the actual file extension is "{}". '
+                      r''.format('Structure_box_1',
+                                 "\['.psf'\]",
+                                 os.path.splitext(test_box_1_psf)[-1],
+                                 )
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_restart_inputs",
+                "GEMC_NVT",
+                1000,
+                300,
+                check_input_files_exist=True,
+                Coordinates_box_0="ethane_box_0.pdb",
+                Structure_box_0="ethane_box_0.psf",
+                Coordinates_box_1="ethane_box_1.pdb",
+                Structure_box_1=test_box_1_psf,
             )

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -9633,7 +9633,9 @@ class TestGOMCControlFileWriter(BaseTest):
             },
         )
 
-        with open("test_restarting_dcd_and_binary_files_GEMC_NVT.conf", "r") as fp:
+        with open(
+            "test_restarting_dcd_and_binary_files_GEMC_NVT.conf", "r"
+        ) as fp:
             variables_read_dict = {
                 "VDWGeometricSigma": False,
                 "DCDFreq": False,
@@ -9670,17 +9672,13 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["Coordinates_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert (
-                        split_line[2] == "../test_files/NVT_ethane_box_0.pdb"
-                    )
+                    assert split_line[2] == "../test_files/NVT_ethane_box_0.pdb"
 
                 elif line.startswith("Structure 0"):
                     variables_read_dict["Structure_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert (
-                        split_line[2] == "../test_files/NVT_ethane_box_0.psf"
-                    )
+                    assert split_line[2] == "../test_files/NVT_ethane_box_0.psf"
 
                 elif line.startswith("binCoordinates   0 "):
                     variables_read_dict["binCoordinates_box_0"] = True
@@ -9694,33 +9692,25 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["extendedSystem_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert (
-                        split_line[2] == "../test_files/NVT_ethane_box_0.xsc"
-                    )
+                    assert split_line[2] == "../test_files/NVT_ethane_box_0.xsc"
 
                 elif line.startswith("binVelocities   	0"):
                     variables_read_dict["binVelocities_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert (
-                        split_line[2] == "../test_files/NVT_ethane_box_0.vel"
-                    )
+                    assert split_line[2] == "../test_files/NVT_ethane_box_0.vel"
 
                 elif line.startswith("Coordinates 1"):
                     variables_read_dict["Coordinates_box_1"] = True
                     split_line = line.split()
                     assert split_line[1] == "1"
-                    assert (
-                        split_line[2] == "../test_files/NVT_ethane_box_1.pdb"
-                    )
+                    assert split_line[2] == "../test_files/NVT_ethane_box_1.pdb"
 
                 elif line.startswith("Structure 1"):
                     variables_read_dict["Structure_box_1"] = True
                     split_line = line.split()
                     assert split_line[1] == "1"
-                    assert (
-                        split_line[2] == "../test_files/NVT_ethane_box_1.psf"
-                    )
+                    assert split_line[2] == "../test_files/NVT_ethane_box_1.psf"
 
                 elif line.startswith("binCoordinates   1 "):
                     variables_read_dict["binCoordinates_box_1"] = True
@@ -9734,17 +9724,13 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["extendedSystem_box_1"] = True
                     split_line = line.split()
                     assert split_line[1] == "1"
-                    assert (
-                        split_line[2] == "../test_files/NVT_ethane_box_1.xsc"
-                    )
+                    assert split_line[2] == "../test_files/NVT_ethane_box_1.xsc"
 
                 elif line.startswith("binVelocities   	1"):
                     variables_read_dict["binVelocities_box_1"] = True
                     split_line = line.split()
                     assert split_line[1] == "1"
-                    assert (
-                        split_line[2] == "../test_files/NVT_ethane_box_1.vel"
-                    )
+                    assert split_line[2] == "../test_files/NVT_ethane_box_1.vel"
 
         assert variables_read_dict == {
             "Restart": True,
@@ -10033,15 +10019,11 @@ class TestGOMCControlFileWriter(BaseTest):
 
             test_parameters = ["XXXX"]
             with pytest.raises(
-                    TypeError,
-                    match=r"ERROR: The {} variable for directly entering the "
-                          r"{} file directory and name is a {} and not a string.".format(
-                        "Parameters",
-                        "force field",
-                        type(test_parameters
-                             )
-                    ),
-
+                TypeError,
+                match=r"ERROR: The {} variable for directly entering the "
+                r"{} file directory and name is a {} and not a string.".format(
+                    "Parameters", "force field", type(test_parameters)
+                ),
             ):
                 gomc_control.write_gomc_control_file(
                     charmm,

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -9770,6 +9770,7 @@ class TestGOMCControlFileWriter(BaseTest):
             1000,
             300,
             ff_psf_pdb_file_directory="../Test",
+            Parameters='../test_folder/new.par',
             Restart=True,
             RestartCheckpoint=True,
             check_input_files_exist=False,
@@ -9778,6 +9779,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
         with open("test_restarting_pdb_psf_NVT.conf", "r") as fp:
             variables_read_dict = {
+                "Parameters": False,
                 "Coordinates_box_0": False,
                 "Structure_box_0": False,
                 "Restart": False,
@@ -9785,7 +9787,12 @@ class TestGOMCControlFileWriter(BaseTest):
             }
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
-                if line.startswith("Coordinates 0 "):
+                if line.startswith("Parameters "):
+                    variables_read_dict["Parameters"] = True
+                    split_line = line.split()
+                    assert split_line[1] == '../test_folder/new.par'
+
+                elif line.startswith("Coordinates 0 "):
                     variables_read_dict["Coordinates_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
@@ -9808,6 +9815,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     assert split_line[1] == "True"
 
         assert variables_read_dict == {
+            "Parameters": True,
             "Coordinates_box_0": True,
             "Structure_box_0": True,
             "Restart": True,
@@ -10112,6 +10120,7 @@ class TestGOMCControlFileWriter(BaseTest):
             1000,
             300,
             ff_psf_pdb_file_directory="../Test",
+            Parameters='../test_folder/new.inp',
             Restart=True,
             RestartCheckpoint=True,
             check_input_files_exist=False,
@@ -10120,6 +10129,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
         with open("test_restarting_pdb_psf_GEMC_NVT.conf", "r") as fp:
             variables_read_dict = {
+                "Parameters": False,
                 "Coordinates_box_0": False,
                 "Structure_box_0": False,
                 "Coordinates_box_1": False,
@@ -10129,7 +10139,12 @@ class TestGOMCControlFileWriter(BaseTest):
             }
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
-                if line.startswith("Coordinates 0 "):
+                if line.startswith("Parameters "):
+                    variables_read_dict["Parameters"] = True
+                    split_line = line.split()
+                    assert split_line[1] == '../test_folder/new.inp'
+
+                elif line.startswith("Coordinates 0 "):
                     variables_read_dict["Coordinates_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
@@ -10164,6 +10179,7 @@ class TestGOMCControlFileWriter(BaseTest):
                     assert split_line[1] == "True"
 
         assert variables_read_dict == {
+            "Parameters": True,
             "Coordinates_box_0": True,
             "Structure_box_0": True,
             "Coordinates_box_1": True,

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -529,13 +529,17 @@ class TestGOMCControlFileWriter(BaseTest):
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
         )
+        charmm.write_inp()
+        charmm.write_psf()
+        charmm.write_pdb()
+
         gomc_control.write_gomc_control_file(
             charmm,
             "test_save_basic_NVT.conf",
             "NVT",
             10,
             300,
-            check_input_files_exist=False,
+            check_input_files_exist=True,
             Restart=False,
         )
 
@@ -1012,13 +1016,17 @@ class TestGOMCControlFileWriter(BaseTest):
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
         )
+        charmm.write_inp()
+        charmm.write_psf()
+        charmm.write_pdb()
+
         gomc_control.write_gomc_control_file(
             charmm,
             "test_save_basic_NPT.conf",
             "NPT",
             1000,
             500,
-            check_input_files_exist=False,
+            check_input_files_exist=True,
         )
 
         with open("test_save_basic_NPT.conf", "r") as fp:
@@ -1285,13 +1293,17 @@ class TestGOMCControlFileWriter(BaseTest):
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
         )
+        charmm.write_inp()
+        charmm.write_psf()
+        charmm.write_pdb()
+
         gomc_control.write_gomc_control_file(
             charmm,
             "test_save_basic_GCMC.conf",
             "GCMC",
             100000,
             500,
-            check_input_files_exist=False,
+            check_input_files_exist=True,
             input_variables_dict={
                 "ChemPot": {"ETH": -4000},
                 "VDWGeometricSigma": True,
@@ -1625,13 +1637,17 @@ class TestGOMCControlFileWriter(BaseTest):
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
         )
+        charmm.write_inp()
+        charmm.write_psf()
+        charmm.write_pdb()
+
         gomc_control.write_gomc_control_file(
             charmm,
             "test_save_basic_GEMC_NVT.conf",
             "GEMC_NVT",
             1000000,
             500,
-            check_input_files_exist=False,
+            check_input_files_exist=True,
         )
 
         with open("test_save_basic_GEMC_NVT.conf", "r") as fp:

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -25,6 +25,8 @@ class TestGOMCControlFileWriter(BaseTest):
             "ensemble_type",
             "RunSteps",
             "Temperature",
+            "ff_psf_pdb_file_directory",
+            "override_check_input_files_exist",
         ]
 
         value = gomc_control._get_required_data(description=True)
@@ -33,6 +35,8 @@ class TestGOMCControlFileWriter(BaseTest):
             "ensemble_type",
             "RunSteps",
             "Temperature",
+            "ff_psf_pdb_file_directory",
+            "override_check_input_files_exist",
         ]
 
     def test_get_all_possible_input_variable(self):
@@ -359,7 +363,8 @@ class TestGOMCControlFileWriter(BaseTest):
             forcefield_selection="oplsaa",
         )
         gomc_control.write_gomc_control_file(
-            charmm, "test_save_basic_NVT.conf", "NVT", 10, 300
+            charmm, "test_save_basic_NVT.conf", "NVT", 10, 300,
+            override_check_input_files_exist=True,
         )
 
         with open("test_save_basic_NVT.conf", "r") as fp:
@@ -836,7 +841,8 @@ class TestGOMCControlFileWriter(BaseTest):
             forcefield_selection="oplsaa",
         )
         gomc_control.write_gomc_control_file(
-            charmm, "test_save_basic_NPT.conf", "NPT", 1000, 500
+            charmm, "test_save_basic_NPT.conf", "NPT", 1000, 500,
+            override_check_input_files_exist=True,
         )
 
         with open("test_save_basic_NPT.conf", "r") as fp:
@@ -1109,6 +1115,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GCMC",
             100000,
             500,
+            override_check_input_files_exist=True,
             input_variables_dict={
                 "ChemPot": {"ETH": -4000},
                 "VDWGeometricSigma": True,
@@ -1443,7 +1450,8 @@ class TestGOMCControlFileWriter(BaseTest):
             forcefield_selection="oplsaa",
         )
         gomc_control.write_gomc_control_file(
-            charmm, "test_save_basic_GEMC_NVT.conf", "GEMC_NVT", 1000000, 500
+            charmm, "test_save_basic_GEMC_NVT.conf", "GEMC_NVT", 1000000, 500,
+            override_check_input_files_exist=True,
         )
 
         with open("test_save_basic_GEMC_NVT.conf", "r") as fp:
@@ -1574,6 +1582,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NPT",
             1000000,
             500,
+            override_check_input_files_exist=True,
             input_variables_dict={
                 "Pressure": 10,
                 "useConstantArea": True,
@@ -1747,6 +1756,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "NVT",
             100000,
             300,
+            override_check_input_files_exist=True,
             input_variables_dict={
                 "Restart": True,
                 "PRNG": 123,
@@ -2381,6 +2391,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10],
                     "MoleculeType": ["ETH", 1],
@@ -2400,6 +2411,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10],
                     "MoleculeType": ["ETH", 1],
@@ -2436,6 +2448,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Restart": "s"},
             )
 
@@ -2452,6 +2465,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RestartCheckpoint": "s"},
             )
 
@@ -2468,6 +2482,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PRNG": [1]},
             )
 
@@ -2484,6 +2499,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ParaTypeCHARMM": "s"},
             )
 
@@ -2500,6 +2516,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ParaTypeMie": "s"},
             )
 
@@ -2516,6 +2533,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ParaTypeMARTINI": "s"},
             )
 
@@ -2532,6 +2550,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RcutCoulomb_box_0": "s"},
             )
 
@@ -2550,6 +2569,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RcutCoulomb_box_1": "s"},
             )
 
@@ -2566,6 +2586,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Pressure": "s"},
             )
 
@@ -2582,6 +2603,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Rcut": "s"},
             )
 
@@ -2598,6 +2620,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RcutLow": "s"},
             )
 
@@ -2614,6 +2637,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"LRC": "s"},
             )
 
@@ -2630,6 +2654,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Exclude": "s"},
             )
 
@@ -2646,6 +2671,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Potential": "s"},
             )
 
@@ -2662,6 +2688,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Rswitch": "s"},
             )
 
@@ -2678,6 +2705,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ElectroStatic": "s"},
             )
 
@@ -2694,6 +2722,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Ewald": "s"},
             )
 
@@ -2710,6 +2739,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CachedFourier": "s"},
             )
 
@@ -2726,6 +2756,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Tolerance": "s"},
             )
 
@@ -2742,6 +2773,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Dielectric": "s"},
             )
 
@@ -2758,6 +2790,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": "s"},
             )
 
@@ -2774,6 +2807,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"EqSteps": "s"},
             )
 
@@ -2790,6 +2824,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"EqSteps": "s"},
             )
 
@@ -2806,6 +2841,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"useConstantArea": "s"},
             )
 
@@ -2824,6 +2860,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ChemPot": "s"},
             )
 
@@ -2842,6 +2879,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Fugacity": "s"},
             )
 
@@ -2858,6 +2896,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CBMC_First": "s"},
             )
 
@@ -2874,6 +2913,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CBMC_Nth": "s"},
             )
 
@@ -2890,6 +2930,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CBMC_Ang": "s"},
             )
 
@@ -2906,6 +2947,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CBMC_Dih": "s"},
             )
 
@@ -2922,6 +2964,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutputName": 1},
             )
 
@@ -2938,6 +2981,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CoordinatesFreq": "s"},
             )
 
@@ -2954,6 +2998,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RestartFreq": "s"},
             )
 
@@ -2970,6 +3015,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CheckpointFreq": "s"},
             )
 
@@ -2986,6 +3032,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ConsoleFreq": "s"},
             )
 
@@ -3002,6 +3049,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"BlockAverageFreq": "s"},
             )
 
@@ -3018,6 +3066,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"HistogramFreq": "s"},
             )
 
@@ -3034,6 +3083,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"DistName": 1},
             )
 
@@ -3050,6 +3100,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"HistName": 1},
             )
 
@@ -3066,6 +3117,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RunNumber": "s"},
             )
 
@@ -3082,6 +3134,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RunLetter": 1},
             )
 
@@ -3098,6 +3151,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"SampleFreq": "s"},
             )
 
@@ -3114,6 +3168,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": "s"},
             )
 
@@ -3130,6 +3185,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutPressure": "s"},
             )
 
@@ -3146,6 +3202,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutMolNumber": "s"},
             )
 
@@ -3162,6 +3219,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutDensity": "s"},
             )
 
@@ -3178,6 +3236,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutVolume": "s"},
             )
 
@@ -3194,6 +3253,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutSurfaceTension": "s"},
             )
 
@@ -3210,6 +3270,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": "s",
                     "MoleculeType": ["ETH", 1],
@@ -3232,6 +3293,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", "s"],
@@ -3254,6 +3316,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [["ETH"], 1],
@@ -3276,6 +3339,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"ETH": "1"}, 1],
@@ -3298,6 +3362,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3320,6 +3385,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3342,6 +3408,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -3363,6 +3430,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"FreeEnergyCalc": [True, 10000]},
             )
 
@@ -3379,6 +3447,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ScaleCoulomb": "s"},
             )
 
@@ -3395,6 +3464,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ScalePower": "s"},
             )
 
@@ -3411,6 +3481,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ScaleAlpha": "s"},
             )
 
@@ -3427,6 +3498,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MinSigma": "s"},
             )
 
@@ -3443,6 +3515,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ExchangeVolumeDim": "s"},
             )
 
@@ -3459,6 +3532,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC_DataInput": "s"},
             )
 
@@ -3475,6 +3549,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"DisFreq": "s"},
             )
 
@@ -3491,6 +3566,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RotFreq": "s"},
             )
 
@@ -3507,6 +3583,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraSwapFreq": "s"},
             )
 
@@ -3523,6 +3600,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"SwapFreq": "s"},
             )
 
@@ -3539,6 +3617,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RegrowthFreq": "s"},
             )
 
@@ -3555,6 +3634,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CrankShaftFreq": "s"},
             )
 
@@ -3571,6 +3651,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"VolFreq": "s"},
             )
 
@@ -3587,6 +3668,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MultiParticleFreq": "s"},
             )
 
@@ -3603,6 +3685,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraMEMC-1Freq": "s"},
             )
 
@@ -3619,6 +3702,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC-1Freq": "s"},
             )
 
@@ -3635,6 +3719,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraMEMC-2Freq": "s"},
             )
 
@@ -3651,6 +3736,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC-2Freq": "s"},
             )
 
@@ -3667,6 +3753,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraMEMC-3Freq": "s"},
             )
 
@@ -3683,6 +3770,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC-3Freq": "s"},
             )
 
@@ -3701,6 +3789,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"XXXXXX": "s"},
             )
 
@@ -3732,6 +3821,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Restart": []},
             )
 
@@ -3748,6 +3838,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RestartCheckpoint": []},
             )
 
@@ -3764,6 +3855,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PRNG": []},
             )
 
@@ -3780,6 +3872,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ParaTypeCHARMM": []},
             )
 
@@ -3796,6 +3889,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ParaTypeMie": []},
             )
 
@@ -3812,6 +3906,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ParaTypeMARTINI": []},
             )
 
@@ -3828,6 +3923,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RcutCoulomb_box_0": []},
             )
 
@@ -3846,6 +3942,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RcutCoulomb_box_1": []},
             )
 
@@ -3862,6 +3959,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Pressure": []},
             )
 
@@ -3878,6 +3976,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Rcut": []},
             )
 
@@ -3894,6 +3993,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RcutLow": []},
             )
 
@@ -3910,6 +4010,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"LRC": []},
             )
 
@@ -3926,6 +4027,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Exclude": []},
             )
 
@@ -3942,6 +4044,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Potential": []},
             )
 
@@ -3958,6 +4061,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Rswitch": []},
             )
 
@@ -3974,6 +4078,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ElectroStatic": []},
             )
 
@@ -3990,6 +4095,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Ewald": []},
             )
 
@@ -4006,6 +4112,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CachedFourier": []},
             )
 
@@ -4022,6 +4129,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Tolerance": []},
             )
 
@@ -4038,6 +4146,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Dielectric": []},
             )
 
@@ -4054,6 +4163,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": []},
             )
 
@@ -4070,6 +4180,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"EqSteps": []},
             )
 
@@ -4086,6 +4197,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"AdjSteps": []},
             )
 
@@ -4102,6 +4214,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"useConstantArea": []},
             )
 
@@ -4120,6 +4233,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"FixVolBox0": []},
             )
 
@@ -4138,6 +4252,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ChemPot": []},
             )
 
@@ -4156,6 +4271,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Fugacity": []},
             )
 
@@ -4172,6 +4288,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CBMC_First": []},
             )
 
@@ -4188,6 +4305,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CBMC_Nth": []},
             )
 
@@ -4204,6 +4322,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CBMC_Ang": []},
             )
 
@@ -4220,6 +4339,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CBMC_Dih": []},
             )
 
@@ -4236,6 +4356,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutputName": []},
             )
 
@@ -4252,6 +4373,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CoordinatesFreq": []},
             )
 
@@ -4268,6 +4390,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RestartFreq": []},
             )
 
@@ -4284,6 +4407,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CheckpointFreq": []},
             )
 
@@ -4300,6 +4424,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ConsoleFreq": []},
             )
 
@@ -4316,6 +4441,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"BlockAverageFreq": []},
             )
 
@@ -4332,6 +4458,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"HistogramFreq": []},
             )
 
@@ -4348,6 +4475,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"DistName": []},
             )
 
@@ -4364,6 +4492,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"HistName": []},
             )
 
@@ -4380,6 +4509,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RunNumber": []},
             )
 
@@ -4396,6 +4526,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RunLetter": []},
             )
 
@@ -4412,6 +4543,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"SampleFreq": []},
             )
 
@@ -4428,6 +4560,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": []},
             )
 
@@ -4444,6 +4577,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutPressure": []},
             )
 
@@ -4460,6 +4594,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutMolNumber": []},
             )
 
@@ -4476,6 +4611,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutDensity": []},
             )
 
@@ -4492,6 +4628,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutVolume": []},
             )
 
@@ -4508,6 +4645,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutSurfaceTension": []},
             )
 
@@ -4524,6 +4662,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [],
                     "MoleculeType": ["ETH", 1],
@@ -4546,6 +4685,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", []],
@@ -4568,6 +4708,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [["ETH"], 1],
@@ -4590,6 +4731,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"ETH": "1"}, 1],
@@ -4612,6 +4754,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4634,6 +4777,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4656,6 +4800,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -4677,6 +4822,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"FreeEnergyCalc": [True, 10000]},
             )
 
@@ -4693,6 +4839,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ScaleCoulomb": []},
             )
 
@@ -4709,6 +4856,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ScalePower": []},
             )
 
@@ -4725,6 +4873,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ScaleAlpha": []},
             )
 
@@ -4741,6 +4890,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MinSigma": []},
             )
 
@@ -4757,6 +4907,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ExchangeVolumeDim": []},
             )
 
@@ -4773,6 +4924,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC_DataInput": []},
             )
 
@@ -4789,6 +4941,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"DisFreq": []},
             )
 
@@ -4805,6 +4958,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"DisFreq": []},
             )
 
@@ -4821,6 +4975,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraSwapFreq": []},
             )
 
@@ -4837,6 +4992,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraSwapFreq": []},
             )
 
@@ -4853,6 +5009,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RegrowthFreq": []},
             )
 
@@ -4869,6 +5026,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"CrankShaftFreq": []},
             )
 
@@ -4885,6 +5043,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"VolFreq": []},
             )
 
@@ -4901,6 +5060,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MultiParticleFreq": []},
             )
 
@@ -4917,6 +5077,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraMEMC-1Freq": []},
             )
 
@@ -4933,6 +5094,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC-1Freq": []},
             )
 
@@ -4949,6 +5111,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraMEMC-2Freq": []},
             )
 
@@ -4965,6 +5128,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC-2Freq": []},
             )
 
@@ -4981,6 +5145,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"IntraMEMC-3Freq": []},
             )
 
@@ -4997,6 +5162,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC-3Freq": []},
             )
 
@@ -5015,6 +5181,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"XXXXXX": []},
             )
 
@@ -5040,6 +5207,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [True, 10000]},
             )
         except:
@@ -5054,6 +5222,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [False, 10000]},
             )
         except:
@@ -5074,6 +5243,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [1, 10000]},
             )
 
@@ -5084,6 +5254,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [True, 10000]},
             )
         except:
@@ -5098,6 +5269,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [False, 10000]},
             )
         except:
@@ -5118,6 +5290,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [1, 10000]},
             )
 
@@ -5134,6 +5307,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": ["", 10000]},
             )
 
@@ -5150,6 +5324,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [["x"], 10000]},
             )
 
@@ -5166,6 +5341,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [{"s": 1}, 10000]},
             )
 
@@ -5182,6 +5358,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [True, 1.0]},
             )
 
@@ -5198,6 +5375,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [True, "x"]},
             )
 
@@ -5214,6 +5392,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [True, ["x"]]},
             )
 
@@ -5230,6 +5409,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [True, {"s": 1}]},
             )
 
@@ -5246,6 +5426,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"PressureCalc": [1, True]},
             )
 
@@ -5271,6 +5452,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [True, True]},
             )
         except:
@@ -5285,6 +5467,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [False, True]},
             )
         except:
@@ -5299,6 +5482,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [False, False]},
             )
         except:
@@ -5313,6 +5497,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [True, True]},
             )
         except:
@@ -5327,6 +5512,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [False, True]},
             )
         except:
@@ -5341,6 +5527,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [False, False]},
             )
         except:
@@ -5361,6 +5548,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [1, True]},
             )
 
@@ -5377,6 +5565,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": ["", True]},
             )
 
@@ -5393,6 +5582,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [["x"], True]},
             )
 
@@ -5409,6 +5599,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [{"s": 1}, True]},
             )
 
@@ -5425,6 +5616,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [True, 1.0]},
             )
 
@@ -5441,6 +5633,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [True, "x"]},
             )
 
@@ -5457,6 +5650,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [True, ["x"]]},
             )
 
@@ -5473,6 +5667,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"OutEnergy": [True, {"s": 1}]},
             )
 
@@ -5498,6 +5693,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -5519,6 +5715,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5539,6 +5736,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETH", 1],
@@ -5560,6 +5758,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5585,6 +5784,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MoleculeType": ["ETO", 1],
                     "InitialState": 1,
@@ -5605,6 +5805,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "InitialState": 1,
@@ -5625,6 +5826,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5645,6 +5847,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5660,6 +5863,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5686,6 +5890,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [1, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5708,6 +5913,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": ["1", 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5730,6 +5936,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [["1"], 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5752,6 +5959,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [{"a": "1"}, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5768,6 +5976,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [False, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -5794,6 +6003,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 1.0],
                     "MoleculeType": ["ETO", 1],
@@ -5816,6 +6026,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, "1"],
                     "MoleculeType": ["ETO", 1],
@@ -5838,6 +6049,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, ["1"]],
                     "MoleculeType": ["ETO", 1],
@@ -5860,6 +6072,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, {"a": "1"}],
                     "MoleculeType": ["ETO", 1],
@@ -5882,6 +6095,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000, "s"],
                     "MoleculeType": ["ETO", 1],
@@ -5905,6 +6119,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [1, 1],
@@ -5927,6 +6142,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [[1], 1],
@@ -5949,6 +6165,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": [{"a": "1"}, 1],
@@ -5971,6 +6188,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", "1"],
@@ -5993,6 +6211,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", ["1"]],
@@ -6015,6 +6234,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", {"a": "1"}],
@@ -6037,6 +6257,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETOa", 1],
@@ -6060,6 +6281,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6082,6 +6304,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6104,6 +6327,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6126,6 +6350,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6149,6 +6374,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6171,6 +6397,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6193,6 +6420,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6216,6 +6444,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6238,6 +6467,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6260,6 +6490,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6280,6 +6511,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6299,6 +6531,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "FreeEnergyCalc": [True, 10000],
                     "MoleculeType": ["ETO", 1],
@@ -6352,6 +6585,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"RcutCoulomb_box_1": "s"},
             )
 
@@ -6368,6 +6602,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"FixVolBox0": "s"},
             )
 
@@ -6385,6 +6620,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"MEMC-1Freq": 1},
             )
 
@@ -6395,6 +6631,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ExchangeVolumeDim": [1.0, 1.0, 1.0]},
             )
         except:
@@ -6409,6 +6646,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ExchangeVolumeDim": [1, 1, 1]},
             )
         except:
@@ -6429,6 +6667,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ExchangeVolumeDim": ["s", 1.0, 1.0]},
             )
 
@@ -6445,6 +6684,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ExchangeVolumeDim": [1.0, [1.0], 1.0]},
             )
 
@@ -6461,6 +6701,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "ExchangeVolumeDim": [1.0, 1.0, {"a": 1.0}]
                 },
@@ -6474,6 +6715,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6506,6 +6748,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "O1"]]
@@ -6538,6 +6781,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C2", "C1"], "ETO", ["O1", "C1"]]
@@ -6576,6 +6820,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "O1"], "ETO", ["C1", "C2"]]
@@ -6610,6 +6855,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["O1", "C1"], "ETO", ["C2", "C1"]]
@@ -6644,6 +6890,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1.0, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6678,6 +6925,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         ["s", "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6712,6 +6960,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [[1], "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6746,6 +6995,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [{"a": "1"}, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6780,6 +7030,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETHa", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6814,6 +7065,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, 1, ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6848,6 +7100,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, [1], ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -6882,6 +7135,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", [1, "C2"], "ETO", ["C1", "C2"]]
@@ -6916,6 +7170,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", [[1], "C2"], "ETO", ["C1", "C2"]]
@@ -6950,6 +7205,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", 1], "ETO", ["C1", "C2"]]
@@ -6984,6 +7240,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", [1]], "ETO", ["C1", "C2"]]
@@ -7018,6 +7275,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], 1, ["C1", "C2"]]
@@ -7052,6 +7310,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], [1], ["C1", "C2"]]
@@ -7086,6 +7345,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", [1, "C2"]]
@@ -7120,6 +7380,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", [[1], "C2"]]
@@ -7154,6 +7415,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", 1]]
@@ -7188,6 +7450,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", [1]]]
@@ -7223,6 +7486,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "IntraMEMC-1Freq": 0.20,
                     "MEMC-1Freq": 0.20,
@@ -7247,6 +7511,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"ChemPot": "s"},
             )
 
@@ -7263,6 +7528,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={"Fugacity": "s"},
             )
 
@@ -7274,6 +7540,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7316,6 +7583,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7344,6 +7612,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7385,6 +7654,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7412,6 +7682,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7454,6 +7725,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7482,6 +7754,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7524,6 +7797,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7552,6 +7826,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7594,6 +7869,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7623,6 +7899,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7655,6 +7932,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7687,6 +7965,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7727,6 +8006,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7749,6 +8029,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7771,6 +8052,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7792,6 +8074,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7814,6 +8097,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "DisFreq": 1,
                     "Fugacity": {"ETH": 0, "XXX": 1.0},
@@ -7833,6 +8117,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "DisFreq": 1,
                     "Fugacity": {"XXX": 0, "ETO": 1.0},
@@ -7852,6 +8137,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {1: -4000, "ETO": -8000},
@@ -7871,6 +8157,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"XXX": -4000, "ETO": -8000},
@@ -7890,6 +8177,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": -4000, "XXX": -8000},
@@ -7909,6 +8197,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": "40", "ETO": -8000},
@@ -7928,6 +8217,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "DisFreq": 1,
                     "ChemPot": {"ETH": ["40"], "ETO": -8000},
@@ -7947,6 +8237,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -7980,6 +8271,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8016,6 +8308,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8050,6 +8343,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8084,6 +8378,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8118,6 +8413,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8152,6 +8448,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8186,6 +8483,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8215,6 +8513,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8248,6 +8547,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8281,6 +8581,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]]
@@ -8315,6 +8616,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 10,
                 300,
+                override_check_input_files_exist=True,
                 input_variables_dict={
                     "MEMC_DataInput": [
                         [1, "ETH", ["C1", "C2"], "ETO", ["C1", "C2"]],
@@ -8389,6 +8691,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NVT",
                 100,
                 300,
+                override_check_input_files_exist=True,
             )
 
         # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
@@ -8405,6 +8708,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GEMC_NPT",
                 100,
                 300,
+                override_check_input_files_exist=True,
             )
 
         # test that it fails with the GCMC with only 1 box in the Charmm object
@@ -8421,6 +8725,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 100,
                 300,
+                override_check_input_files_exist=True,
             )
 
         # test that it fails with the NVT with 2 boxes in the Charmm object
@@ -8437,6 +8742,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
+                override_check_input_files_exist=True,
             )
 
         # test that it fails with the NPT with 2 boxes in the Charmm object
@@ -8452,6 +8758,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NPT",
                 100,
                 300,
+                override_check_input_files_exist=True,
             )
 
     def test_save_non_othoganol_writer(self):
@@ -8488,6 +8795,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             100000,
             300,
+            override_check_input_files_exist=True,
         )
 
         with open("test_save_non_othoganol_writer.conf", "r") as fp:
@@ -8621,6 +8929,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 "NVT",
                 100,
                 300,
+                override_check_input_files_exist=True,
             )
 
         # test that it fails with the GEMC_NPT with only 1 box in the Charmm object
@@ -8637,27 +8946,48 @@ class TestGOMCControlFileWriter(BaseTest):
                 "GCMC",
                 100,
                 300,
+                override_check_input_files_exist=True,
             )
 
-    def test_adjustment_steps(self, ethane_gomc):
+    def test_adjustment_steps_and_ff_psf_pdb_file_directory(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
             compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
         )
+        changed_file_path = '../files'
         charmm = Charmm(
             test_box_ethane_gomc,
             "ethane_box_0",
-            structure_box_1=None,
-            filename_box_1=None,
+            structure_box_1=test_box_ethane_gomc,
+            filename_box_1="ethane_box_1",
             ff_filename="ethane_FF",
             residues=[ethane_gomc.name],
             forcefield_selection="oplsaa",
         )
+
+        # test the failure of the ff_psf_pdb_file_directory variable is not None or a string
+        with pytest.raises(
+            TypeError,
+            match=f"ERROR: The ff_psf_pdb_file_directory variable for modifying the FF, pdb, "
+                  f"and psf file directories is a {type(['x'])} and not a string.",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_charmm_object_ff_psf_pdb_file_directory_not_a_sting",
+                "GEMC_NPT",
+                100,
+                300,
+                override_check_input_files_exist=True,
+                ff_psf_pdb_file_directory=['x'],
+            )
+
         gomc_control.write_gomc_control_file(
             charmm,
             "test_adjustment_steps.conf",
-            "NVT",
+            "GEMC_NVT",
             100000,
             500,
+            override_check_input_files_exist=True,
+            ff_psf_pdb_file_directory=changed_file_path,
             input_variables_dict={
                 "PressureCalc": [True, 1],
                 "AdjSteps": 2,
@@ -8686,6 +9016,11 @@ class TestGOMCControlFileWriter(BaseTest):
                 "HistogramFreq": False,
                 "SampleFreq": False,
                 "VDWGeometricSigma": False,
+                "Parameters": False,
+                "Coordinates_box_0": False,
+                "Structure_box_0": False,
+                "Coordinates_box_1": False,
+                "Structure_box_1": False,
             }
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
@@ -8751,6 +9086,31 @@ class TestGOMCControlFileWriter(BaseTest):
                     split_line = line.split()
                     assert split_line[1] == "True"
 
+                elif line.startswith("Parameters "):
+                    variables_read_dict["Parameters"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "{}/ethane_FF.inp".format(changed_file_path)
+
+                elif line.startswith("Coordinates 0 "):
+                    variables_read_dict["Coordinates_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[2] == "{}/ethane_box_0.pdb".format(changed_file_path)
+
+                elif line.startswith("Structure 0 "):
+                    variables_read_dict["Structure_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[2] == "{}/ethane_box_0.psf".format(changed_file_path)
+
+                elif line.startswith("Coordinates 1 "):
+                    variables_read_dict["Coordinates_box_1"] = True
+                    split_line = line.split()
+                    assert split_line[2] == "{}/ethane_box_1.pdb".format(changed_file_path)
+
+                elif line.startswith("Structure 1 "):
+                    variables_read_dict["Structure_box_1"] = True
+                    split_line = line.split()
+                    assert split_line[2] == "{}/ethane_box_1.psf".format(changed_file_path)
+
         assert variables_read_dict == {
             "PressureCalc": True,
             "AdjSteps": True,
@@ -8763,4 +9123,168 @@ class TestGOMCControlFileWriter(BaseTest):
             "HistogramFreq": True,
             "SampleFreq": True,
             "VDWGeometricSigma": True,
+            "Parameters": True,
+            "Coordinates_box_0": True,
+            "Structure_box_0": True,
+            "Coordinates_box_1": True,
+            "Structure_box_1": True,
         }
+
+    def test_check_required_gomc_files_inp_exist_GEMC_NPT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=test_box_ethane_gomc,
+            filename_box_1="ethane_box_1",
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+                ValueError,
+                match=r"The {} with the file directory and name {}, "
+                      "does not exist.".format("force field file or parameter file",
+                                              "{}".format("ethane_FF.inp")),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_gomc_ff_exists_GEMC_NPT",
+                "GEMC_NPT",
+                100,
+                300,
+                override_check_input_files_exist=False,
+            )
+
+    def test_check_required_gomc_files_pdb_exist_GEMC_NPT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=test_box_ethane_gomc,
+            filename_box_1="ethane_box_1",
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        charmm.write_inp()
+
+        with pytest.raises(
+                ValueError,
+                match=r"The {} with the file directory and name {}, "
+                      "does not exist.".format("box 0 pdb file",
+                                               "{}".format("ethane_box_0.pdb")),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_gomc_pdb_exists_GEMC_NPT",
+                "GEMC_NPT",
+                100,
+                300,
+                override_check_input_files_exist=False,
+            )
+
+    def test_check_required_gomc_files_psf_exist_GEMC_NPT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=test_box_ethane_gomc,
+            filename_box_1="ethane_box_1",
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        charmm.write_inp()
+        charmm.write_pdb()
+
+        with pytest.raises(
+                ValueError,
+                match=r"The {} with the file directory and name {}, "
+                      "does not exist.".format("box 0 psf file",
+                                               "{}".format("ethane_box_0.psf")),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_gomc_psf_exists_GEMC_NPT",
+                "GEMC_NPT",
+                100,
+                300,
+                override_check_input_files_exist=False,
+            )
+
+    def test_check_required_gomc_files_pdb_exist_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        charmm.write_inp()
+
+        with pytest.raises(
+                ValueError,
+                match=r"The {} with the file directory and name {}, "
+                      "does not exist.".format("box 0 pdb file",
+                                               "{}".format("ethane_box_0.pdb")),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_gomc_pdb_exists_NVT",
+                "NVT",
+                100,
+                300,
+                override_check_input_files_exist=False,
+            )
+
+    def test_check_required_gomc_files_psf_exist_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        charmm.write_inp()
+        charmm.write_pdb()
+
+        with pytest.raises(
+                ValueError,
+                match=r"The {} with the file directory and name {}, "
+                      "does not exist.".format("box 0 psf file",
+                                               "{}".format("ethane_box_0.psf")),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_gomc_psf_exists_NVT",
+                "NVT",
+                100,
+                300,
+                override_check_input_files_exist=False,
+            )

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -403,9 +403,12 @@ class TestGOMCControlFileWriter(BaseTest):
         assert test_status == "FAILED"
 
     def test_get_possible_ensemble_input_variables(self):
-        with pytest.warns(UserWarning, match="WARNING: The ensemble_type selected for "
-                                             "the _get_possible_ensemble_input_variables "
-                                             "function is not valid."):
+        with pytest.warns(
+            UserWarning,
+            match="WARNING: The ensemble_type selected for "
+            "the _get_possible_ensemble_input_variables "
+            "function is not valid.",
+        ):
             gomc_control._get_possible_ensemble_input_variables("XXX")
 
     def test_wrong_ensemble_gomccontrol(self, ethane_gomc):
@@ -427,8 +430,8 @@ class TestGOMCControlFileWriter(BaseTest):
         with pytest.raises(
             ValueError,
             match=r"ERROR: The ensemble type selection of '{}' is not a valid ensemble option. "
-                  r"Please choose the 'NPT', 'NVT', 'GEMC_NVT', 'GEMC_NPT', or 'GCMC' "
-                  "ensembles".format(ensemble_input),
+            r"Please choose the 'NPT', 'NVT', 'GEMC_NVT', 'GEMC_NPT', or 'GCMC' "
+            "ensembles".format(ensemble_input),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -457,11 +460,9 @@ class TestGOMCControlFileWriter(BaseTest):
         with pytest.raises(
             ValueError,
             match=r"The force field file name was not specified and in the Charmm object \({}\)."
-                  r"Therefore, the force field file \(.inp\) can not be written, and thus, the "
-                  r"GOMC control file \(.conf\) can not be created. Please use the force field file "
-                  r"name when building the Charmm object".format(
-                type(Charmm)
-            ),
+            r"Therefore, the force field file \(.inp\) can not be written, and thus, the "
+            r"GOMC control file \(.conf\) can not be created. Please use the force field file "
+            r"name when building the Charmm object".format(type(Charmm)),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -489,7 +490,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
         with pytest.raises(
             ValueError,
-            match=r"ERROR: The input_variables_dict variable is not None or a dictionary."
+            match=r"ERROR: The input_variables_dict variable is not None or a dictionary.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -498,7 +499,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 100,
                 300,
                 check_input_files_exist=False,
-                input_variables_dict="XXXXX"
+                input_variables_dict="XXXXX",
             )
 
     def test_not_entered_charmm_object(self):
@@ -506,15 +507,12 @@ class TestGOMCControlFileWriter(BaseTest):
         with pytest.raises(
             TypeError,
             match=r"ERROR: The variable supplied is a \({}\), not a charmm_object \({}\)"
-                  r"".format(
-                type(not_charmm_object),
-                type(Charmm)
-            ),
+            r"".format(type(not_charmm_object), type(Charmm)),
         ):
             gomc_control.write_gomc_control_file(
                 not_charmm_object,
                 "test_not_charmm_object",
-                'NVT',
+                "NVT",
                 100,
                 300,
                 check_input_files_exist=False,

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -390,6 +390,136 @@ class TestGOMCControlFileWriter(BaseTest):
             test_status = "FAILED"
         assert test_status == "PASSED"
 
+        try:
+            gomc_control.print_valid_ensemble_input_variables(
+                "XXXXX", description=True
+            )
+            gomc_control.print_valid_ensemble_input_variables(
+                "XXXXX", description=False
+            )
+            test_status = "PASSED"
+        except:
+            test_status = "FAILED"
+        assert test_status == "FAILED"
+
+    def test_get_possible_ensemble_input_variables(self):
+        with pytest.warns(UserWarning, match="WARNING: The ensemble_type selected for "
+                                             "the _get_possible_ensemble_input_variables "
+                                             "function is not valid."):
+            gomc_control._get_possible_ensemble_input_variables("XXX")
+
+    def test_wrong_ensemble_gomccontrol(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        ensemble_input = "XXXXX"
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: The ensemble type selection of '{}' is not a valid ensemble option. "
+                  r"Please choose the 'NPT', 'NVT', 'GEMC_NVT', 'GEMC_NPT', or 'GCMC' "
+                  "ensembles".format(ensemble_input),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_wrong_ensemble_gomccontrol",
+                ensemble_input,
+                100,
+                300,
+                check_input_files_exist=False,
+            )
+
+    def test_charmm_ff_name_is_none(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename=None,
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"The force field file name was not specified and in the Charmm object \({}\)."
+                  r"Therefore, the force field file \(.inp\) can not be written, and thus, the "
+                  r"GOMC control file \(.conf\) can not be created. Please use the force field file "
+                  r"name when building the Charmm object".format(
+                type(Charmm)
+            ),
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_charmm_ff_name_is_none",
+                "NVT",
+                100,
+                300,
+                check_input_files_exist=False,
+            )
+
+    def test_input_variables_dict_wrong_value(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=None,
+            filename_box_1=None,
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: The input_variables_dict variable is not None or a dictionary."
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_input_variables_dict_wrong_value",
+                "NVT",
+                100,
+                300,
+                check_input_files_exist=False,
+                input_variables_dict="XXXXX"
+            )
+
+    def test_not_entered_charmm_object(self):
+        not_charmm_object = "XXXXX"
+        with pytest.raises(
+            TypeError,
+            match=r"ERROR: The variable supplied is a \({}\), not a charmm_object \({}\)"
+                  r"".format(
+                type(not_charmm_object),
+                type(Charmm)
+            ),
+        ):
+            gomc_control.write_gomc_control_file(
+                not_charmm_object,
+                "test_not_charmm_object",
+                'NVT',
+                100,
+                300,
+                check_input_files_exist=False,
+            )
+
     def test_save_basic_NVT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
             compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -27,6 +27,11 @@ class TestGOMCControlFileWriter(BaseTest):
             "Temperature",
             "ff_psf_pdb_file_directory",
             "override_check_input_files_exist",
+            "override_ff_directory_filename",
+            "override_box_0_pdb_directory_filename",
+            "override_box_0_psf_directory_filename",
+            "override_box_1_pdb_directory_filename",
+            "override_box_1_psf_directory_filename",
         ]
 
         value = gomc_control._get_required_data(description=True)
@@ -37,6 +42,11 @@ class TestGOMCControlFileWriter(BaseTest):
             "Temperature",
             "ff_psf_pdb_file_directory",
             "override_check_input_files_exist",
+            "override_ff_directory_filename",
+            "override_box_0_pdb_directory_filename",
+            "override_box_0_psf_directory_filename",
+            "override_box_1_pdb_directory_filename",
+            "override_box_1_psf_directory_filename",
         ]
 
     def test_get_all_possible_input_variable(self):
@@ -8979,8 +8989,8 @@ class TestGOMCControlFileWriter(BaseTest):
         # test the failure of the ff_psf_pdb_file_directory variable is not None or a string
         with pytest.raises(
             TypeError,
-            match=f"ERROR: The ff_psf_pdb_file_directory variable for modifying the FF, pdb, "
-            f"and psf file directories is a {type(['x'])} and not a string.",
+            match= f"ERROR: The {'ff_psf_pdb_file_directory'} variable for directly entering the "
+                   f"{'force field, pdb, and psf'} file directory and name is a {type(['x'])} and not a string."
         ):
             gomc_control.write_gomc_control_file(
                 charmm,

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -9770,7 +9770,7 @@ class TestGOMCControlFileWriter(BaseTest):
             1000,
             300,
             ff_psf_pdb_file_directory="../Test",
-            Parameters='../test_folder/new.par',
+            Parameters="../test_folder/new.par",
             Restart=True,
             RestartCheckpoint=True,
             check_input_files_exist=False,
@@ -9790,7 +9790,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 if line.startswith("Parameters "):
                     variables_read_dict["Parameters"] = True
                     split_line = line.split()
-                    assert split_line[1] == '../test_folder/new.par'
+                    assert split_line[1] == "../test_folder/new.par"
 
                 elif line.startswith("Coordinates 0 "):
                     variables_read_dict["Coordinates_box_0"] = True
@@ -10120,7 +10120,7 @@ class TestGOMCControlFileWriter(BaseTest):
             1000,
             300,
             ff_psf_pdb_file_directory="../Test",
-            Parameters='../test_folder/new.inp',
+            Parameters="../test_folder/new.inp",
             Restart=True,
             RestartCheckpoint=True,
             check_input_files_exist=False,
@@ -10142,7 +10142,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 if line.startswith("Parameters "):
                     variables_read_dict["Parameters"] = True
                     split_line = line.split()
-                    assert split_line[1] == '../test_folder/new.inp'
+                    assert split_line[1] == "../test_folder/new.inp"
 
                 elif line.startswith("Coordinates 0 "):
                     variables_read_dict["Coordinates_box_0"] = True

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -363,7 +363,11 @@ class TestGOMCControlFileWriter(BaseTest):
             forcefield_selection="oplsaa",
         )
         gomc_control.write_gomc_control_file(
-            charmm, "test_save_basic_NVT.conf", "NVT", 10, 300,
+            charmm,
+            "test_save_basic_NVT.conf",
+            "NVT",
+            10,
+            300,
             override_check_input_files_exist=True,
         )
 
@@ -841,7 +845,11 @@ class TestGOMCControlFileWriter(BaseTest):
             forcefield_selection="oplsaa",
         )
         gomc_control.write_gomc_control_file(
-            charmm, "test_save_basic_NPT.conf", "NPT", 1000, 500,
+            charmm,
+            "test_save_basic_NPT.conf",
+            "NPT",
+            1000,
+            500,
             override_check_input_files_exist=True,
         )
 
@@ -1450,7 +1458,11 @@ class TestGOMCControlFileWriter(BaseTest):
             forcefield_selection="oplsaa",
         )
         gomc_control.write_gomc_control_file(
-            charmm, "test_save_basic_GEMC_NVT.conf", "GEMC_NVT", 1000000, 500,
+            charmm,
+            "test_save_basic_GEMC_NVT.conf",
+            "GEMC_NVT",
+            1000000,
+            500,
             override_check_input_files_exist=True,
         )
 
@@ -8953,7 +8965,7 @@ class TestGOMCControlFileWriter(BaseTest):
         test_box_ethane_gomc = mb.fill_box(
             compound=[ethane_gomc], n_compounds=[1], box=[2, 2, 2]
         )
-        changed_file_path = '../files'
+        changed_file_path = "../files"
         charmm = Charmm(
             test_box_ethane_gomc,
             "ethane_box_0",
@@ -8968,7 +8980,7 @@ class TestGOMCControlFileWriter(BaseTest):
         with pytest.raises(
             TypeError,
             match=f"ERROR: The ff_psf_pdb_file_directory variable for modifying the FF, pdb, "
-                  f"and psf file directories is a {type(['x'])} and not a string.",
+            f"and psf file directories is a {type(['x'])} and not a string.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -8977,7 +8989,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 100,
                 300,
                 override_check_input_files_exist=True,
-                ff_psf_pdb_file_directory=['x'],
+                ff_psf_pdb_file_directory=["x"],
             )
 
         gomc_control.write_gomc_control_file(
@@ -9089,27 +9101,37 @@ class TestGOMCControlFileWriter(BaseTest):
                 elif line.startswith("Parameters "):
                     variables_read_dict["Parameters"] = True
                     split_line = line.split()
-                    assert split_line[1] == "{}/ethane_FF.inp".format(changed_file_path)
+                    assert split_line[1] == "{}/ethane_FF.inp".format(
+                        changed_file_path
+                    )
 
                 elif line.startswith("Coordinates 0 "):
                     variables_read_dict["Coordinates_box_0"] = True
                     split_line = line.split()
-                    assert split_line[2] == "{}/ethane_box_0.pdb".format(changed_file_path)
+                    assert split_line[2] == "{}/ethane_box_0.pdb".format(
+                        changed_file_path
+                    )
 
                 elif line.startswith("Structure 0 "):
                     variables_read_dict["Structure_box_0"] = True
                     split_line = line.split()
-                    assert split_line[2] == "{}/ethane_box_0.psf".format(changed_file_path)
+                    assert split_line[2] == "{}/ethane_box_0.psf".format(
+                        changed_file_path
+                    )
 
                 elif line.startswith("Coordinates 1 "):
                     variables_read_dict["Coordinates_box_1"] = True
                     split_line = line.split()
-                    assert split_line[2] == "{}/ethane_box_1.pdb".format(changed_file_path)
+                    assert split_line[2] == "{}/ethane_box_1.pdb".format(
+                        changed_file_path
+                    )
 
                 elif line.startswith("Structure 1 "):
                     variables_read_dict["Structure_box_1"] = True
                     split_line = line.split()
-                    assert split_line[2] == "{}/ethane_box_1.psf".format(changed_file_path)
+                    assert split_line[2] == "{}/ethane_box_1.psf".format(
+                        changed_file_path
+                    )
 
         assert variables_read_dict == {
             "PressureCalc": True,
@@ -9145,10 +9167,12 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with pytest.raises(
-                ValueError,
-                match=r"The {} with the file directory and name {}, "
-                      "does not exist.".format("force field file or parameter file",
-                                              "{}".format("ethane_FF.inp")),
+            ValueError,
+            match=r"The {} with the file directory and name {}, "
+            "does not exist.".format(
+                "force field file or parameter file",
+                "{}".format("ethane_FF.inp"),
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9177,10 +9201,11 @@ class TestGOMCControlFileWriter(BaseTest):
         charmm.write_inp()
 
         with pytest.raises(
-                ValueError,
-                match=r"The {} with the file directory and name {}, "
-                      "does not exist.".format("box 0 pdb file",
-                                               "{}".format("ethane_box_0.pdb")),
+            ValueError,
+            match=r"The {} with the file directory and name {}, "
+            "does not exist.".format(
+                "box 0 pdb file", "{}".format("ethane_box_0.pdb")
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9210,10 +9235,11 @@ class TestGOMCControlFileWriter(BaseTest):
         charmm.write_pdb()
 
         with pytest.raises(
-                ValueError,
-                match=r"The {} with the file directory and name {}, "
-                      "does not exist.".format("box 0 psf file",
-                                               "{}".format("ethane_box_0.psf")),
+            ValueError,
+            match=r"The {} with the file directory and name {}, "
+            "does not exist.".format(
+                "box 0 psf file", "{}".format("ethane_box_0.psf")
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9242,10 +9268,11 @@ class TestGOMCControlFileWriter(BaseTest):
         charmm.write_inp()
 
         with pytest.raises(
-                ValueError,
-                match=r"The {} with the file directory and name {}, "
-                      "does not exist.".format("box 0 pdb file",
-                                               "{}".format("ethane_box_0.pdb")),
+            ValueError,
+            match=r"The {} with the file directory and name {}, "
+            "does not exist.".format(
+                "box 0 pdb file", "{}".format("ethane_box_0.pdb")
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -9275,10 +9302,11 @@ class TestGOMCControlFileWriter(BaseTest):
         charmm.write_pdb()
 
         with pytest.raises(
-                ValueError,
-                match=r"The {} with the file directory and name {}, "
-                      "does not exist.".format("box 0 psf file",
-                                               "{}".format("ethane_box_0.psf")),
+            ValueError,
+            match=r"The {} with the file directory and name {}, "
+            "does not exist.".format(
+                "box 0 psf file", "{}".format("ethane_box_0.psf")
+            ),
         ):
             gomc_control.write_gomc_control_file(
                 charmm,

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -9594,6 +9594,174 @@ class TestGOMCControlFileWriter(BaseTest):
             "binVelocities_box_0": True,
         }
 
+    def test_restarting_dcd_and_binary_files_GEMC_NVT(self, ethane_gomc):
+        test_box_ethane_gomc = mb.fill_box(
+            compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
+        )
+
+        charmm = Charmm(
+            test_box_ethane_gomc,
+            "ethane_box_0",
+            structure_box_1=test_box_ethane_gomc,
+            filename_box_1="ethane_box_1",
+            ff_filename="ethane_FF",
+            residues=[ethane_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_restarting_dcd_and_binary_files_GEMC_NVT",
+            "GEMC_NVT",
+            1000,
+            300,
+            Restart=True,
+            check_input_files_exist=False,
+            Coordinates_box_0="../test_files/NVT_ethane_box_0.pdb",
+            Structure_box_0="../test_files/NVT_ethane_box_0.psf",
+            binCoordinates_box_0="../test_files/NVT_ethane_box_0.coor",
+            extendedSystem_box_0="../test_files/NVT_ethane_box_0.xsc",
+            binVelocities_box_0="../test_files/NVT_ethane_box_0.vel",
+            Coordinates_box_1="../test_files/NVT_ethane_box_1.pdb",
+            Structure_box_1="../test_files/NVT_ethane_box_1.psf",
+            binCoordinates_box_1="../test_files/NVT_ethane_box_1.coor",
+            extendedSystem_box_1="../test_files/NVT_ethane_box_1.xsc",
+            binVelocities_box_1="../test_files/NVT_ethane_box_1.vel",
+            input_variables_dict={
+                "VDWGeometricSigma": True,
+                "DCDFreq": [True, 1000],
+            },
+        )
+
+        with open("test_restarting_dcd_and_binary_files_GEMC_NVT.conf", "r") as fp:
+            variables_read_dict = {
+                "VDWGeometricSigma": False,
+                "DCDFreq": False,
+                "Coordinates_box_0": False,
+                "Structure_box_0": False,
+                "binCoordinates_box_0": False,
+                "extendedSystem_box_0": False,
+                "binVelocities_box_0": False,
+                "Coordinates_box_1": False,
+                "Structure_box_1": False,
+                "binCoordinates_box_1": False,
+                "extendedSystem_box_1": False,
+                "binVelocities_box_1": False,
+            }
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith("Restart "):
+                    variables_read_dict["Restart"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                elif line.startswith("VDWGeometricSigma "):
+                    variables_read_dict["VDWGeometricSigma"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                elif line.startswith("DCDFreq "):
+                    variables_read_dict["DCDFreq"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+                    assert split_line[2] == "1000"
+
+                elif line.startswith("Coordinates 0"):
+                    variables_read_dict["Coordinates_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_0.pdb"
+                    )
+
+                elif line.startswith("Structure 0"):
+                    variables_read_dict["Structure_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_0.psf"
+                    )
+
+                elif line.startswith("binCoordinates   0 "):
+                    variables_read_dict["binCoordinates_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_0.coor"
+                    )
+
+                elif line.startswith("extendedSystem 	0 "):
+                    variables_read_dict["extendedSystem_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_0.xsc"
+                    )
+
+                elif line.startswith("binVelocities   	0"):
+                    variables_read_dict["binVelocities_box_0"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "0"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_0.vel"
+                    )
+
+                elif line.startswith("Coordinates 1"):
+                    variables_read_dict["Coordinates_box_1"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "1"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_1.pdb"
+                    )
+
+                elif line.startswith("Structure 1"):
+                    variables_read_dict["Structure_box_1"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "1"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_1.psf"
+                    )
+
+                elif line.startswith("binCoordinates   1 "):
+                    variables_read_dict["binCoordinates_box_1"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "1"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_1.coor"
+                    )
+
+                elif line.startswith("extendedSystem 	1 "):
+                    variables_read_dict["extendedSystem_box_1"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "1"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_1.xsc"
+                    )
+
+                elif line.startswith("binVelocities   	1"):
+                    variables_read_dict["binVelocities_box_1"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "1"
+                    assert (
+                        split_line[2] == "../test_files/NVT_ethane_box_1.vel"
+                    )
+
+        assert variables_read_dict == {
+            "Restart": True,
+            "VDWGeometricSigma": True,
+            "DCDFreq": True,
+            "Coordinates_box_0": True,
+            "Structure_box_0": True,
+            "binCoordinates_box_0": True,
+            "extendedSystem_box_0": True,
+            "binVelocities_box_0": True,
+            "Coordinates_box_1": True,
+            "Structure_box_1": True,
+            "binCoordinates_box_1": True,
+            "extendedSystem_box_1": True,
+            "binVelocities_box_1": True,
+        }
+
     def test_failures_restarting_dcd_and_binary_files_NVT(self, ethane_gomc):
         test_box_ethane_gomc = mb.fill_box(
             compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
@@ -9621,7 +9789,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 300,
                 Restart=True,
                 check_input_files_exist=False,
-                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
+                binCoordinates_box_0="../test_files/NVT_ethane_box_0.coor",
                 extendedSystem_box_0=None,
                 binVelocities_box_0=None,
                 input_variables_dict={
@@ -9644,7 +9812,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 Restart=True,
                 check_input_files_exist=False,
                 binCoordinates_box_0=None,
-                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                extendedSystem_box_0="../test_files/NVT_ethane_box_0.xsc",
                 binVelocities_box_0=None,
                 input_variables_dict={
                     "VDWGeometricSigma": True,
@@ -9668,7 +9836,7 @@ class TestGOMCControlFileWriter(BaseTest):
                 check_input_files_exist=False,
                 binCoordinates_box_0=None,
                 extendedSystem_box_0=None,
-                binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
+                binVelocities_box_0="../test_files/NVT_ethane_box_0.vel",
                 input_variables_dict={
                     "VDWGeometricSigma": True,
                     "DCDFreq": [True, 1000],
@@ -9708,10 +9876,10 @@ class TestGOMCControlFileWriter(BaseTest):
                 300,
                 Restart=True,
                 check_input_files_exist=False,
-                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
-                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binCoordinates_box_0="../test_files/NVT_ethane_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_ethane_box_0.xsc",
                 binVelocities_box_0=None,
-                binCoordinates_box_1="../test_files/NVT_toluene_box_1.coor",
+                binCoordinates_box_1="../test_files/NVT_ethane_box_1.coor",
                 extendedSystem_box_1=None,
                 binVelocities_box_1=None,
                 input_variables_dict={
@@ -9733,11 +9901,11 @@ class TestGOMCControlFileWriter(BaseTest):
                 300,
                 Restart=True,
                 check_input_files_exist=False,
-                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
-                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
+                binCoordinates_box_0="../test_files/NVT_ethane_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_ethane_box_0.xsc",
                 binVelocities_box_0=None,
                 binCoordinates_box_1=None,
-                extendedSystem_box_1="../test_files/NVT_toluene_box_0.xsc",
+                extendedSystem_box_1="../test_files/NVT_ethane_box_0.xsc",
                 binVelocities_box_1=None,
                 input_variables_dict={
                     "VDWGeometricSigma": True,
@@ -9759,11 +9927,11 @@ class TestGOMCControlFileWriter(BaseTest):
                 300,
                 Restart=True,
                 check_input_files_exist=False,
-                binCoordinates_box_0="../test_files/NVT_toluene_box_0.coor",
-                extendedSystem_box_0="../test_files/NVT_toluene_box_0.xsc",
-                binVelocities_box_0="../test_files/NVT_toluene_box_0.vel",
-                binCoordinates_box_1="../test_files/NVT_toluene_box_1.coor",
-                extendedSystem_box_1="../test_files/NVT_toluene_box_1.xsc",
+                binCoordinates_box_0="../test_files/NVT_ethane_box_0.coor",
+                extendedSystem_box_0="../test_files/NVT_ethane_box_0.xsc",
+                binVelocities_box_0="../test_files/NVT_ethane_box_0.vel",
+                binCoordinates_box_1="../test_files/NVT_ethane_box_1.coor",
+                extendedSystem_box_1="../test_files/NVT_ethane_box_1.xsc",
                 binVelocities_box_1=None,
                 input_variables_dict={
                     "VDWGeometricSigma": True,
@@ -9862,3 +10030,29 @@ class TestGOMCControlFileWriter(BaseTest):
                 Coordinates_box_1="ethane_box_1.pdb",
                 Structure_box_1=test_box_1_psf,
             )
+
+            test_parameters = ["XXXX"]
+            with pytest.raises(
+                    TypeError,
+                    match=r"ERROR: The {} variable for directly entering the "
+                          r"{} file directory and name is a {} and not a string.".format(
+                        "Parameters",
+                        "force field",
+                        type(test_parameters
+                             )
+                    ),
+
+            ):
+                gomc_control.write_gomc_control_file(
+                    charmm,
+                    "test_restart_inputs",
+                    "GEMC_NVT",
+                    1000,
+                    300,
+                    check_input_files_exist=True,
+                    Parameters=test_parameters,
+                    Coordinates_box_0="ethane_box_0.pdb",
+                    Structure_box_0="ethane_box_0.psf",
+                    Coordinates_box_1="ethane_box_1.pdb",
+                    Structure_box_1=test_box_1_psf,
+                )

--- a/mbuild/tests/test_gomc_conf_writer.py
+++ b/mbuild/tests/test_gomc_conf_writer.py
@@ -9769,16 +9769,14 @@ class TestGOMCControlFileWriter(BaseTest):
             "NVT",
             1000,
             300,
-            ff_psf_pdb_file_directory='../Test',
+            ff_psf_pdb_file_directory="../Test",
             Restart=True,
             RestartCheckpoint=True,
             check_input_files_exist=False,
             input_variables_dict={},
         )
 
-        with open(
-            "test_restarting_pdb_psf_NVT.conf", "r"
-        ) as fp:
+        with open("test_restarting_pdb_psf_NVT.conf", "r") as fp:
             variables_read_dict = {
                 "Coordinates_box_0": False,
                 "Structure_box_0": False,
@@ -9837,7 +9835,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "NVT",
             1000,
             300,
-            ff_psf_pdb_file_directory='../Test',
+            ff_psf_pdb_file_directory="../Test",
             Restart=True,
             RestartCheckpoint=True,
             Coordinates_box_0="../test_files_1/NVT_toluene_box_0.pdb",
@@ -9847,7 +9845,7 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with open(
-                "test_restarting_pdb_psf_NVT_only_rename_coordinates.conf", "r"
+            "test_restarting_pdb_psf_NVT_only_rename_coordinates.conf", "r"
         ) as fp:
             variables_read_dict = {
                 "Coordinates_box_0": False,
@@ -9859,7 +9857,9 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["Coordinates_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files_1/NVT_toluene_box_0.pdb"
+                    assert (
+                        split_line[2] == "../test_files_1/NVT_toluene_box_0.pdb"
+                    )
 
                 elif line.startswith("Structure 0 "):
                     variables_read_dict["Structure_box_0"] = True
@@ -9921,14 +9921,18 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["Structure_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files_2/NVT_toluene_box_0.psf"
+                    assert (
+                        split_line[2] == "../test_files_2/NVT_toluene_box_0.psf"
+                    )
 
         assert variables_read_dict == {
             "Coordinates_box_0": True,
             "Structure_box_0": True,
         }
 
-    def test_restarting_pdb_psf_GEMC_NVT_only_rename_coordinates(self, ethane_gomc):
+    def test_restarting_pdb_psf_GEMC_NVT_only_rename_coordinates(
+        self, ethane_gomc
+    ):
         test_box_ethane_gomc = mb.fill_box(
             compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
         )
@@ -9961,7 +9965,7 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with open(
-                "test_restarting_pdb_psf_GEMC_NVT_only_rename_coordinates.conf", "r"
+            "test_restarting_pdb_psf_GEMC_NVT_only_rename_coordinates.conf", "r"
         ) as fp:
             variables_read_dict = {
                 "Coordinates_box_0": False,
@@ -9975,7 +9979,9 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["Coordinates_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files_1/NVT_toluene_box_0.pdb"
+                    assert (
+                        split_line[2] == "../test_files_1/NVT_toluene_box_0.pdb"
+                    )
 
                 elif line.startswith("Structure 0 "):
                     variables_read_dict["Structure_box_0"] = True
@@ -9987,7 +9993,9 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["Coordinates_box_1"] = True
                     split_line = line.split()
                     assert split_line[1] == "1"
-                    assert split_line[2] == "../test_files_2/NVT_toluene_box_1.pdb"
+                    assert (
+                        split_line[2] == "../test_files_2/NVT_toluene_box_1.pdb"
+                    )
 
                 elif line.startswith("Structure 1 "):
                     variables_read_dict["Structure_box_1"] = True
@@ -10002,7 +10010,9 @@ class TestGOMCControlFileWriter(BaseTest):
             "Structure_box_1": True,
         }
 
-    def test_restarting_pdb_psf_GEMC_NVT_only_rename_structure(self, ethane_gomc):
+    def test_restarting_pdb_psf_GEMC_NVT_only_rename_structure(
+        self, ethane_gomc
+    ):
         test_box_ethane_gomc = mb.fill_box(
             compound=[ethane_gomc], n_compounds=[1], box=[1, 1, 1]
         )
@@ -10023,7 +10033,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             1000,
             300,
-            ff_psf_pdb_file_directory='../Test',
+            ff_psf_pdb_file_directory="../Test",
             Restart=True,
             RestartCheckpoint=True,
             Coordinates_box_0=None,
@@ -10055,7 +10065,9 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["Structure_box_0"] = True
                     split_line = line.split()
                     assert split_line[1] == "0"
-                    assert split_line[2] == "../test_files_1/NVT_toluene_box_0.psf"
+                    assert (
+                        split_line[2] == "../test_files_1/NVT_toluene_box_0.psf"
+                    )
 
                 if line.startswith("Coordinates 1 "):
                     variables_read_dict["Coordinates_box_1"] = True
@@ -10067,7 +10079,9 @@ class TestGOMCControlFileWriter(BaseTest):
                     variables_read_dict["Structure_box_1"] = True
                     split_line = line.split()
                     assert split_line[1] == "1"
-                    assert split_line[2] == "../test_files_2/NVT_toluene_box_1.psf"
+                    assert (
+                        split_line[2] == "../test_files_2/NVT_toluene_box_1.psf"
+                    )
 
         assert variables_read_dict == {
             "Coordinates_box_0": True,
@@ -10097,16 +10111,14 @@ class TestGOMCControlFileWriter(BaseTest):
             "GEMC_NVT",
             1000,
             300,
-            ff_psf_pdb_file_directory='../Test',
+            ff_psf_pdb_file_directory="../Test",
             Restart=True,
             RestartCheckpoint=True,
             check_input_files_exist=False,
             input_variables_dict={},
         )
 
-        with open(
-            "test_restarting_pdb_psf_GEMC_NVT.conf", "r"
-        ) as fp:
+        with open("test_restarting_pdb_psf_GEMC_NVT.conf", "r") as fp:
             variables_read_dict = {
                 "Coordinates_box_0": False,
                 "Structure_box_0": False,

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,19 +6,19 @@ message = Bump to version {new_version}
 tag_name = {new_version}
 
 [coverage:run]
-omit = 
+omit =
 	mbuild/examples/*
 	mbuild/tests/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
-	
+
 	if 0:
 	if __name__ == .__main__.:
 	def __repr__
 	except ImportError
-omit = 
+omit =
 	mbuild/examples/*
 	mbuild/tests/*
 


### PR DESCRIPTION
### PR Summary:

- Added functionality and tests add the ability to change the path of the  FF, psf, and pdb files written in the GOMC control file writer.  This includes a default check to see if the FF, psf, and pdb files exist in the specified path, but this can also be overridden.  This will allow many simulations to be run from 1 existing system build and FF file.  

- Added the ability to add the binCoordinates, extendedSystem, and binVelocities for restarting the simulation.  
The restart and RestartCheckpoint were moved to the required variables.  The existence of these files is also checked if the control file writer fails and the "check_input_files_exist" is True (default=True).  Note: to restart a simulation the Charmm object for that system must be build again, but the **ff, psf, and pdb files do not need to be created from the Charm object.**  The Charmm object still needs to be used in writing a GOMC control file, as it includes many checks which are used when writing the GOMC control file.

- 1 or more functions were deleted from the gomc_conf_writer.py file, as they were not used anywhere in the code.

- The "OutMolNumber" variable is wrong and changed to the correct "OutMolNum" variable. 

Example systems for NVT and GEMC-NVT are provided below to show the new features. Please see the following python files:
- gomc_writer_examples/GEMC_NVT/build_GEMC_NVT_gomc_sim.py 
- gomc_writer_examples/NVT/build_NVT_gomc_sim.py

[gomc_writer_examples.zip](https://github.com/mosdef-hub/mbuild/files/6920210/gomc_writer_examples.zip)


### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
