### PR TITLE
Allow compound.energy_minimize to use constraints

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1584,8 +1584,8 @@ class Compound(object):
             Scales epsilon (1 is completely on)
             For _energy_minimize_openmm
         constraints : str, optional, default=None
-            Scales epsilon (1 is completely on)
-            For _energy_minimize_openmm
+            Specify constraints on the molecule to minimize, options are:
+            "HBonds", "AllBonds", "HAngles"
 
         References
         ----------

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1521,16 +1521,6 @@ class Compound(object):
             particle.pos += (np.random.rand(3) - 0.5) / 100
         self._update_port_locations(xyz_init)
 
-    def energy_minimization(
-        self, forcefield="UFF", steps=1000, **kwargs
-    ):  # noqa: D102
-        raise RemovedFuncError(
-            "Compound.energy_minimization()",
-            "Compound.energy_minimize()",
-            "0.8.1",
-            "0.11.0",
-        )
-
     def energy_minimize(self, forcefield="UFF", steps=1000, **kwargs):
         """Perform an energy minimization on a Compound.
 
@@ -1583,9 +1573,10 @@ class Compound(object):
         scale_nonbonded : float, optional, default=1
             Scales epsilon (1 is completely on)
             For _energy_minimize_openmm
-        constraints : str, optional, default=None
+        constraints : str, optional, default="AllBonds"
             Specify constraints on the molecule to minimize, options are:
-            "HBonds", "AllBonds", "HAngles"
+            None, "HBonds", "AllBonds", "HAngles"
+            For _energy_minimize_openmm
 
         References
         ----------
@@ -1693,7 +1684,7 @@ class Compound(object):
         scale_angles=1,
         scale_torsions=1,
         scale_nonbonded=1,
-        constraints=None,
+        constraints="AllBonds",
     ):
         """Perform energy minimization using OpenMM.
 
@@ -1718,9 +1709,9 @@ class Compound(object):
             Scales the torsional force constants (1 is completely on)
         scale_nonbonded : float, optional, default=1
             Scales epsilon (1 is completely on)
-        constraints : str, optional, default=None
+        constraints : str, optional, default="AllBonds"
             Specify constraints on the molecule to minimize, options are:
-            "HBonds", "AllBonds", "HAngles"
+            None, "HBonds", "AllBonds", "HAngles"
 
         Notes
         -----

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1037,9 +1037,6 @@ class TestCompound(BaseTest):
     @pytest.mark.skipif(
         not has_openbabel, reason="Open Babel package not installed"
     )
-    def test_energy_minimization(self, octane):
-        with pytest.raises(RemovedFuncError):
-            octane.energy_minimization()
 
     @pytest.mark.skipif(
         not has_openbabel, reason="Open Babel package not installed"

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1120,7 +1120,9 @@ class TestCompound(BaseTest):
         octane.energy_minimize(forcefield="oplsaa")
 
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
-    @pytest.mark.parametrize("constraints", ["AllBonds", "HBonds", "HAngles", None])
+    @pytest.mark.parametrize(
+        "constraints", ["AllBonds", "HBonds", "HAngles", None]
+    )
     def test_energy_minimize_openmm_constraints(self, octane, constraints):
         octane.energy_minimize(forcefield="oplsaa", constraints=constraints)
 

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1037,7 +1037,6 @@ class TestCompound(BaseTest):
     @pytest.mark.skipif(
         not has_openbabel, reason="Open Babel package not installed"
     )
-
     @pytest.mark.skipif(
         not has_openbabel, reason="Open Babel package not installed"
     )

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1120,6 +1120,15 @@ class TestCompound(BaseTest):
         octane.energy_minimize(forcefield="oplsaa")
 
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    @pytest.mark.parametrize("constraints", ["AllBonds", "HBonds", "HAngles", None])
+    def test_energy_minimize_openmm_constraints(self, octane, constraints):
+        octane.energy_minimize(forcefield="oplsaa", constraints=constraints)
+
+    def test_energy_minimize_openmm_invalid_constraints(self, octane):
+        with pytest.raises(ValueError):
+            octane.energy_minimize(forcefield="oplsaa", constraints="boo")
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_energy_minimize_openmm_xml(self, octane):
         octane.energy_minimize(forcefield=get_fn("small_oplsaa.xml"))
 


### PR DESCRIPTION
### PR Summary:
Previously, when using openmm to energy minimize a `Compound`, there was
no way to use bond constraints during those steps.

This PR adds in the ability for the user to use openMM to constrain
either: 'AllBonds', 'HBonds', or 'HAngles' according to the
[parmed.structure.createSystem](https://parmed.github.io/ParmEd/html/api/parmed/parmed.structure.html#parmed.structure.Structure.createSystem)

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?

Closes #940 