### PR TITLE
API Map generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,6 +78,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "numpydoc",
+    "autoapi.extension",
 ]
 
 # nbsphinx specific configuration
@@ -86,6 +87,14 @@ nbsphinx_input_prompt = "%s"
 nbsphinx_prompt_width = "1.1"
 html_scaled_image_link = False
 nbsphinx_allow_errors = False
+
+# autoapi specific configuration
+autoapi_dirs = ["../mbuild"]
+autoapi_root = "./autoapi"
+autoapi_ignore = ["*tests*"]
+autoapi_add_toctree_entry = False
+
+suppress_warnings = ["autoapi"]
 
 # Prolog: Displayed on top of the notebook
 

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -17,3 +17,4 @@ dependencies:
   - pip:
     - sphinxcontrib-svg2pdfconverter[CairoSVG]
     - cairosvg
+    - sphinx-autoapi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,3 +66,8 @@ The `MoSDeF <https://mosdef.org>`_ software is comprised the following packages:
 	reference/units
     	reference/citing_mbuild
     	reference/older_documentation
+
+.. toctree::
+    :caption: API Documentation
+
+    autoapi/mbuild/index


### PR DESCRIPTION
### PR Summary:
This is an effort to document the API for mbuid. Once ready and tested here, we can port the configuration to foyer and gmso. Using `sphinx-autoapi` to do this. 

Drafting it here for RTD testing as well as input from fellow @mosdef-hub/mosdef-contributors.