### PR TITLE
Include moleculeID offset in lammpswriter

### DIFF
--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -43,6 +43,7 @@ def write_lammpsdata(
     use_rb_torsions=True,
     use_dihedrals=False,
     zero_dihedral_weighting_factor=False,
+    moleculeID_offset=1,
 ):
     """Output a LAMMPS data file.
 
@@ -89,6 +90,11 @@ def write_lammpsdata(
     zero_dihedral_weighting_factor:
         If True, will set weighting parameter to zero in CHARMM-style dihedrals.
         This should be True if the CHARMM dihedral style is used in non-CHARMM forcefields.
+    moleculeID_offset : int , optional, default=1
+        Since LAMMPS treats the MoleculeID as an additional set of information
+        to identify what molecule an atom belongs to, this currently
+        behaves as a residue id. This value needs to start at 1 to be
+        considered a real molecule.
 
     Notes
     -----
@@ -775,7 +781,7 @@ def write_lammpsdata(
                 atom_line.format(
                     index=i + 1,
                     type_index=unique_types.index(types[i]) + 1,
-                    zero=structure.atoms[i].residue.idx,
+                    zero=structure.atoms[i].residue.idx + moleculeID_offset,
                     charge=charges[i],
                     x=coords[0],
                     y=coords[1],

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -272,21 +272,26 @@ class TestLammpsData(BaseTest):
                     assert "# " + atom_style in line
 
     def test_resid(self, ethane, methane):
-        structure = ethane.to_parmed() + methane.to_parmed()
-        n_atoms = len(structure.atoms)
-        write_lammpsdata(structure, "compound.lammps")
-        res_list = list()
-        with open("compound.lammps", "r") as f:
-            for i, line in enumerate(f):
-                if "Atoms" in line:
-                    break
-        atom_lines = open("compound.lammps", "r").readlines()[
-            i + 2 : i + n_atoms + 2
-        ]
-        for line in atom_lines:
-            res_list.append(line.rstrip().split()[1])
-
-        assert set(res_list) == set(["1", "0"])
+        for offset in [0, 1]:
+            structure = ethane.to_parmed() + methane.to_parmed()
+            n_atoms = len(structure.atoms)
+            write_lammpsdata(
+                structure, "compound.lammps", moleculeID_offset=offset
+            )
+            res_list = list()
+            with open("compound.lammps", "r") as f:
+                for i, line in enumerate(f):
+                    if "Atoms" in line:
+                        break
+            atom_lines = open("compound.lammps", "r").readlines()[
+                i + 2 : i + n_atoms + 2
+            ]
+            for line in atom_lines:
+                res_list.append(line.rstrip().split()[1])
+            if offset == 0:
+                assert set(res_list) == set(["0", "1"])
+            else:
+                assert set(res_list) == set(["1", "2"])
 
     def test_box_bounds(self, ethane):
         from foyer import Forcefield

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from pytest import FixtureRequest
 
 import mbuild as mb
 from mbuild.formats.lammpsdata import write_lammpsdata
@@ -271,27 +272,24 @@ class TestLammpsData(BaseTest):
                 else:
                     assert "# " + atom_style in line
 
-    def test_resid(self, ethane, methane):
-        for offset in [0, 1]:
-            structure = ethane.to_parmed() + methane.to_parmed()
-            n_atoms = len(structure.atoms)
-            write_lammpsdata(
-                structure, "compound.lammps", moleculeID_offset=offset
-            )
-            res_list = list()
-            with open("compound.lammps", "r") as f:
-                for i, line in enumerate(f):
-                    if "Atoms" in line:
-                        break
-            atom_lines = open("compound.lammps", "r").readlines()[
-                i + 2 : i + n_atoms + 2
-            ]
-            for line in atom_lines:
-                res_list.append(line.rstrip().split()[1])
-            if offset == 0:
-                assert set(res_list) == set(["0", "1"])
-            else:
-                assert set(res_list) == set(["1", "2"])
+    @pytest.mark.parametrize(
+        "offset, expected_value", [(0, ("0", "1")), (1, ("1", "2"))]
+    )
+    def test_resid(self, offset, expected_value, ethane, methane):
+        structure = ethane.to_parmed() + methane.to_parmed()
+        n_atoms = len(structure.atoms)
+        write_lammpsdata(structure, "compound.lammps", moleculeID_offset=offset)
+        res_list = list()
+        with open("compound.lammps", "r") as f:
+            for i, line in enumerate(f):
+                if "Atoms" in line:
+                    break
+        atom_lines = open("compound.lammps", "r").readlines()[
+            i + 2 : i + n_atoms + 2
+        ]
+        for line in atom_lines:
+            res_list.append(line.rstrip().split()[1])
+        assert set(res_list) == set(expected_value)
 
     def test_box_bounds(self, ethane):
         from foyer import Forcefield


### PR DESCRIPTION
### PR Summary:
LAMMPS handles moleculeID's as an additional set of data to link atoms
with specific molecules (similar to residues in other engines).

However, there is a special case where the moleculeID is 0
>The molecule ID is a second identifier attached to an atom.
>Normally, it is a number from 1 to N, identifying which molecule the atom belongs to.
>It can be 0 if it is a non-bonded atom or if you don't care to keep track of molecule assignments.

In the lammpswriter case, the resid was always starting at 0, which was
treating the first molecule "residue" as a non-molecule.

Now, an additional flag `moleculeID_offset` will let the user change
this starting offset value if they want to use the previous starting
value of 0. The default behavior now is to start all IDs at 1.
### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?

closes #950 