### PR TITLE
Add option to update and replace old labels

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1544,6 +1544,15 @@ class Compound(object):
         remove_old_label : bool, optional, default=True
             Remove the old label associate with the target descendent.
         """
+        if remove_old_label:
+            if isinstance(descendent, mb.Port):
+                for old_label in descendent.access_labels():
+                    self.labels.pop(old_label)
+            elif isinstance(descendent, mb.Compound):
+                for label, item in self.labels.items():
+                    if descendent == item:
+                        self.labels.pop(label)
+
         if new_label in self.labels:
             raise ValueError(f"{label} have already been used in {self}")
         else:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1547,7 +1547,7 @@ class Compound(object):
         if new_label in self.labels:
             raise ValueError(f"{label} have already been used in {self}")
         else:
-            self[new_label] = descendent
+            self.labels[new_label] = descendent
 
         if remove_old_label:
             if isinstance(descendent, mb.Port):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -835,7 +835,7 @@ class Compound(object):
         all_ports_list = list(self.all_ports())
         for port in all_ports_list:
             if port.anchor not in [i for i in self.particles()]:
-                port.parent.children.remove(port)
+                self.remove(port)
 
         # Check and reorder rigid id
         for _ in particles_to_remove:
@@ -1532,6 +1532,30 @@ class Compound(object):
             widget.add_ball_and_stick("_VS", aspect_ratio=1.0, color="#991f00")
         overwrite_nglview_default(widget)
         return widget
+
+    def update_label(self, descendent, new_label, remove_old_label=True):
+        """Update the label of one a descendent of this Compound.
+
+        Parameters
+        ----------
+        descendent : mb.Port or mb.Compound
+            Descendent of this Compound whose label need to be updated.
+        remove_old_label : bool, optional, default=True
+            Remove the old label associate with the target descendent.
+        """
+        if new_label in self.labels:
+            raise ValueError(f"{label} have already been used in {self}")
+        else:
+            self[new_label] = descendent
+
+        if remove_old_label:
+            if isinstance(descendent, mb.Port):
+                for old_label in descendent.access_labels():
+                    self.labels.pop(old_label)
+            elif isinstance(descendent, mb.Compound):
+                for label, item in self.labels.items():
+                    if descendent == item:
+                        self.labels.pop(label)
 
     def update_coordinates(self, filename, update_port_locations=True):
         """Update the coordinates of this Compound from a file.

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1544,9 +1544,11 @@ class Compound(object):
         remove_old_label : bool, optional, default=True
             Remove the old label associate with the target descendent.
         """
+        from mbuild.port import Port
+
         if remove_old_label:
-            if isinstance(descendent, mb.Port):
-                for old_label in descendent.access_labels():
+            if isinstance(descendent, Port):
+                for old_label in descendent.access_labels:
                     self.labels.pop(old_label)
             elif isinstance(descendent, mb.Compound):
                 for label, item in self.labels.items():
@@ -1557,15 +1559,6 @@ class Compound(object):
             raise ValueError(f"{label} have already been used in {self}")
         else:
             self.labels[new_label] = descendent
-
-        if remove_old_label:
-            if isinstance(descendent, mb.Port):
-                for old_label in descendent.access_labels():
-                    self.labels.pop(old_label)
-            elif isinstance(descendent, mb.Compound):
-                for label, item in self.labels.items():
-                    if descendent == item:
-                        self.labels.pop(label)
 
     def update_coordinates(self, filename, update_port_locations=True):
         """Update the coordinates of this Compound from a file.

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -836,6 +836,7 @@ class Compound(object):
         for port in all_ports_list:
             if port.anchor not in [i for i in self.particles()]:
                 self.remove(port)
+                self["port"].remove(port)
 
         # Check and reorder rigid id
         for _ in particles_to_remove:

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -183,11 +183,11 @@ class Port(Compound):
         descr.append(self.name + ", ")
 
         if self.anchor:
-            descr.append("anchor: '{}', ".format(self.anchor.name))
+            descr.append(f"anchor: '{self.anchor.name}', ")
         else:
             descr.append("anchor: None, ")
 
-        descr.append("labels: {}, ".format(", ".join(self.access_labels)))
+        descr.append(f"labels: {self.access_labels}, ")
 
-        descr.append("id: {}>".format(id(self)))
+        descr.append(f"id: {id(self)}>")
         return "".join(descr)

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -171,9 +171,9 @@ class Port(Compound):
             ]
             if referrer is self.root:
                 for label in port_labels:
-                    access_labels.append("['{}']".format(label))
+                    access_labels.append(label)
             for label in itertools.product(referrer_labels, port_labels):
-                access_labels.append("['{}']".format("']['".join(label)))
+                access_labels.append(label)
 
         return access_labels
 


### PR DESCRIPTION
### PR Summary:
Add `update_label` method to add (with option to replace) label of children object (port or Compound). Pending tests.
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
