### PR TITLE
Change default hoomd `r_cut` values to 2.5

### DIFF
--- a/mbuild/formats/hoomd_forcefield.py
+++ b/mbuild/formats/hoomd_forcefield.py
@@ -22,7 +22,7 @@ def create_hoomd_forcefield(
     ref_distance=1.0,
     ref_mass=1.0,
     ref_energy=1.0,
-    r_cut=1.2,
+    r_cut=2.5,
     auto_scale=False,
     snapshot_kwargs={},
     pppm_kwargs={"Nx": 8, "Ny": 8, "Nz": 8, "order": 4},
@@ -40,7 +40,7 @@ def create_hoomd_forcefield(
         Reference mass for conversion to reduced units
     ref_energy : float, optional, default=1.0
         Reference energy for conversion to reduced units
-    r_cut : float, optional, default 1.2
+    r_cut : float, optional, default 2.5
         Cutoff radius, in reduced units
     auto_scale : bool, optional, default=False
         Automatically use largest sigma value as ref_distance,
@@ -167,7 +167,7 @@ def create_hoomd_forcefield(
     return snapshot, hoomd_forcefield, ref_values
 
 
-def _init_hoomd_lj(structure, nl, r_cut=1.2, ref_distance=1.0, ref_energy=1.0):
+def _init_hoomd_lj(structure, nl, r_cut=2.5, ref_distance=1.0, ref_energy=1.0):
     """LJ parameters."""
     # Identify the unique atom types before setting
     atom_type_params = {}
@@ -230,7 +230,7 @@ def _init_hoomd_lj(structure, nl, r_cut=1.2, ref_distance=1.0, ref_energy=1.0):
 
 
 def _init_hoomd_qq(
-    structure, nl, snapshot, Nx=1, Ny=1, Nz=1, order=4, r_cut=1.2
+    structure, nl, snapshot, Nx=1, Ny=1, Nz=1, order=4, r_cut=2.5
 ):
     """Charge interactions."""
     num_charged = np.sum(snapshot.particles.charge[:] != 0)
@@ -245,7 +245,7 @@ def _init_hoomd_qq(
 
 
 def _init_hoomd_14_pairs(
-    structure, nl, snapshot, r_cut=1.2, ref_distance=1.0, ref_energy=1.0
+    structure, nl, snapshot, r_cut=2.5, ref_distance=1.0, ref_energy=1.0
 ):
     """Special_pairs to handle 14 scaling.
 

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -108,6 +108,13 @@ def create_hoomd_simulation(
 
     hoomd_objects = []  # Potential adaptation for Hoomd v3 API
 
+    pair_coeffs = list(
+        set((a.type, a.epsilon, a.sigma) for a in structure.atoms)
+    )
+    max_sigma = max(pair_coeffs, key=operator.itemgetter(2))[2]
+    # Scale r_cut by sigma
+    r_cut *= max_sigma
+
     if auto_scale:
         if not all([i == 1 for i in (ref_distance, ref_energy, ref_mass)]):
             warnings.warn(
@@ -116,11 +123,8 @@ def create_hoomd_simulation(
             )
 
         ref_mass = max([atom.mass for atom in structure.atoms])
-        pair_coeffs = list(
-            set((a.type, a.epsilon, a.sigma) for a in structure.atoms)
-        )
         ref_energy = max(pair_coeffs, key=operator.itemgetter(1))[1]
-        ref_distance = max(pair_coeffs, key=operator.itemgetter(2))[2]
+        ref_distance = max_sigma
 
     ReferenceValues = namedtuple("ref_values", ["distance", "mass", "energy"])
     ref_values = ReferenceValues(ref_distance, ref_mass, ref_energy)

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -40,16 +40,18 @@ def create_hoomd_simulation(
     structure : parmed.Structure
         ParmEd Structure object
     ref_distance : float, optional, default=1.0
-        Reference distance for conversion to reduced units
+        Reference distance for unit conversion (from Angstrom)
     ref_mass : float, optional, default=1.0
-        Reference mass for conversion to reduced units
+        Reference mass for unit conversion (from Dalton)
     ref_energy : float, optional, default=1.0
-        Reference energy for conversion to reduced units
+        Reference energy for unit conversion (from kcal/mol)
     r_cut : float, optional, default 2.5
-        Cutoff radius, in reduced units
+        Cutoff radius in sigma units (where sigma is the largest sigma value
+        from the forcefield)
     auto_scale : bool, optional, default=False
-        Automatically use largest sigma value as ref_distance, largest mass
-        value as ref_mass, and largest epsilon value as ref_energy
+        Scale to reduced units by automatically using the largest sigma value
+        as ref_distance, largest mass value as ref_mass, and largest epsilon
+        value as ref_energy
     snapshot_kwargs : dict
         Kwargs to pass to to_hoomdsnapshot
     pppm_kwargs : dict

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -165,7 +165,11 @@ def create_hoomd_simulation(
     if structure.adjusts:
         print("Processing 1-4 interactions, adjusting neighborlist exclusions")
         lj_14, qq_14 = _init_hoomd_14_pairs(
-            structure, nl, ref_distance=ref_distance, ref_energy=ref_energy
+            structure,
+            nl,
+            r_cut,
+            ref_distance=ref_distance,
+            ref_energy=ref_energy,
         )
         hoomd_objects.append(lj_14)
         hoomd_objects.append(qq_14)

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -25,7 +25,7 @@ def create_hoomd_simulation(
     ref_distance=1.0,
     ref_mass=1.0,
     ref_energy=1.0,
-    r_cut=1.2,
+    r_cut=2.5,
     auto_scale=False,
     snapshot_kwargs={},
     pppm_kwargs={"Nx": 8, "Ny": 8, "Nz": 8, "order": 4},
@@ -45,7 +45,7 @@ def create_hoomd_simulation(
         Reference mass for conversion to reduced units
     ref_energy : float, optional, default=1.0
         Reference energy for conversion to reduced units
-    r_cut : float, optional, default 1.2
+    r_cut : float, optional, default 2.5
         Cutoff radius, in reduced units
     auto_scale : bool, optional, default=False
         Automatically use largest sigma value as ref_distance, largest mass
@@ -187,7 +187,7 @@ def create_hoomd_simulation(
     return hoomd_objects, ref_values
 
 
-def _init_hoomd_lj(structure, nl, r_cut=1.2, ref_distance=1.0, ref_energy=1.0):
+def _init_hoomd_lj(structure, nl, r_cut=2.5, ref_distance=1.0, ref_energy=1.0):
     """LJ parameters."""
     # Identify the unique atom types before setting
     atom_type_params = {}
@@ -249,7 +249,7 @@ def _init_hoomd_lj(structure, nl, r_cut=1.2, ref_distance=1.0, ref_energy=1.0):
     return lj
 
 
-def _init_hoomd_qq(structure, nl, Nx=1, Ny=1, Nz=1, order=4, r_cut=1.2):
+def _init_hoomd_qq(structure, nl, Nx=1, Ny=1, Nz=1, order=4, r_cut=2.5):
     """Charge interactions."""
     charged = hoomd.group.charged()
     if len(charged) == 0:
@@ -262,7 +262,7 @@ def _init_hoomd_qq(structure, nl, Nx=1, Ny=1, Nz=1, order=4, r_cut=1.2):
 
 
 def _init_hoomd_14_pairs(
-    structure, nl, r_cut=1.2, ref_distance=1.0, ref_energy=1.0
+    structure, nl, r_cut=2.5, ref_distance=1.0, ref_energy=1.0
 ):
     """Special_pairs to handle 14 scalings.
 

--- a/mbuild/formats/hoomd_simulation.py
+++ b/mbuild/formats/hoomd_simulation.py
@@ -109,6 +109,12 @@ def create_hoomd_simulation(
     hoomd_objects = []  # Potential adaptation for Hoomd v3 API
 
     if auto_scale:
+        if not all([i == 1 for i in (ref_distance, ref_energy, ref_mass)]):
+            warnings.warn(
+                "Autoscale option selected--provided reference values will not "
+                "be used."
+            )
+
         ref_mass = max([atom.mass for atom in structure.atoms])
         pair_coeffs = list(
             set((a.type, a.epsilon, a.sigma) for a in structure.atoms)

--- a/mbuild/tests/test_hoomd.py
+++ b/mbuild/tests/test_hoomd.py
@@ -203,13 +203,13 @@ class TestHoomdSimulation(BaseTest):
         from mbuild.formats.hoomd_simulation import create_hoomd_simulation
 
         with pytest.raises(ValueError):
-            create_hoomd_simulation("fake_object")
+            create_hoomd_simulation("fake_object", 2)
 
     def test_compound_to_hoomdsimulation(self, ethane):
         from mbuild.formats.hoomd_simulation import create_hoomd_simulation
 
         with pytest.raises(ValueError):
-            create_hoomd_simulation(ethane)
+            create_hoomd_simulation(ethane, 2.5)
 
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_structure_to_hoomdsimulation(self, ethane):
@@ -222,7 +222,7 @@ class TestHoomdSimulation(BaseTest):
         structure = ff.apply(ethane)
         sim = hoomd.context.SimulationContext()
         with sim:
-            create_hoomd_simulation(structure)
+            create_hoomd_simulation(structure, 2.5)
 
             sim_forces = hoomd.context.current.forces
             pair_force = import_("hoomd.md.pair")
@@ -256,7 +256,7 @@ class TestHoomdSimulation(BaseTest):
         structure.box = [10, 10, 10, 90, 90, 90]
         sim = hoomd.context.SimulationContext()
         with sim:
-            create_hoomd_simulation(structure)
+            create_hoomd_simulation(structure, 2.5)
             sim_forces = hoomd.context.current.forces
             pair_force = import_("hoomd.md.pair")
 
@@ -280,7 +280,7 @@ class TestHoomdSimulation(BaseTest):
         sim = hoomd.context.SimulationContext()
         with sim:
             hoomd_obj, ref_vals = create_hoomd_simulation(
-                structure, restart=get_fn("restart.gsd")
+                structure, 2.5, restart=get_fn("restart.gsd")
             )
             sim_forces = hoomd.context.current.forces
             pair_force = import_("hoomd.md.pair")
@@ -299,7 +299,7 @@ class TestHoomdSimulation(BaseTest):
 
         with pytest.raises(ValueError):
             hoomd_simulation.create_hoomd_simulation(
-                ethane, nlist=hoomd.md.nlist.tree
+                ethane, 2.5, nlist=hoomd.md.nlist.tree
             )
 
 
@@ -312,13 +312,13 @@ class TestHoomdForcefield(BaseTest):
         from mbuild.formats.hoomd_forcefield import create_hoomd_forcefield
 
         with pytest.raises(ValueError):
-            create_hoomd_forcefield("fake_object")
+            create_hoomd_forcefield("fake_object", 2.5)
 
     def test_compound_to_hoomd_forcefield(self, ethane):
         from mbuild.formats.hoomd_forcefield import create_hoomd_forcefield
 
         with pytest.raises(ValueError):
-            create_hoomd_forcefield(ethane)
+            create_hoomd_forcefield(ethane, 2.5)
 
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_structure_to_hoomd_forcefield(self, ethane):
@@ -330,7 +330,7 @@ class TestHoomdForcefield(BaseTest):
         ff = Forcefield(name="oplsaa")
         structure = ff.apply(ethane)
 
-        snapshot, forces, ref_values = create_hoomd_forcefield(structure)
+        snapshot, forces, ref_values = create_hoomd_forcefield(structure, 2.5)
 
         assert isinstance(forces[0], hoomd.md.pair.LJ)
         assert isinstance(forces[1], hoomd.md.pair.Ewald)
@@ -355,7 +355,7 @@ class TestHoomdForcefield(BaseTest):
         structure = ff.apply(box)
         structure.box = [10, 10, 10, 90, 90, 90]
 
-        snapshot, forces, ref_values = create_hoomd_forcefield(structure)
+        snapshot, forces, ref_values = create_hoomd_forcefield(structure, 2.5)
 
         assert isinstance(forces[0], hoomd.md.pair.LJ)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,19 +6,19 @@ message = Bump to version {new_version}
 tag_name = {new_version}
 
 [coverage:run]
-omit = 
+omit =
 	mbuild/examples/*
 	mbuild/tests/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
-	
+
 	if 0:
 	if __name__ == .__main__.:
 	def __repr__
 	except ImportError
-omit = 
+omit =
 	mbuild/examples/*
 	mbuild/tests/*
 


### PR DESCRIPTION
### PR Summary:
The current default values for `r_cut` are 1.2 in both `hoomd_simulation.py` and `hoomd_forcefield.py`. Since these are in reduced units, this seems kind of small for an `r_cut` value. I believe the typical approach is to use `2.5` sigma or half the box length. It's easy enough for the user to change when calling these functions, but I feel like a more standard default value is needed.  

Please let me know what you think, or if I'm missing anything about why we'd prefer a default value of `1.2`

### PR Checklist
------------
 - [X] Includes appropriate unit test(s)
 - [X] Appropriate docstring(s) are added/updated
 - [X] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
