### PR TITLE
Update dockerimage information and entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM continuumio/miniconda3:4.8.2-alpine AS builder
 EXPOSE 8888
 
 LABEL maintainer.name="mosdef-hub"\
-      maintainer.url="https://mosdef.org"
+  maintainer.url="https://mosdef.org"
 
 ENV PATH /opt/conda/bin:$PATH
 
@@ -15,21 +15,21 @@ ADD . /mbuild
 WORKDIR /mbuild
 
 RUN conda update conda -yq && \
-	conda config --set always_yes yes --set changeps1 no && \
-	. /opt/conda/etc/profile.d/conda.sh && \
-    sed -i -E "s/python.*$/python="$(PY_VERSION)"/" environment-dev.yml && \
+  conda config --set always_yes yes --set changeps1 no && \
+  . /opt/conda/etc/profile.d/conda.sh && \
+  sed -i -E "s/python.*$/python="$(PY_VERSION)"/" environment-dev.yml && \
   conda install -c conda-forge mamba && \
-	mamba env create nomkl --file environment-dev.yml && \
-	conda activate mbuild-dev && \
-	mamba install -c conda-forge nomkl jupyter && \
-    python setup.py install && \
-	echo "source activate mbuild-dev" >> \
-	/home/anaconda/.profile && \
-	conda clean -afy && \
-	mkdir /home/anaconda/data && \
-	chown -R anaconda:anaconda /mbuild && \
-	chown -R anaconda:anaconda /opt && \
-	chown -R anaconda:anaconda /home/anaconda
+  mamba env create nomkl --file environment-dev.yml && \
+  conda activate mbuild-dev && \
+  mamba install -c conda-forge nomkl jupyter python=${PY_VERSION} && \
+  python setup.py install && \
+  echo "source activate mbuild-dev" >> \
+  /home/anaconda/.profile && \
+  conda clean -afy && \
+  mkdir /home/anaconda/data && \
+  chown -R anaconda:anaconda /mbuild && \
+  chown -R anaconda:anaconda /opt && \
+  chown -R anaconda:anaconda /home/anaconda
 
 
 WORKDIR /home/anaconda

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN conda update conda -yq && \
   conda install -c conda-forge mamba && \
   mamba env create nomkl --file environment-dev.yml && \
   conda activate mbuild-dev && \
-  mamba install -c conda-forge nomkl jupyter python=$(PY_VERSION) && \
+  mamba install -c conda-forge nomkl jupyter python="$PY_VERSION" && \
   python setup.py install && \
   echo "source activate mbuild-dev" >> \
   /home/anaconda/.profile && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN conda update conda -yq && \
   conda install -c conda-forge mamba && \
   mamba env create nomkl --file environment-dev.yml && \
   conda activate mbuild-dev && \
-  mamba install -c conda-forge nomkl jupyter python=${PY_VERSION} && \
+  mamba install -c conda-forge nomkl jupyter python=$(PY_VERSION) && \
   python setup.py install && \
   echo "source activate mbuild-dev" >> \
   /home/anaconda/.profile && \

--- a/devtools/docker-entrypoint.sh
+++ b/devtools/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 . /opt/conda/etc/profile.d/conda.sh
 conda activate base
-conda activate mbuild-docker
+conda activate mbuild-dev
 
 if [ "$@" == "jupyter" ]; then
 	jupyter notebook --no-browser --notebook-dir /home/anaconda/data --ip="0.0.0.0"


### PR DESCRIPTION
While working with the latest mbuild docker image, I noticed that the
entrypoint script would fail due to an incorrect conda environement
name.

I also noticed in some cases where python would be updated to 3.9
instead of being fixed at 3.7. I think it is due to the second line
where we install jupyter with nomkl after we create the environment with
the environment.yml file. These have been updated and fixed now.
