### PR TITLE
Use `functools.wraps` to preserve docstring

### DIFF
--- a/mbuild/utils/decorators.py
+++ b/mbuild/utils/decorators.py
@@ -129,6 +129,7 @@ def experimental_feature(warning_string=""):  # pragma no cover
     """Decorate experimental methods."""
 
     def experimental_function(fcn):
+        @wraps(fcn)
         def wrapper(*args, **kwargs):
             warn(
                 f"{fcn.__name__} is an experimental feature and is not subject to follow standard deprecation cycles. Use at your own risk! {warning_string}",


### PR DESCRIPTION
### PR Summary:
With the addition of the `@experimental_function` wrapper to decorate
functions that are experimental and subject to frequent changes, the
docstring of the decorated function was not preserved.

This prevents the user from being able to see the `__doc__` and proper
`__name__` attributes of these methods. This PR includes the
`functools.wraps` method to ensure that the experimental functions are
properly documented in our docs and docstrings.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
