### PR TITLE
Update the api for the cif file reader

### DIFF
--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -28,7 +28,7 @@ def load_cif(file_or_path=None, wrap_coords=False):
     assert isinstance(file_or_path, (str, pathlib.Path))
     cif_location = pathlib.Path(file_or_path)
 
-    reader = garnett.ciffilereader.CifFileReader()
+    reader = garnett.reader.CifFileReader()
     with open(cif_location.absolute(), "r") as cif_file:
         my_cif = reader.read(cif_file)
 


### PR DESCRIPTION
There was a small issue when trying to use the garnett in
`lattice.load_cif`, the garnett readers now use a standard
`garnett.reader` to access the various file readers. `load_cif` has been
updated to support this.

### PR Summary:

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
