### PR TITLE
Include box info when writing/reading json file

### DIFF
--- a/mbuild/formats/json_formats.py
+++ b/mbuild/formats/json_formats.py
@@ -68,6 +68,9 @@ def compound_from_json(json_file):
         _add_ports(compound_dict, converted_dict)
         _add_bonds(compound_dict, parent, converted_dict)
 
+        box = compound_dict.get("box")
+        if box is not None:
+            parent.box = mb.Box(lengths=box["lengths"], angles=box["angles"])
         return parent
 
 
@@ -137,6 +140,7 @@ def _particle_info(cmpd, include_ports=False):
     particle_dict["pos"] = cmpd.pos.tolist()
     particle_dict["charge"] = cmpd.charge
     particle_dict["element"] = cmpd.element
+    particle_dict["box"] = _box_info(cmpd)
 
     if include_ports:
         particle_dict["ports"] = list()
@@ -161,6 +165,16 @@ def _bond_info(cmpd):
     for bond in cmpd.bonds():
         bond_list.append((id(bond[0]), id(bond[1])))
     return bond_list
+
+
+def _box_info(cmpd):
+    """Given a compound, return the box information."""
+    if cmpd.box:
+        box_info = {"lengths": cmpd.box.lengths, "angles": cmpd.box.angles}
+    else:
+        box_info = None
+
+    return box_info
 
 
 def _dict_to_mb(compound_dict):

--- a/mbuild/formats/json_formats.py
+++ b/mbuild/formats/json_formats.py
@@ -184,6 +184,7 @@ def _dict_to_mb(compound_dict):
     charge = compound_dict.get("charge", 0.0)
     periodicity = compound_dict.get("periodicity", (False, False, False))
     element = compound_dict.get("element", None)
+    box = compound_dict.get("box", None)
     if isinstance(element, ele.element.Element):
         pass
     elif isinstance(element, list):
@@ -194,12 +195,16 @@ def _dict_to_mb(compound_dict):
     else:
         pass
 
+    if box is not None:
+        box = mb.Box(lengths=box["lengths"], angles=box["angles"])
+
     this_particle = mb.Compound(
         name=name,
         pos=pos,
         charge=charge,
         periodicity=periodicity,
         element=element,
+        box=box,
     )
     return this_particle
 

--- a/mbuild/tests/test_json_formats.py
+++ b/mbuild/tests/test_json_formats.py
@@ -17,6 +17,15 @@ class TestJSONFormats(BaseTest):
         assert ethane.n_bonds == ethane_copy.n_bonds
         assert len(ethane.children) == len(ethane_copy.children)
 
+    def test_box(self):
+        meth = mb.load("C", smiles=True)
+        meth.box = mb.Box(lengths=(3, 3, 3), angles=(45, 45, 45))
+        meth.save("meth_with_box.json")
+
+        loaded_meth = mb.load("meth_with_box.json")
+        assert meth.box.lengths == loaded_meth.box.lengths == (3, 3, 3)
+        assert meth.box.angles == loaded_meth.box.angles
+
     def test_loop_with_ports(self):
         from mbuild.lib.moieties import CH3
 

--- a/mbuild/tests/test_json_formats.py
+++ b/mbuild/tests/test_json_formats.py
@@ -19,12 +19,22 @@ class TestJSONFormats(BaseTest):
 
     def test_box(self):
         meth = mb.load("C", smiles=True)
+
+        meth.save("meth_no_box.json")
+        meth_no_box = mb.load("meth_no_box.json")
+        assert meth_no_box.box is None
+
         meth.box = mb.Box(lengths=(3, 3, 3), angles=(45, 45, 45))
         meth.save("meth_with_box.json")
-
-        loaded_meth = mb.load("meth_with_box.json")
-        assert meth.box.lengths == loaded_meth.box.lengths == (3, 3, 3)
-        assert meth.box.angles == loaded_meth.box.angles
+        meth_with_box = mb.load("meth_with_box.json")
+        assert (
+            meth.n_particles
+            == meth_with_box.n_particles
+            == meth_no_box.n_particles
+        )
+        assert meth.n_bonds == meth_with_box.n_bonds == meth_no_box.n_bonds
+        assert meth.box.lengths == meth_with_box.box.lengths == (3, 3, 3)
+        assert meth.box.angles == meth_with_box.box.angles
 
     def test_loop_with_ports(self):
         from mbuild.lib.moieties import CH3


### PR DESCRIPTION
### PR Summary:
Currently, box information is not written out/read in when saving/loading from json file format. This PR add that field during the writing/reading of json file. Relate to #1003 
### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
