### PR TITLE
Update openmm references in energy_minimize

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ dependencies:
   - bump2version
   - codecov
   - ele
-  - foyer>=0.9.2
+  - foyer>=0.9.4
   - garnett>=0.7.1
   - gsd>=2
   - hoomd=2.9.6
@@ -16,7 +16,7 @@ dependencies:
   - numpy
   - openbabel>=3
   - packmol>=20
-  - parmed>=3.4.0
+  - parmed>=3.4.3
   - pip
   - pre-commit
   - protobuf

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -6,7 +6,7 @@ dependencies:
   - bump2version
   - codecov
   - ele
-  - foyer>=0.9.2
+  - foyer>=0.9.4
   - garnett>=0.7.1
   - gsd>=1.2
   - intermol
@@ -16,7 +16,7 @@ dependencies:
   - numpy
   - openbabel>=3.0.0
   - packmol=1!18.013
-  - parmed>=3.4.0
+  - parmed>=3.4.3
   - pip
   - pre-commit
   - protobuf

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - ele
   - numpy
   - packmol>=18
-  - parmed>=3.4.0
+  - parmed>=3.4.3
   - python<=3.8
   - rdkit
   - scipy

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1794,11 +1794,11 @@ class Compound(object):
         )
         to_parmed = ff.apply(to_parmed)
 
-        import simtk.unit as u
-        from simtk.openmm.app import AllBonds, HAngles, HBonds
-        from simtk.openmm.app.pdbreporter import PDBReporter
-        from simtk.openmm.app.simulation import Simulation
-        from simtk.openmm.openmm import LangevinIntegrator
+        import openmm.unit as u
+        from openmm.app import AllBonds, HAngles, HBonds
+        from openmm.app.pdbreporter import PDBReporter
+        from openmm.app.simulation import Simulation
+        from openmm.openmm import LangevinIntegrator
 
         if constraints:
             if constraints == "AllBonds":


### PR DESCRIPTION
### PR Summary:
Currently our unit tests are failing for master due to `simtk`
references that are incompatible with openmm >= 7.6.

This updates the references and should fix the failing tests.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
