### PR TITLE
Fix incorrect indexing of force constants in HOOMD forcefield

### DIFF
--- a/mbuild/formats/hoomd_forcefield.py
+++ b/mbuild/formats/hoomd_forcefield.py
@@ -412,7 +412,7 @@ def _init_hoomd_rb_torsions(structure, ref_energy=1.0):
             dihedral_type.c5 / ref_energy,
         )
         rb_torsion.params[name] = dict(
-            k1=F_coeffs[0], k2=F_coeffs[1], k3=F_coeffs[2], k4=F_coeffs[3]
+            k1=F_coeffs[1], k2=F_coeffs[2], k3=F_coeffs[3], k4=F_coeffs[4]
         )
 
     return rb_torsion


### PR DESCRIPTION
### PR Summary:

OPLS 0th order term is not used by [HOOMD OPLS dihedral](https://hoomd-blue.readthedocs.io/en/latest/module-md-dihedral.html#hoomd.md.dihedral.OPLS) see [RB_to_OPLS note](https://github.com/mosdef-hub/mbuild/blob/8baa19a46d1ece809f214a2e1a2f8984dd923b56/mbuild/utils/conversion.py#L55). 

This PR fixes the OPLS conversion for HOOMD v3. The implementation is [already correct in HOOMD v2](https://github.com/mosdef-hub/mbuild/blob/8baa19a46d1ece809f214a2e1a2f8984dd923b56/mbuild/formats/hoomd_simulation.py#L446). Thanks to @bc118, @chrisiacovella, and @joaander for guidance!

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
