### PR TITLE
Ensure positions are casted to python floats before conversion to json

### DIFF
--- a/mbuild/formats/json_formats.py
+++ b/mbuild/formats/json_formats.py
@@ -135,7 +135,7 @@ def _particle_info(cmpd, include_ports=False):
     particle_dict = OrderedDict()
     particle_dict["id"] = id(cmpd)
     particle_dict["name"] = cmpd.name
-    particle_dict["pos"] = list(np.asarray(cmpd.pos, dtype=float))
+    particle_dict["pos"] = cmpd.pos.tolist()
     particle_dict["charge"] = cmpd.charge
     particle_dict["element"] = cmpd.element
 

--- a/mbuild/formats/json_formats.py
+++ b/mbuild/formats/json_formats.py
@@ -3,6 +3,7 @@ import json
 from collections import OrderedDict
 
 import ele
+import numpy as np
 
 import mbuild as mb
 from mbuild.exceptions import MBuildError
@@ -125,7 +126,6 @@ def compound_to_json(cmpd, file_path, include_ports=False):
     compound_json["mbuild-version"] = version
     compound_json["type"] = "Compound"
     compound_json["Compound"] = compound_dict
-
     with open(file_path, "w") as datafile:
         json.dump(compound_json, datafile, indent=2)
 
@@ -135,7 +135,7 @@ def _particle_info(cmpd, include_ports=False):
     particle_dict = OrderedDict()
     particle_dict["id"] = id(cmpd)
     particle_dict["name"] = cmpd.name
-    particle_dict["pos"] = list(cmpd.pos)
+    particle_dict["pos"] = list(np.asarray(cmpd.pos, dtype=float))
     particle_dict["charge"] = cmpd.charge
     particle_dict["element"] = cmpd.element
 

--- a/mbuild/formats/json_formats.py
+++ b/mbuild/formats/json_formats.py
@@ -3,7 +3,6 @@ import json
 from collections import OrderedDict
 
 import ele
-import numpy as np
 
 import mbuild as mb
 from mbuild.exceptions import MBuildError

--- a/mbuild/tests/test_json_formats.py
+++ b/mbuild/tests/test_json_formats.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import mbuild as mb
 from mbuild.formats.json_formats import compound_from_json, compound_to_json
 from mbuild.tests.base_test import BaseTest
@@ -93,3 +95,10 @@ class TestJSONFormats(BaseTest):
         ):
             assert child.labels.keys() == child_copy.labels.keys()
         assert parent_copy.available_ports() == parent.available_ports()
+
+    def test_float_64_position(self):
+        ethane = mb.lib.molecules.Ethane()
+        ethane.xyz = np.asarray(ethane.xyz, dtype=np.float64)
+        compound_to_json(ethane, "ethane.json", include_ports=True)
+        ethane_copy = compound_from_json("ethane.json")
+        assert np.allclose(ethane.xyz, ethane_copy.xyz, atol=10**-6)


### PR DESCRIPTION
Fixes #1001, where sometimes `compound.pos` can be an array numpy dtypes (`np.float64`/ `np.float32`), converting them to a list using a list's constructor will not be able to cast them to python `float`. This PR fixes it.
