### PR TITLE
Migrate azure pipeline environment creation to use mamba instead of conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,10 @@ RUN conda update conda -yq && \
 	conda config --set always_yes yes --set changeps1 no && \
 	. /opt/conda/etc/profile.d/conda.sh && \
     sed -i -E "s/python.*$/python="$(PY_VERSION)"/" environment-dev.yml && \
-	conda env create nomkl --file environment-dev.yml && \
+  conda install -c conda-forge mamba && \
+	mamba env create nomkl --file environment-dev.yml && \
 	conda activate mbuild-dev && \
-	conda install -c conda-forge nomkl jupyter && \
+	mamba install -c conda-forge nomkl jupyter && \
     python setup.py install && \
 	echo "source activate mbuild-dev" >> \
 	/home/anaconda/.profile && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
               conda install -c conda-forge mamba
               conda update --all
               git clone https://github.com/mosdef-hub/foyer.git
-              mamba env create -f environment-dev.yml
+              mamba env create --name bleeding -f environment-dev.yml
               source activate bleeding
               pip install -e .
               cd foyer

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,11 +117,10 @@ stages:
           - script: |
               conda update -c defaults conda
               conda update conda -yq
-              conda install -c conda-forge mamba
               sed -i -E 's/python.*$/python='$(python.version)'/' environment-win.yml
-              mamba env create -f environment-win.yml
+              conda env create -f environment-win.yml
               call activate mbuild-dev
-            displayName: Create Conda env, Install mamba, Activate, Install dependencies
+            displayName: Create Conda env, Activate, Install dependencies
 
           - script: |
               call activate mbuild-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,9 +65,12 @@ stages:
             displayName: Set conda config
 
           - bash: |
-              conda update -c defaults conda
-              conda update --all
               conda install -c conda-forge mamba
+            displayName: Install mamba
+
+          - bash: |
+              mamba update -c defaults conda
+              mamba update --all
               sed -i -E 's/python.*$/python='$(python.version)'/' environment-dev.yml
               mamba env create -f environment-dev.yml
               source activate mbuild-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,15 +156,29 @@ stages:
               sed -iE 's/python.*$/python=3.8/' combine.yml
               sed -iE '/mbuild/d' combine.yml
               sed -iE '/ foyer/d' combine.yml
-              mamba env create -n bleeding -f combine.yml
-              source activate bleeding
+              mamba env create -n bleeding-mamba -f combine.yml
+              conda env create -n bleeding-conda -f combine.yml
+              source activate bleeding-mamba
+              pip install -e .
+              cd foyer
+              pip install -e .
+              echo "LISTING mamba env"
+              conda list
+              echo "DONE LISTING mamba env"
+
+              source activate bleeding-conda
+              echo "LISTING conda env"
+              conda list
+              echo "DONE LISTING conda env"
               pip install -e .
               cd foyer
               pip install -e .
             displayName: Create a new bleeding test environment with mamba
 
           - bash: |
-              source activate bleeding
+              source activate bleeding-mamba
+              python -m pytest -v --cov=mbuild --cov-report=html --color=yes --pyargs mbuild
+              source activate bleeding-conda
               python -m pytest -v --cov=mbuild --cov-report=html --color=yes --pyargs mbuild
             displayName: Run Tests
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ stages:
 
           - bash: |
               source activate mbuild-dev
-              python -m pytest -v --cov=mbuild --cov-report=html --pyargs mbuild
+              python -m pytest -v --cov=mbuild --cov-report=html --color=yes --pyargs mbuild
             displayName: Run Tests
 
           - bash: |
@@ -133,7 +133,7 @@ stages:
 
           - script: |
               call activate mbuild-dev
-              python -m pytest -v --cov=mbuild --cov-report=html --pyargs mbuild
+              python -m pytest -v --cov=mbuild --cov-report=html --color=yes --pyargs mbuild
             displayName: Run Tests
 
       - job: LinuxBleedingFoyer
@@ -150,36 +150,17 @@ stages:
               conda update -c defaults conda
               conda install -c conda-forge mamba
               conda update --all
