### PR TITLE
Add windows installation note

### DIFF
--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -18,6 +18,11 @@ after which you can simply install without specifying the channels::
     The order in which channels are added matters: ``conda-forge`` should be the highest priority as a result of being added last. In your ``.condarc`` file, it should be listed first.
 
 .. note::
+    Because ``packmol`` binaries are unavailable for windows from ``conda-forge`` channel to use mbuild with conda in a Windows system requires ``omnia`` channel. Use the following command to use mbuild with conda in a Windows system
+
+        $ conda install -c conda-forge -c omnia mbuild
+
+.. note::
     The `MDTraj website <http://mdtraj.org/1.9.3/new_to_python.html>`_ makes a
     nice case for using Python and in particular the
     `Anaconda scientific python distribution <https://www.anaconda.com/products/individual>`_

--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -18,7 +18,7 @@ after which you can simply install without specifying the channels::
     The order in which channels are added matters: ``conda-forge`` should be the highest priority as a result of being added last. In your ``.condarc`` file, it should be listed first.
 
 .. note::
-    Because ``packmol`` binaries are unavailable for windows from ``conda-forge`` channel to use mbuild with conda in a Windows system requires ``omnia`` channel. Use the following command to use mbuild with conda in a Windows system
+    Because ``packmol`` binaries are unavailable for windows from ``conda-forge`` channel to use mbuild with conda in a Windows system requires ``omnia`` channel. Use the following command to use mbuild with conda in a Windows system::
 
         $ conda install -c conda-forge -c omnia mbuild
 

--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -18,7 +18,7 @@ after which you can simply install without specifying the channels::
     The order in which channels are added matters: ``conda-forge`` should be the highest priority as a result of being added last. In your ``.condarc`` file, it should be listed first.
 
 .. note::
-    Because ``packmol`` binaries are unavailable for windows from ``conda-forge`` channel to use mbuild with conda in a Windows system requires ``omnia`` channel. Use the following command to use mbuild with conda in a Windows system::
+    Because ``packmol`` binaries are unavailable for windows from ``conda-forge`` channel, to use mbuild with conda in a Windows system requires the ``omnia`` channel. Use the following command to use ``mbuild`` with conda in a Windows system::
 
         $ conda install -c conda-forge -c omnia mbuild
 


### PR DESCRIPTION
### PR Summary:
I am constrained to using a windows machine (for a few weeks). While I tried to install `mbuild` using the installation instructions, `conda` couldn't find appropriate executable for `packmol`. This PR adds instruction to install mbuild on Windows in our docs.
