### PR TITLE
Remove bash uploader in favor of codecov uploader

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,9 @@ stages:
 
           - bash: |
               source activate test-environment
-              bash <(curl -s https://codecov.io/bash) -C $(Build.SourceVersion)
+              curl -Os https://uploader.codecov.io/latest/linux/codecov
+              chmod +x codecov
+              bash ./codecov -C $(Build.SourceVersion)
             condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.8' ) )
             displayName: Upload Coverage Report
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,17 +83,12 @@ stages:
             displayName: Run Tests
 
           - bash: |
-              source activate test-environment
-              bash <(curl -s https://codecov.io/bash) -C $(Build.SourceVersion)
-            condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.8' ) )
-            displayName: Upload Coverage Report
-
-          - bash: |
               source activate mbuild-dev
-              mamba update -c conda-forge/label/hoomd_dev -c conda-forge hoomd
-              python -m pytest -v --cov=mbuild --cov-report=html --color=yes mbuild/tests/test_hoomd.py
+              curl -Os https://uploader.codecov.io/latest/linux/codecov
+              chmod +x codecov
+              ./codecov -C $(Build.SourceVersion)
             condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.8' ) )
-            displayName: Run tests for hoomdv3
+            displayName: Upload Coverage Report (regular)
 
           - task: PublishCodeCoverageResults@1
             inputs:
@@ -104,12 +99,19 @@ stages:
             displayName: Publish Coverage Report
 
           - bash: |
-              source activate test-environment
+              source activate mbuild-dev
+              mamba update -c conda-forge/label/hoomd_dev -c conda-forge hoomd
+              python -m pytest -v --cov=mbuild --cov-report=html --color=yes mbuild/tests/test_hoomd.py
+            condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.8' ) )
+            displayName: Run tests for hoomdv3
+
+          - bash: |
+              source activate mbuild-dev
               curl -Os https://uploader.codecov.io/latest/linux/codecov
               chmod +x codecov
-              bash ./codecov -C $(Build.SourceVersion)
+              ./codecov -C $(Build.SourceVersion)
             condition: and( eq( variables['Agent.OS'], 'Linux' ), eq( variables['python.version'], '3.8' ) )
-            displayName: Upload Coverage Report
+            displayName: Upload Coverage Report (HoomdV3)
 
 
       - job: Windows_no_bleeding


### PR DESCRIPTION
### PR Summary:

https://docs.codecov.com/docs/about-the-codecov-bash-uploader#deprecation-notice-and-schedule 

Suggests that the bash uploader we use will be deprecated soon. This PR uses the recommended codecov uploader to upload coverage reports.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s): N/A
 - [ ] Appropriate docstring(s) are added/updated: N/A
 - [ ] Code is (approximately) PEP8 compliant: N/A
 - [ ] Issue(s) raised/addressed?: N/A
