### PR TITLE
Fix 1-4 LJ scaling detection for mcf writer

### DIFF
--- a/mbuild/formats/cassandramcf.py
+++ b/mbuild/formats/cassandramcf.py
@@ -120,22 +120,23 @@ def write_mcf(
                 )
     if lj14 is None:
         if len(structure.adjusts) > 0:
-            type1_eps = structure.adjusts[0].atom1.epsilon
-            type2_eps = structure.adjusts[0].atom2.epsilon
-            scaled_eps = structure.adjusts[0].type.epsilon
             if (
                 structure.combining_rule == "geometric"
                 or structure.combining_rule == "lorentz"
             ):
-                combined_eps = sqrt(type1_eps * type2_eps)
-                if combined_eps == 0:
+                combined_eps_list = [sqrt(adj.atom1.epsilon * adj.atom2.epsilon) for adj in structure.adjusts]
+                if all([c_eps == 0 for c_eps in combined_eps_list]):
                     lj14 = 0.0
                     warnings.warn(
                         "Unable to infer LJ 1-4 scaling factor. Setting to "
                         "{:.1f}".format(lj14)
                     )
                 else:
-                    lj14 = scaled_eps / combined_eps
+                    scaled_eps_list = [adj.type.epsilon for adj in structure.adjusts]
+                    for i_adj, combined_eps in enumerate(combined_eps_list):
+                        if combined_eps != 0:
+                            lj14 = scaled_eps_list[i_adj] / combined_eps
+                            break
             else:
                 lj14 = 0.0
                 warnings.warn(


### PR DESCRIPTION
Previously, the 1-4 LJ scaling detection in the mcf writer only checked the first element of `structure.adjusts` to infer the LJ 1-4 scaling factor, but this caused it to fail to infer the LJ 1-4 scaling factor correctly if the 1-4 pair of atoms in the first element of `structure.adjusts` contains an atom with zero epsilon, such as hydrogen in the OPLSAA force field.

I fixed this by making it base the inference on the first element of `structure.adjusts` that doesn't include an atom with zero epsilon.


### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
