### PR TITLE
Allow user to pad bounding box for small cmpds

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1309,9 +1309,11 @@ class Compound(object):
         pad_box: Sequence, optional, default=None
             Pad all lengths or a list of lengths by a specified amount in nm.
             Acceptable values are:
-                * A single float: apply this pad value to all 3 box lengths.
-                * A sequence of length 1: apply this pad value to all 3 box lengths.
-                * A sequence of length 3: apply these pad values to the a, b, c box lengths.
+
+                - A single float: apply this pad value to all 3 box lengths.
+                - A sequence of length 1: apply this pad value to all 3 box lengths.
+                - A sequence of length 3: apply these pad values to the a, b, c box lengths.
+
 
         Returns
         -------

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1572,12 +1572,36 @@ class TestCompound(BaseTest):
         h1.pos = [-0.07590747, 0.00182889, 0.00211742]
         h2.pos = [0.07590747, -0.00182889, -0.00211742]
         container = mb.Compound([h1, h2])
+        distances = container.maxs - container.mins
         with pytest.raises(
             MBuildError, match=r"The vectors to define the box are co\-linear\,"
         ):
             container.get_boundingbox()
+        distance_list = [val for val in distances]
+        distance_list = [val + 1.0 for val in distance_list]
+        np.testing.assert_almost_equal(
+            container.get_boundingbox(pad_box=1.0).lengths,
+            distance_list,
+            decimal=6,
+        )
 
-        assert container.get_boundingbox(pad_box=True)
+        distance_list = [val for val in distances]
+        distance_list[0] = distance_list[0] + 1.0
+        distance_list[1] = distance_list[1] + 2.0
+        distance_list[2] = distance_list[2] + 3.0
+        np.testing.assert_almost_equal(
+            container.get_boundingbox(pad_box=[1.0, 2.0, 3.0]).lengths,
+            distance_list,
+            decimal=6,
+        )
+
+    @pytest.mark.parametrize(
+        "bad_value", [[1.0, 2.0], set([1, 2, 3]), {"x": 1.0}]
+    )
+    def test_get_boundingbox_error(self, bad_value):
+        with pytest.raises(TypeError):
+            meth = mb.load(get_fn("methyl.pdb"))
+            meth.get_boundingbox(pad_box=bad_value)
 
     @pytest.mark.skipif(not has_py3Dmol, reason="Py3Dmol is not installed")
     def test_visualize_py3dmol(self, ethane):

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1566,6 +1566,19 @@ class TestCompound(BaseTest):
         with pytest.warns(UserWarning):
             compound.box = Box(lengths=[1.0, 1.0, 1.0], angles=angles)
 
+    def test_get_boundingbox_extrema(self):
+        h1 = mb.Compound()
+        h2 = mb.Compound()
+        h1.pos = [-0.07590747, 0.00182889, 0.00211742]
+        h2.pos = [0.07590747, -0.00182889, -0.00211742]
+        container = mb.Compound([h1, h2])
+        with pytest.raises(
+            MBuildError, match=r"The vectors to define the box are co\-linear\,"
+        ):
+            container.get_boundingbox()
+
+        assert container.get_boundingbox(pad_box=True)
+
     @pytest.mark.skipif(not has_py3Dmol, reason="Py3Dmol is not installed")
     def test_visualize_py3dmol(self, ethane):
         py3Dmol = import_("py3Dmol")


### PR DESCRIPTION
### PR Summary:
Raised by @daico007 in #1006, for very small molecules, the bounding
boxes will be so close to zero that the determinant of the box vectors
will be close to zero, signaling a co-linear box (psuedo-{1D, 2D}) and
raising an exception.

This PR provides an additional parmeter for the
`mb.Compound.get_bounding_box` method, `pad_box` which is a boolean to
avoid these co-linear systems by adding a 1nm pad to all box edges.

`pad_box` is `False` by default, and unit tests have been provided to
check both cases.

Closes #1006

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
 * #1006
