### PR TITLE
Generate bonds with freud

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,8 @@ MOCK_MODULES = [
     "gsd",
     "gsd.hoomd",
     "gsd.fl",
+    "freud",
+    "freud.box",
 ]
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.Mock()

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -2,6 +2,7 @@ name: mbuild-docs
 channels:
   - conda-forge
 dependencies:
+  - freud
   - ipykernel
   - ipywidgets
   - mock

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,6 +6,7 @@ dependencies:
   - codecov
   - ele
   - foyer>=0.9.4
+  - freud
   - garnett>=0.7.1
   - gsd>=2
   - hoomd=2.9.6

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ dependencies:
   - codecov
   - ele
   - foyer>=0.9.4
-  - freud
+  - freud>=2.0.0
   - garnett>=0.7.1
   - gsd>=2
   - hoomd=2.9.6

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -7,6 +7,7 @@ dependencies:
   - codecov
   - ele
   - foyer>=0.9.4
+  - freud
   - garnett>=0.7.1
   - gsd>=1.2
   - intermol

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -7,7 +7,6 @@ dependencies:
   - codecov
   - ele
   - foyer>=0.9.4
-  - freud
   - garnett>=0.7.1
   - gsd>=1.2
   - intermol

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ele
+  - freud
   - numpy
   - packmol>=18
   - parmed>=3.4.3

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - ele
-  - freud
   - numpy
   - packmol>=18
   - parmed>=3.4.3

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1033,6 +1033,11 @@ class Compound(object):
             The maximum distance (in nm) between Particles for considering a bond
         exclude_ii : bool, optional, default=True
             Whether or not to include neighbors with the same index.
+
+        Notes
+        -----
+        This is an experimental feature and some behavior might change out of step of a standard development release.
+
         """
         freud = import_("freud")
         if self.box is None:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1043,15 +1043,8 @@ class Compound(object):
             [box.Lx / 2, box.Ly / 2, box.Lz / 2]
         )
 
-        # extend non-periodic dimensions for pseudo-periodicity
-        extended_lengths = list(box.lengths)
-        for i, truthy in enumerate(self.periodicity):
-            if truthy:
-                continue
-            else:
-                extended_lengths[i] = extended_lengths[i] * 10
-        tmp_box = Box(lengths=extended_lengths, angles=list(box.angles))
-        freud_box = freud.box.Box.from_matrix(tmp_box.vectors.T)
+        freud_box = freud.box.Box.from_matrix(box.vectors.T)
+        freud.box.periodic = self.periodicity
 
         a_indices = []
         b_indices = []
@@ -1060,7 +1053,6 @@ class Compound(object):
                 a_indices.append(i)
             if part.name == name_b:
                 b_indices.append(i)
-        print(a_indices, b_indices)
 
         aq = freud.locality.AABBQuery(freud_box, moved_positions[b_indices])
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1035,17 +1035,21 @@ class Compound(object):
         exclude_ii : bool, optional, default=True
             Whether or not to include neighbors with the same index.
         """
+        if self.box is None:
+            box = self.get_boundingbox()
+        else:
+            box = self.box
         moved_positions = self.xyz - np.array(
-            [self.box.Lx / 2, self.box.Ly / 2, self.box.Lz / 2]
+            [box.Lx / 2, box.Ly / 2, box.Lz / 2]
         )
-        extended_lengths = list(self.box.lengths)
+        extended_lengths = list(box.lengths)
         # extend non-periodic dimensions for pseudo-periodicity
         for i, truthy in enumerate(self.periodicity):
             if truthy:
                 continue
             else:
                 extended_lengths[i] = extended_lengths[i] * 10
-        tmp_box = Box(lengths=extended_lengths, angles=list(self.box.angles))
+        tmp_box = Box(lengths=extended_lengths, angles=list(box.angles))
         freud_box = freud.box.Box.from_matrix(tmp_box.vectors.T)
 
         aq = freud.locality.AABBQuery(freud_box, moved_positions)

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -980,9 +980,9 @@ class Compound(object):
         name_b : str
             The name of the other Particle to be in each bond
         dmin : float
-            The minimum distance between Particles for considering a bond
+            The minimum distance (in nm) between Particles for considering a bond
         dmax : float
