### PR TITLE
Use clone of solute in `packing.solvate()` method

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -743,7 +743,7 @@ def solvate(
 
         # Create the topology and update the coordinates.
         solvated = Compound()
-        solvated.add(solute)
+        solvated.add(clone(solute))
         solvated = _create_topology(solvated, solvent, n_solvent)
         solvated.update_coordinates(
             solvated_xyz.name, update_port_locations=update_port_locations

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -190,6 +190,7 @@ class TestPacking(BaseTest):
         solvated = mb.solvate(ethane, h2o, n_solvent=n_solvent, box=[4, 4, 4])
         assert solvated.n_particles == 8 + n_solvent * 3
         assert solvated.n_bonds == 7 + n_solvent * 2
+        assert ethane.parent == None
 
     def test_solvate_multiple(self, methane, ethane, h2o):
         init_box = mb.fill_box(methane, 2, box=[4, 4, 4])


### PR DESCRIPTION
### PR Summary:
Resolve #984. Modify `packing.solvate()` method to use clone of provided solute instead. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
