### PR TITLE
Removed the C0 or K0 dihedral term from the Charmm writer

### DIFF
--- a/mbuild/formats/charmm_writer.py
+++ b/mbuild/formats/charmm_writer.py
@@ -2933,37 +2933,10 @@ class Charmm:
                             # check the error between the convertions of RB_tortions to CHARMM DIHEDRALS (end)
                             # **************************************
                             dihedral_format = "{}\t{}\t{}\t{}\t{:.6f}\t{}\t{}\t\t! {}\t{}\t{}\t{}\n"
-                            data.write(
-                                dihedral_format.format(
-                                    base10_to_base52_alph(
-                                        self.atom_types_to_index_value_dict[
-                                            params[8] + "_" + params[12]
-                                        ]
-                                    ),
-                                    base10_to_base52_alph(
-                                        self.atom_types_to_index_value_dict[
-                                            params[9] + "_" + params[13]
-                                        ]
-                                    ),
-                                    base10_to_base52_alph(
-                                        self.atom_types_to_index_value_dict[
-                                            params[10] + "_" + params[14]
-                                        ]
-                                    ),
-                                    base10_to_base52_alph(
-                                        self.atom_types_to_index_value_dict[
-                                            params[11] + "_" + params[15]
-                                        ]
-                                    ),
-                                    charmm_coeffs[0, 0],
-                                    int(charmm_coeffs[0, 1]),
-                                    charmm_coeffs[0, 2],
-                                    params[8] + "_" + params[12],
-                                    params[9] + "_" + params[13],
-                                    params[10] + "_" + params[14],
-                                    params[11] + "_" + params[15],
-                                )
-                            )
+
+                            # Note the Charmm C0 or K0 dihedral term is not printed as it is used/read
+                            # as a harmonic potential in the Charmm format
+
                             data.write(
                                 dihedral_format.format(
                                     base10_to_base52_alph(

--- a/mbuild/tests/test_charmm_writer.py
+++ b/mbuild/tests/test_charmm_writer.py
@@ -157,7 +157,6 @@ class TestCharmmWriterData(BaseTest):
                 ):
                     dihedrals_read = True
                     dihed_types = [
-                        ["B", "A", "A", "B", "0.300000", "0", "90.0"],
                         ["B", "A", "A", "B", "0.000000", "1", "180.0"],
                         ["B", "A", "A", "B", "0.000000", "2", "0.0"],
                         ["B", "A", "A", "B", "-0.150000", "3", "180.0"],
@@ -507,7 +506,6 @@ class TestCharmmWriterData(BaseTest):
                 ):
                     dihedrals_read = True
                     dihedral_types = [
-                        ["A", "B", "D", "C", "0.647232", "0", "90.0"],
                         ["A", "B", "D", "C", "-0.392135", "1", "180.0"],
                         ["A", "B", "D", "C", "-0.062518", "2", "0.0"],
                         ["A", "B", "D", "C", "0.345615", "3", "180.0"],

--- a/mbuild/utils/specific_ff_to_residue.py
+++ b/mbuild/utils/specific_ff_to_residue.py
@@ -390,6 +390,7 @@ def specific_ff_to_residue(
                 ff_iteration = Forcefield(name=ff_data[residues[i]])
                 residues_applied_list.append(residues[i])
 
+            new_compound_iteration.box = None
             new_structure_iteration = ff_iteration.apply(
                 new_compound_iteration, residues=[residues[i]]
             )


### PR DESCRIPTION
### PR Summary:

- Removed the C0 or K0 dihedral term from the Charmm writer.  GOMC uses it as a dihedral constant, but the standard CHARMM format reads it as a harmonic potential (this includes NAMD). Therefore, this can cause errors that will be hard to see in any reader using the standard Chamm format (see attached file).
![CHARMM_dihderal_style_behavior](https://user-images.githubusercontent.com/65550266/149634419-2682c893-99a1-4803-ae1c-324240a0a4ee.png)



- Also, added a line to the specific_ff_to_residue.py file to prevent errors when multiple box sizes are used/merged.



### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