-            The maximum distance between Particles for considering a bond
+            The maximum distance (in nm) between Particles for considering a bond
         """
         if self.box is None:
             self.box = self.get_boundingbox()
@@ -1028,9 +1028,9 @@ class Compound(object):
         name_b : str
             The name of the other Particle to be in each bond
         dmin : float
-            The minimum distance between Particles for considering a bond
+            The minimum distance (in nm) between Particles for considering a bond
         dmax : float
-            The maximum distance between Particles for considering a bond
+            The maximum distance (in nm) between Particles for considering a bond
         exclude_ii : bool, optional, default=True
             Whether or not to include neighbors with the same index.
         """

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 from warnings import warn
 
 import ele
-import freud
 import numpy as np
 from ele.element import Element, element_from_name, element_from_symbol
 from ele.exceptions import ElementError
@@ -1035,6 +1034,7 @@ class Compound(object):
         exclude_ii : bool, optional, default=True
             Whether or not to include neighbors with the same index.
         """
+        freud = import_("freud")
         if self.box is None:
             box = self.get_boundingbox()
         else:

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -466,6 +466,16 @@ class TestCompound(BaseTest):
         ch3.generate_bonds("H", "H", dmin=0.01, dmax=2.0)
         assert ch3.n_bonds == 3 + 3
 
+    def test_freud_generate_bonds(self, ch3):
+        ch3.freud_generate_bonds(
+            "H", "H", dmin=0.01, dmax=0.19, exclude_ii=True
+        )
+        assert ch3.n_bonds == 3 + 3
+
+    def test_freud_generate_bonds_expected(self, ch3):
+        ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.1, exclude_ii=True)
+        assert ch3.n_bonds == 3
+
     def test_remove_from_box(self, ethane):
         n_ethanes = 5
         box = mb.fill_box(ethane, n_ethanes, [3, 3, 3])

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -14,6 +14,7 @@ from mbuild.utils.geometry import calc_dihedral
 from mbuild.utils.io import (
     get_fn,
     has_foyer,
+    has_freud,
     has_intermol,
     has_mdtraj,
     has_networkx,
@@ -466,10 +467,12 @@ class TestCompound(BaseTest):
         ch3.generate_bonds("H", "H", dmin=0.01, dmax=2.0)
         assert ch3.n_bonds == 3 + 3
 
+    @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
     def test_freud_generate_bonds(self, ch3):
         ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.2, exclude_ii=True)
         assert ch3.n_bonds == 3 + 3
 
+    @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
     def test_freud_generate_bonds_expected(self, ch3):
         ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.1, exclude_ii=True)
         assert ch3.n_bonds == 3

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -469,11 +469,15 @@ class TestCompound(BaseTest):
 
     @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
     def test_freud_generate_bonds(self, ch3):
+        bounding_box = ch3.get_boundingbox()
+        ch3.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.2, exclude_ii=True)
         assert ch3.n_bonds == 3 + 3
 
     @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
     def test_freud_generate_bonds_expected(self, ch3):
+        bounding_box = ch3.get_boundingbox()
+        ch3.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.1, exclude_ii=True)
         assert ch3.n_bonds == 3
 

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -467,9 +467,7 @@ class TestCompound(BaseTest):
         assert ch3.n_bonds == 3 + 3
 
     def test_freud_generate_bonds(self, ch3):
-        ch3.freud_generate_bonds(
-            "H", "H", dmin=0.01, dmax=0.19, exclude_ii=True
-        )
+        ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.2, exclude_ii=True)
         assert ch3.n_bonds == 3 + 3
 
     def test_freud_generate_bonds_expected(self, ch3):

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -149,6 +149,16 @@ pycifrw can be installed with conda using:
 """
 
 MESSAGES[
+    "freud"
+] = """
+The code at {filename}:{line_number} requires the "freud" package
+
+freud can be installed with conda using:
+
+# conda install -c conda-forge freud
+"""
+
+MESSAGES[
     "protobuf"
 ] = """
 The code at {filename}:{line_number} requires the "protobuf" package
@@ -356,6 +366,14 @@ try:
     del rdkit
 except ImportError:
     has_rdkit = False
+
+try:
+    import freud
+
+    has_freud = True
+    del freud
+except ImportError:
+    has_freud = False
 
 
 def get_fn(name):


### PR DESCRIPTION
### PR Summary:
After dealing with updates for our implementation of the periodicKDTree in mBuild, I have been increasingly in favor of using a different tool that might get us similar/same behavior without us having to also maintain this KDTree implementation that is over 10 years old, and has never been updated to take advantage of any KDtree updates in the scipy core.

`freud` seems like an excellent package that can handle not just rectangular bounding boxes (our current PKDTree can only handle rectangular boxes), but also triclinic!

This is an experimental feature and also depends on #968 .

Currently opening as a draft, since I need to test other features as well. 
### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