-              pip install conda-merge
               git clone https://github.com/mosdef-hub/foyer.git
-              conda-merge environment-dev.yml foyer/environment-dev.yml > combine.yml
-              sed -iE 's/python.*$/python=3.8/' combine.yml
-              sed -iE '/mbuild/d' combine.yml
-              sed -iE '/ foyer/d' combine.yml
-              mamba env create -n bleeding-mamba -f combine.yml
-              conda env create -n bleeding-conda -f combine.yml
-              source activate bleeding-mamba
+              mamba env create -n -f environment-dev.yml
+              source activate bleeding
               pip install -e .
               cd foyer
-              pip install -e .
-              echo "LISTING mamba env"
-              conda list
-              echo "DONE LISTING mamba env"
-
-              source activate bleeding-conda
-              echo "LISTING conda env"
-              conda list
-              echo "DONE LISTING conda env"
-              cd ..
-              pip install -e .
-              cd foyer
+              mamba env update --name bleeding --file environment.yml
               pip install -e .
             displayName: Create a new bleeding test environment with mamba
 
           - bash: |
-              source activate bleeding-mamba
-              python -m pytest -v --cov=mbuild --cov-report=html --color=yes --pyargs mbuild
-              source activate bleeding-conda
+              source activate bleeding
               python -m pytest -v --cov=mbuild --cov-report=html --color=yes --pyargs mbuild
             displayName: Run Tests
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,6 +170,7 @@ stages:
               echo "LISTING conda env"
               conda list
               echo "DONE LISTING conda env"
+              cd ..
               pip install -e .
               cd foyer
               pip install -e .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,7 @@ stages:
               pip install conda-merge
               git clone https://github.com/mosdef-hub/foyer.git
               conda-merge environment-dev.yml foyer/environment-dev.yml > combine.yml
-              sed -iE 's/python.*$/python=3.7/' combine.yml
+              sed -iE 's/python.*$/python=3.8/' combine.yml
               sed -iE '/mbuild/d' combine.yml
               sed -iE '/ foyer/d' combine.yml
               mamba env create -n bleeding -f combine.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
               conda install -c conda-forge mamba
               conda update --all
               git clone https://github.com/mosdef-hub/foyer.git
-              mamba env create -n -f environment-dev.yml
+              mamba env create -f environment-dev.yml
               source activate bleeding
               pip install -e .
               cd foyer

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,7 +165,7 @@ stages:
 
           - bash: |
               source activate bleeding
-              python -m pytest -v --cov=mbuild --cov-report=html --pyargs mbuild
+              python -m pytest -v --cov=mbuild --cov-report=html --color=yes --pyargs mbuild
             displayName: Run Tests
 
   - stage: Docker

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,11 +67,12 @@ stages:
           - bash: |
               conda update -c defaults conda
               conda update --all
+              conda install -c conda-forge mamba
               sed -i -E 's/python.*$/python='$(python.version)'/' environment-dev.yml
-              conda env create -f environment-dev.yml
+              mamba env create -f environment-dev.yml
               source activate mbuild-dev
               pip install -e .
-            displayName: Create Conda env, Activate, Install dependencies, Install Branch
+            displayName: Create Conda env, Install mamba, Activate, Install dependencies, Install Branch
 
           - bash: |
               source activate mbuild-dev
@@ -116,10 +117,11 @@ stages:
           - script: |
               conda update -c defaults conda
               conda update conda -yq
+              conda install -c conda-forge mamba
               sed -i -E 's/python.*$/python='$(python.version)'/' environment-win.yml
-              conda env create -f environment-win.yml
+              mamba env create -f environment-win.yml
               call activate mbuild-dev
-            displayName: Create Conda env, Activate, Install dependencies
+            displayName: Create Conda env, Install mamba, Activate, Install dependencies
 
           - script: |
               call activate mbuild-dev
@@ -144,6 +146,7 @@ stages:
           - bash: |
               conda config --set always_yes yes --set changeps1 no
               conda update -c defaults conda
+              conda install -c conda-forge mamba
               conda update --all
               pip install conda-merge
               git clone https://github.com/mosdef-hub/foyer.git
