### PR TITLE
Fix bug in mbuild clone

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2510,6 +2510,7 @@ class Compound(object):
         newone._check_if_contains_rigid_bodies = deepcopy(
             self._check_if_contains_rigid_bodies
         )
+        newone._periodicity = deepcopy(self._periodicity)
         newone._contains_rigid = deepcopy(self._contains_rigid)
         newone._rigid_id = deepcopy(self._rigid_id)
         newone._charge = deepcopy(self._charge)

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -306,6 +306,7 @@ class TestCompound(BaseTest):
 
     def test_clone_with_box(self, ethane):
         ethane.box = ethane.get_boundingbox()
+        ethane.periodicity = (True, True, False)
         ethane_clone = mb.clone(ethane)
         assert np.all(ethane.xyz == ethane_clone.xyz)
         assert np.all(

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -314,6 +314,7 @@ class TestCompound(BaseTest):
         )
         assert len(ethane.children) == len(ethane_clone.children)
         assert ethane_clone.mass == ethane.mass
+        assert ethane.periodicity == ethane_clone.periodicity
 
     def test_batch_add(self, ethane, h2o):
         compound = Compound()


### PR DESCRIPTION
### PR Summary:
Found a bug in `mb.clone()` where the periodicity of the original compound is not included in the cloning process. This PR add a line to also clone periodicity. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