@@ -151,12 +154,12 @@ stages:
               sed -iE 's/python.*$/python=3.7/' combine.yml
               sed -iE '/mbuild/d' combine.yml
               sed -iE '/ foyer/d' combine.yml
-              conda env create -n bleeding -f combine.yml
+              mamba env create -n bleeding -f combine.yml
               source activate bleeding
               pip install -e .
               cd foyer
               pip install -e .
-            displayName: Create a new bleeding test environment
+            displayName: Create a new bleeding test environment with mamba
 
           - bash: |
               source activate bleeding

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -7,7 +7,7 @@ from mbuild.tests.base_test import BaseTest
 from mbuild.utils.io import get_fn, has_foyer
 
 
-@pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+# @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
 class TestLammpsData(BaseTest):
     def test_save(self, ethane):
         ethane.save(filename="ethane.lammps")
@@ -36,7 +36,7 @@ class TestLammpsData(BaseTest):
                     else:
                         assert "# {}".format(pair_coeff_label) in line
 
-    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_save_charmm(self):
         from foyer import Forcefield
 
@@ -74,7 +74,7 @@ class TestLammpsData(BaseTest):
         assert found_angles
         assert found_dihedrals
 
-    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_singleterm_charmm(self):
         from foyer import Forcefield
 
@@ -107,7 +107,7 @@ class TestLammpsData(BaseTest):
                 pass
         assert found_dihedrals
 
-    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_charmm_improper(self):
         from foyer import Forcefield
 
@@ -145,7 +145,7 @@ class TestLammpsData(BaseTest):
                 found_impropers = True
         assert found_impropers
 
-    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_amber(self):
         from foyer import Forcefield
 
@@ -187,7 +187,7 @@ class TestLammpsData(BaseTest):
         assert found_dihedrals
         assert found_impropers
 
-    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.parametrize("unit_style", ["real", "lj"])
     def test_save_box(self, ethane, unit_style):
         box = mb.Box(

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -7,7 +7,7 @@ from mbuild.tests.base_test import BaseTest
 from mbuild.utils.io import get_fn, has_foyer
 
 
-# @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+@pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
 class TestLammpsData(BaseTest):
     def test_save(self, ethane):
         ethane.save(filename="ethane.lammps")
@@ -36,7 +36,7 @@ class TestLammpsData(BaseTest):
                     else:
                         assert "# {}".format(pair_coeff_label) in line
 
-    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_save_charmm(self):
         from foyer import Forcefield
 
@@ -74,7 +74,7 @@ class TestLammpsData(BaseTest):
         assert found_angles
         assert found_dihedrals
 
-    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_singleterm_charmm(self):
         from foyer import Forcefield
 
@@ -107,7 +107,7 @@ class TestLammpsData(BaseTest):
                 pass
         assert found_dihedrals
 
-    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_charmm_improper(self):
         from foyer import Forcefield
 
@@ -145,7 +145,7 @@ class TestLammpsData(BaseTest):
                 found_impropers = True
         assert found_impropers
 
-    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_amber(self):
         from foyer import Forcefield
 
@@ -187,7 +187,7 @@ class TestLammpsData(BaseTest):
         assert found_dihedrals
         assert found_impropers
 
-    #    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
+    @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     @pytest.mark.parametrize("unit_style", ["real", "lj"])
     def test_save_box(self, ethane, unit_style):
         box = mb.Box(

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,19 +6,19 @@ message = Bump to version {new_version}
 tag_name = {new_version}
 
 [coverage:run]
-omit = 
+omit =
 	mbuild/examples/*
 	mbuild/tests/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
-	
+
 	if 0:
 	if __name__ == .__main__.:
 	def __repr__
 	except ImportError
-omit = 
+omit =
 	mbuild/examples/*
 	mbuild/tests/*
 


### PR DESCRIPTION
### PR Summary:
Previously, all conda environment creations use `conda` for the
dependency resolution, which is notoriously slower than `mamba`'s
implementation.

This can have a noticeable impact on run times during CI as well as
building docker images. Mamba has replaced conda in our dockerfile as
well as our azurepipelines.yml file.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
