### PR TITLE
Make Lammps Writer use correct indexing

### DIFF
--- a/mbuild/formats/cassandramcf.py
+++ b/mbuild/formats/cassandramcf.py
@@ -120,22 +120,28 @@ def write_mcf(
                 )
     if lj14 is None:
         if len(structure.adjusts) > 0:
-            type1_eps = structure.adjusts[0].atom1.epsilon
-            type2_eps = structure.adjusts[0].atom2.epsilon
-            scaled_eps = structure.adjusts[0].type.epsilon
             if (
                 structure.combining_rule == "geometric"
                 or structure.combining_rule == "lorentz"
             ):
-                combined_eps = sqrt(type1_eps * type2_eps)
-                if combined_eps == 0:
+                combined_eps_list = [
+                    sqrt(adj.atom1.epsilon * adj.atom2.epsilon)
+                    for adj in structure.adjusts
+                ]
+                if all([c_eps == 0 for c_eps in combined_eps_list]):
                     lj14 = 0.0
                     warnings.warn(
                         "Unable to infer LJ 1-4 scaling factor. Setting to "
                         "{:.1f}".format(lj14)
                     )
                 else:
-                    lj14 = scaled_eps / combined_eps
+                    scaled_eps_list = [
+                        adj.type.epsilon for adj in structure.adjusts
+                    ]
+                    for i_adj, combined_eps in enumerate(combined_eps_list):
+                        if combined_eps != 0:
+                            lj14 = scaled_eps_list[i_adj] / combined_eps
+                            break
             else:
                 lj14 = 0.0
                 warnings.warn(

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -657,7 +657,7 @@ def _get_bond_types(
                     ),
                     bond_precision,
                 ),
-                round(bond.type.req / sigma_conversion_factor, bond_precision,
+                round(bond.type.req / sigma_conversion_factor, bond_precision),
                 tuple(sorted((bond.atom1.type, bond.atom2.type))),
             )
         ]
@@ -741,7 +741,7 @@ def _get_angle_types(
                 (
                     round(
                         angle.type.k * (1 / epsilon_conversion_factor),
-                        angle_precision),
+                        angle_precision,
                     ),
                     round(angle.type.theteq, angle_precision),
                     angle.atom2.type,
@@ -781,7 +781,7 @@ def _get_dihedral_types(
                             round(dihedral.type.c4 * lj_unit, dihedral_precision),
                             round(dihedral.type.c5 * lj_unit, dihedral_precision),
                             round(dihedral.type.scee, 1),
-                            round(dihedral.type.scnb, 1)
+                            round(dihedral.type.scnb, 1),
                             dihedral.atom1.type,
                             dihedral.atom2.type,
                             dihedral.atom3.type,
@@ -873,7 +873,7 @@ def _get_improper_dihedral_types(structure, epsilon_conversion_factor, imp_dih_p
                 d = 1
             improper_dihedrals.append(
                 (
-                    round(dih_type.phi_k * lj_unit, imp_dih_precision)),
+                    round(dih_type.phi_k * lj_unit, imp_dih_precision),
                     d,
                     int(round(dih_type.per, 0)),
                     round(dih_type.scee, 1),

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -11,6 +11,7 @@ from scipy.constants import epsilon_0
 from mbuild import Box
 from mbuild.utils.conversion import RB_to_OPLS
 from mbuild.utils.sorting import natural_sort
+from mbuild.utils.orderedset import OrderedSet
 
 __all__ = ["write_lammpsdata"]
 # Define constants for conversions
@@ -624,8 +625,8 @@ def _get_bond_types(
     """Will get the bond types from a parmed structure and convert them to lammps real units."""
     unique_bond_types = OrderedDict(
         enumerate(
-            set(
-                 [
+            OrderedSet(
+                 *[
                      (
                         round(
                             bond.type.k
@@ -702,7 +703,7 @@ def _get_angle_types(
                 )
             )
 
-        unique_angle_types = OrderedDict(enumerate(set(charmm_angle_types)))
+        unique_angle_types = OrderedDict(enumerate(OrderedSet(*charmm_angle_types)))
         unique_angle_types = OrderedDict(
             [(y, x + 1) for x, y in unique_angle_types.items()]
         )
@@ -713,8 +714,8 @@ def _get_angle_types(
     else:
         unique_angle_types = OrderedDict(
             enumerate(
-                set(
-                    [
+                OrderedSet(
+                    *[
                         (
                             round(
                                 angle.type.k * (1 / epsilon_conversion_factor),
@@ -766,8 +767,8 @@ def _get_dihedral_types(
     if use_rb_torsions:
         unique_dihedral_types = OrderedDict(
             enumerate(
-                set(
-                    [
+                OrderedSet(
+                    *[
                         (
 			    round(dihedral.type.c0 * lj_unit, 5),
 			    round(dihedral.type.c1 * lj_unit, 5),

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -620,7 +620,11 @@ def _check_minsmaxs(mins, maxs):
 
 
 def _get_bond_types(
-    structure, bonds, sigma_conversion_factor, epsilon_conversion_factor, bond_precision=3
+    structure,
+    bonds,
+    sigma_conversion_factor,
+    epsilon_conversion_factor,
+    bond_precision=3,
 ):
     """Will get the bond types from a parmed structure and convert them to lammps real units."""
     unique_bond_types = OrderedDict(
@@ -636,7 +640,10 @@ def _get_bond_types(
                             ),
                             bond_precision,
                         ),
-                        round(bond.type.req / sigma_conversion_factor, bond_precision),
+                        round(
+                            bond.type.req / sigma_conversion_factor,
+                            bond_precision,
+                        ),
                         tuple(sorted((bond.atom1.type, bond.atom2.type))),
                     )
                     for bond in structure.bonds
@@ -671,7 +678,7 @@ def _get_angle_types(
     use_urey_bradleys,
     sigma_conversion_factor,
     epsilon_conversion_factor,
-    angle_precision=3
+    angle_precision=3,
 ):
     """
     Will get the angle types from a parmed structure and convert them to lammps real units.
@@ -760,7 +767,7 @@ def _get_dihedral_types(
     use_dihedrals,
     epsilon_conversion_factor,
     zero_dihedral_weighting_factor,
-    dihedral_precision=5
+    dihedral_precision=5,
 ):
     """
     Will get the dihedral types from a parmed structure and convert them to lammps real units.
@@ -774,12 +781,24 @@ def _get_dihedral_types(
                 OrderedSet(
                     *[
                         (
-                            round(dihedral.type.c0 * lj_unit, dihedral_precision),
-                            round(dihedral.type.c1 * lj_unit, dihedral_precision),
-                            round(dihedral.type.c2 * lj_unit, dihedral_precision),
-                            round(dihedral.type.c3 * lj_unit, dihedral_precision),
-                            round(dihedral.type.c4 * lj_unit, dihedral_precision),
-                            round(dihedral.type.c5 * lj_unit, dihedral_precision),
+                            round(
+                                dihedral.type.c0 * lj_unit, dihedral_precision
+                            ),
+                            round(
+                                dihedral.type.c1 * lj_unit, dihedral_precision
+                            ),
+                            round(
+                                dihedral.type.c2 * lj_unit, dihedral_precision
+                            ),
+                            round(
+                                dihedral.type.c3 * lj_unit, dihedral_precision
+                            ),
+                            round(
+                                dihedral.type.c4 * lj_unit, dihedral_precision
+                            ),
+                            round(
+                                dihedral.type.c5 * lj_unit, dihedral_precision
+                            ),
                             round(dihedral.type.scee, 1),
                             round(dihedral.type.scnb, 1),
                             dihedral.atom1.type,
@@ -853,7 +872,9 @@ def _get_dihedral_types(
     return dihedral_types, unique_dihedral_types
 
 
-def _get_improper_dihedral_types(structure, epsilon_conversion_factor, imp_dih_precision=3):
+def _get_improper_dihedral_types(
+    structure, epsilon_conversion_factor, imp_dih_precision=3
+):
     """
     Will get the improper types from a parmed structure and convert them to lammps real units.
 
@@ -908,7 +929,9 @@ def _get_impropers(structure, epsilon_conversion_factor, improper_precision=3):
             OrderedSet(
                 *[
                     (
-                        round(improper.type.psi_k * lj_unit, improper_precision),
+                        round(
+                            improper.type.psi_k * lj_unit, improper_precision
+                        ),
                         round(improper.type.psi_eq, improper_precision),
                         improper.atom3.type,
                         improper.atom2.type,

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -624,21 +624,23 @@ def _get_bond_types(
     """Will get the bond types from a parmed structure and convert them to lammps real units."""
     unique_bond_types = OrderedDict(
         enumerate(
-            [
-                (
-                    round(
-                        bond.type.k
-                        * (
-                            sigma_conversion_factor**2
-                            / epsilon_conversion_factor
+            set(
+                 [
+                     (
+                        round(
+                            bond.type.k
+                            * (
+                                sigma_conversion_factor**2
+                                / epsilon_conversion_factor
+                            ),
+                            3,
                         ),
-                        3,
-                    ),
-                    round(bond.type.req / sigma_conversion_factor, 3),
-                    tuple(sorted((bond.atom1.type, bond.atom2.type))),
-                )
-                for bond in structure.bonds
-            ]
+                        round(bond.type.req / sigma_conversion_factor, 3),
+                        tuple(sorted((bond.atom1.type, bond.atom2.type))),
+                    )
+                    for bond in structure.bonds
+                ]
+            )
         )
     )
     unique_bond_types = OrderedDict(
@@ -711,18 +713,20 @@ def _get_angle_types(
     else:
         unique_angle_types = OrderedDict(
             enumerate(
-                [
-                    (
-                        round(
-                            angle.type.k * (1 / epsilon_conversion_factor),
-                            3,
-                        ),
-                        round(angle.type.theteq, 3),
-                        angle.atom2.type,
-                        tuple(sorted((angle.atom1.type, angle.atom3.type))),
-                    )
-                    for angle in structure.angles
-                ]
+                set(
+                    [
+                        (
+                            round(
+                                angle.type.k * (1 / epsilon_conversion_factor),
+                                3,
+                            ),
+                            round(angle.type.theteq, 3),
+			    angle.atom2.type,
+			    tuple(sorted((angle.atom1.type, angle.atom3.type))),
+		        )
+		        for angle in structure.angles
+		    ]
+                )
             )
         )
         unique_angle_types = OrderedDict(
@@ -762,23 +766,25 @@ def _get_dihedral_types(
     if use_rb_torsions:
         unique_dihedral_types = OrderedDict(
             enumerate(
-                [
-                    (
-                        round(dihedral.type.c0 * lj_unit, 5),
-                        round(dihedral.type.c1 * lj_unit, 5),
-                        round(dihedral.type.c2 * lj_unit, 5),
-                        round(dihedral.type.c3 * lj_unit, 5),
-                        round(dihedral.type.c4 * lj_unit, 5),
-                        round(dihedral.type.c5 * lj_unit, 5),
-                        round(dihedral.type.scee, 1),
-                        round(dihedral.type.scnb, 1),
-                        dihedral.atom1.type,
-                        dihedral.atom2.type,
-                        dihedral.atom3.type,
-                        dihedral.atom4.type,
-                    )
+                set(
+                    [
+                        (
+			    round(dihedral.type.c0 * lj_unit, 5),
+			    round(dihedral.type.c1 * lj_unit, 5),
+			    round(dihedral.type.c2 * lj_unit, 5),
+			    round(dihedral.type.c3 * lj_unit, 5),
+			    round(dihedral.type.c4 * lj_unit, 5),
+			    round(dihedral.type.c5 * lj_unit, 5),
+			    round(dihedral.type.scee, 1),
+			    round(dihedral.type.scnb, 1),
+			    dihedral.atom1.type,
+			    dihedral.atom2.type,
+			    dihedral.atom3.type,
+			    dihedral.atom4.type,
+                        )
                     for dihedral in structure.rb_torsions
-                ]
+                    ]
+                )
             )
         )
         unique_dihedral_types = OrderedDict(

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -620,7 +620,7 @@ def _check_minsmaxs(mins, maxs):
 
 
 def _get_bond_types(
-    structure, bonds, sigma_conversion_factor, epsilon_conversion_factor
+    structure, bonds, sigma_conversion_factor, epsilon_conversion_factor, bond_precision=3
 ):
     """Will get the bond types from a parmed structure and convert them to lammps real units."""
     unique_bond_types = OrderedDict(
@@ -634,9 +634,9 @@ def _get_bond_types(
                                 sigma_conversion_factor**2
                                 / epsilon_conversion_factor
                             ),
-                            3,
+                            bond_precision,
                         ),
-                        round(bond.type.req / sigma_conversion_factor, 3),
+                        round(bond.type.req / sigma_conversion_factor, bond_precision),
                         tuple(sorted((bond.atom1.type, bond.atom2.type))),
                     )
                     for bond in structure.bonds
@@ -655,9 +655,9 @@ def _get_bond_types(
                     * (
                         sigma_conversion_factor**2 / epsilon_conversion_factor
                     ),
-                    3,
+                    bond_precision,
                 ),
-                round(bond.type.req / sigma_conversion_factor, 3),
+                round(bond.type.req / sigma_conversion_factor, bond_precision,
                 tuple(sorted((bond.atom1.type, bond.atom2.type))),
             )
         ]
@@ -671,6 +671,7 @@ def _get_angle_types(
     use_urey_bradleys,
     sigma_conversion_factor,
     epsilon_conversion_factor,
+    angle_precision=3
 ):
     """
     Will get the angle types from a parmed structure and convert them to lammps real units.
@@ -694,11 +695,11 @@ def _get_angle_types(
                             sigma_conversion_factor**2
                             / epsilon_conversion_factor
                         ),
-                        3,
+                        angle_precision,
                     ),
-                    round(angle.type.theteq, 3),
-                    round(ub_k / epsilon_conversion_factor, 3),
-                    round(ub_req, 3),
+                    round(angle.type.theteq, angle_precision),
+                    round(ub_k / epsilon_conversion_factor, angle_precision),
+                    round(ub_req, angle_precision),
                     tuple(sorted((angle.atom1.type, angle.atom3.type))),
                 )
             )
@@ -721,9 +722,9 @@ def _get_angle_types(
                         (
                             round(
                                 angle.type.k * (1 / epsilon_conversion_factor),
-                                3,
+                                angle_precision,
                             ),
-                            round(angle.type.theteq, 3),
+                            round(angle.type.theteq, angle_precision),
                             angle.atom2.type,
                             tuple(sorted((angle.atom1.type, angle.atom3.type))),
                         )
@@ -740,9 +741,9 @@ def _get_angle_types(
                 (
                     round(
                         angle.type.k * (1 / epsilon_conversion_factor),
-                        3,
+                        angle_precision),
                     ),
-                    round(angle.type.theteq, 3),
+                    round(angle.type.theteq, angle_precision),
                     angle.atom2.type,
                     tuple(sorted((angle.atom1.type, angle.atom3.type))),
                 )
@@ -759,6 +760,7 @@ def _get_dihedral_types(
     use_dihedrals,
     epsilon_conversion_factor,
     zero_dihedral_weighting_factor,
+    dihedral_precision=5
 ):
     """
     Will get the dihedral types from a parmed structure and convert them to lammps real units.
@@ -772,14 +774,14 @@ def _get_dihedral_types(
                 OrderedSet(
                     *[
                         (
-                            round(dihedral.type.c0 * lj_unit, 5),
-                            round(dihedral.type.c1 * lj_unit, 5),
-                            round(dihedral.type.c2 * lj_unit, 5),
-                            round(dihedral.type.c3 * lj_unit, 5),
-                            round(dihedral.type.c4 * lj_unit, 5),
-                            round(dihedral.type.c5 * lj_unit, 5),
+                            round(dihedral.type.c0 * lj_unit, dihedral_precision),
+                            round(dihedral.type.c1 * lj_unit, dihedral_precision),
+                            round(dihedral.type.c2 * lj_unit, dihedral_precision),
+                            round(dihedral.type.c3 * lj_unit, dihedral_precision),
+                            round(dihedral.type.c4 * lj_unit, dihedral_precision),
+                            round(dihedral.type.c5 * lj_unit, dihedral_precision),
                             round(dihedral.type.scee, 1),
-                            round(dihedral.type.scnb, 1),
+                            round(dihedral.type.scnb, 1)
                             dihedral.atom1.type,
                             dihedral.atom2.type,
                             dihedral.atom3.type,
@@ -796,12 +798,12 @@ def _get_dihedral_types(
         dihedral_types = [
             unique_dihedral_types[
                 (
-                    round(dihedral.type.c0 * lj_unit, 5),
-                    round(dihedral.type.c1 * lj_unit, 5),
-                    round(dihedral.type.c2 * lj_unit, 5),
-                    round(dihedral.type.c3 * lj_unit, 5),
-                    round(dihedral.type.c4 * lj_unit, 5),
-                    round(dihedral.type.c5 * lj_unit, 5),
+                    round(dihedral.type.c0 * lj_unit, dihedral_precision),
+                    round(dihedral.type.c1 * lj_unit, dihedral_precision),
+                    round(dihedral.type.c2 * lj_unit, dihedral_precision),
+                    round(dihedral.type.c3 * lj_unit, dihedral_precision),
+                    round(dihedral.type.c4 * lj_unit, dihedral_precision),
+                    round(dihedral.type.c5 * lj_unit, dihedral_precision),
                     round(dihedral.type.scee, 1),
                     round(dihedral.type.scnb, 1),
                     dihedral.atom1.type,
@@ -849,7 +851,7 @@ def _get_dihedral_types(
     return dihedral_types, unique_dihedral_types
 
 
-def _get_improper_dihedral_types(structure, epsilon_conversion_factor):
+def _get_improper_dihedral_types(structure, epsilon_conversion_factor, imp_dih_precision=3):
     """
     Will get the improper types from a parmed structure and convert them to lammps real units.
 
@@ -869,7 +871,7 @@ def _get_improper_dihedral_types(structure, epsilon_conversion_factor):
                 d = 1
             improper_dihedrals.append(
                 (
-                    round(dih_type.phi_k * lj_unit, 3),
+                    round(dih_type.phi_k * lj_unit, imp_dih_precision)),
                     d,
                     int(round(dih_type.per, 0)),
                     round(dih_type.scee, 1),
@@ -892,7 +894,7 @@ def _get_improper_dihedral_types(structure, epsilon_conversion_factor):
     return imp_dihedral_types, unique_imp_dihedral_types
 
 
-def _get_impropers(structure, epsilon_conversion_factor):
+def _get_impropers(structure, epsilon_conversion_factor, improper_precision=3):
     """
     Will get the improper types from a parmed structure and convert them to lammps real units.
 
@@ -904,8 +906,8 @@ def _get_impropers(structure, epsilon_conversion_factor):
             OrderedSet(
                 *[
                     (
-                        round(improper.type.psi_k * lj_unit, 3),
-                        round(improper.type.psi_eq, 3),
+                        round(improper.type.psi_k * lj_unit, improper_precision),
+                        round(improper.type.psi_eq, improper_precision),
                         improper.atom3.type,
                         improper.atom2.type,
                         improper.atom1.type,
@@ -922,8 +924,8 @@ def _get_impropers(structure, epsilon_conversion_factor):
     improper_types = [
         unique_improper_types[
             (
-                round(improper.type.psi_k * lj_unit, 3),
-                round(improper.type.psi_eq, 3),
+                round(improper.type.psi_k * lj_unit, improper_precision),
+                round(improper.type.psi_eq, improper_precision),
                 improper.atom3.type,
                 improper.atom2.type,
                 improper.atom1.type,

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -835,7 +835,7 @@ def _get_dihedral_types(
                         )
                     )
 
-        unique_dihedral_types = OrderedDict(enumerate(set(charmm_dihedrals)))
+        unique_dihedral_types = OrderedDict(enumerate(OrderedSet(*charmm_dihedrals)))
         unique_dihedral_types = OrderedDict(
             [(y, x + 1) for x, y in unique_dihedral_types.items()]
         )
@@ -878,7 +878,7 @@ def _get_improper_dihedral_types(structure, epsilon_conversion_factor):
                     dihedral.atom4.type,
                 )
             )
-    unique_imp_dihedral_types = dict(enumerate(set(improper_dihedrals)))
+    unique_imp_dihedral_types = dict(enumerate(OrderedSet(*improper_dihedrals)))
     unique_imp_dihedral_types = OrderedDict(
         [(y, x + 1) for x, y in unique_imp_dihedral_types.items()]
     )
@@ -899,8 +899,8 @@ def _get_impropers(structure, epsilon_conversion_factor):
     lj_unit = 1 / epsilon_conversion_factor
     unique_improper_types = dict(
         enumerate(
-            set(
-                [
+            OrderedSet(
+                *[
                     (
                         round(improper.type.psi_k * lj_unit, 3),
                         round(improper.type.psi_eq, 3),

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -13,21 +13,11 @@ from mbuild.utils.conversion import RB_to_OPLS
 from mbuild.utils.sorting import natural_sort
 
 __all__ = ["write_lammpsdata"]
-
-# returns True if both mins and maxs have been defined, and each have length 3
-# otherwise returns False
-def _check_minsmaxs(mins, maxs):
-    if mins and maxs:
-        if len(mins) == 3 and len(maxs) == 3:
-            return True
-        else:
-            warn(
-                "mins and maxs passed to write_lammpsdata, but list size is "
-                "incorrect. mins and maxs will be ignored."
-            )
-            return False
-    else:
-        return False
+# Define constants for conversions
+KCAL_TO_KJ = 4.184
+NM2_TO_ANG2 = 100.0
+NM_TO_ANG = 10.0
+ELEM_TO_COUL = 1.602176634e-19
 
 
 def write_lammpsdata(
@@ -43,6 +33,9 @@ def write_lammpsdata(
     use_urey_bradleys=False,
     use_rb_torsions=True,
     use_dihedrals=False,
+    sigma_conversion_factor=None,
+    epsilon_conversion_factor=None,
+    mass_conversion_factor=None,
     zero_dihedral_weighting_factor=False,
     moleculeID_offset=1,
 ):
@@ -70,9 +63,9 @@ def write_lammpsdata(
         see https://lammps.sandia.gov/doc/99/units.html for more information
         on unit styles
     mins : list
-        minimum box dimension in x, y, z directions
+        minimum box dimension in x, y, z directions, nm
     maxs : list
-        maximum box dimension in x, y, z directions
+        maximum box dimension in x, y, z directions, nm
     pair_coeff_label : str
         Provide a custom label to the pair_coeffs section in the lammps data
         file. Defaults to None, which means a suitable default will be chosen.
@@ -91,6 +84,18 @@ def write_lammpsdata(
     zero_dihedral_weighting_factor:
         If True, will set weighting parameter to zero in CHARMM-style dihedrals.
         This should be True if the CHARMM dihedral style is used in non-CHARMM forcefields.
+    sigma_conversion_factor: None, float
+        If unit_style is set to 'lj', then sigma conversion factor is used to non-dimensionalize.
+        Assume to be in units of nm. Default is None. If None, will take the largest sigma value in
+        the structure.atoms.sigma values.
+    epsilon_conversion_factor: None, float
+        If unit_style is set to 'lj', then epsilon conversion factor is used to non-dimensionalize.
+        Assume to be in units of kCal/mol. Default is None. If None, will take the largest epsilon value in
+        the structure.atoms.epsilon values.
+    mass_conversion_factor: None, float
+        If unit_style is set to 'lj', then mass conversion factor is used to non-dimensionalize.
+        Assume to be in units of amu. Default is None. If None, will take the largest mass value in
+        the structure.atoms.mass values.
     moleculeID_offset : int , optional, default=1
         Since LAMMPS treats the MoleculeID as an additional set of information
         to identify what molecule an atom belongs to, this currently
@@ -112,10 +117,10 @@ def write_lammpsdata(
     https://github.com/mdtraj/mdtraj/blob/master/mdtraj/formats/lammpstrj.py
     for details.
 
-    unique_types : a sorted list of unique atomtypes for all atoms in the
-        structure where atomtype = atom.type.
-    unique_bond_types: an enumarated OrderedDict of unique bond types for all
-        bonds in the structure.
+    unique_types : a sorted list of unique atomtypes for all atoms in the structure.
+        Defined by:
+            atomtype : atom.type
+    unique_bond_types: an enumarated OrderedDict of unique bond types for all bonds in the structure.
         Defined by bond parameters and component atomtypes, in order:
         --- k : bond.type.k
         --- req : bond.type.req
@@ -144,26 +149,27 @@ def write_lammpsdata(
         --- atomtype 3 : dihedral.atom3.type
         --- atomtype 4 : dihedral.atom4.type
     """
-    # copy structure so the input structure isn't modified in-place
-    structure = structure.copy(cls=Structure, split_dihedrals=True)
     if atom_style not in ["atomic", "charge", "molecular", "full"]:
         raise ValueError(
-            'Atom style "{atom_style}" is invalid or is not currently supported'
-        )
-
-    # Check if structure is paramterized
-    if unit_style == "lj":
-        if any([atom.sigma for atom in structure.atoms]) is None:
-            raise ValueError(
-                "LJ units specified but one or more atoms has undefined LJ "
-                "parameters."
+            'Atom style "{}" is invalid or is not currently supported'.format(
+                atom_style
             )
-
-    xyz = np.array([[atom.xx, atom.xy, atom.xz] for atom in structure.atoms])
+        )
+    if unit_style not in ["real", "lj"]:
+        raise ValueError(
+            'Unit style "{}" is invalid or is not currently supported'.format(
+                unit_style
+            )
+        )
 
     forcefield = True
     if structure[0].type == "":
         forcefield = False
+    # copy structure so the input structure isn't modified in-place
+    structure = structure.copy(cls=Structure, split_dihedrals=True)
+
+    # units of angstroms
+    xyz = np.array([[atom.xx, atom.xy, atom.xz] for atom in structure.atoms])
 
     if forcefield:
         types = [atom.type for atom in structure.atoms]
@@ -175,26 +181,6 @@ def write_lammpsdata(
 
     charges = np.array([atom.charge for atom in structure.atoms])
 
-    # Convert coordinates to LJ units
-    if unit_style == "lj":
-        # Get sigma, mass, and epsilon conversions by finding maximum of each
-        sigma_conversion_factor = np.max([a.sigma for a in structure.atoms])
-        epsilon_conversion_factor = np.max([a.epsilon for a in structure.atoms])
-        mass_conversion_factor = np.max([a.mass for a in structure.atoms])
-
-        xyz = xyz / sigma_conversion_factor
-        charges = (charges * 1.6021e-19) / np.sqrt(
-            4
-            * np.pi
-            * (sigma_conversion_factor * 1e-10)
-            * (epsilon_conversion_factor * 4184)
-            * epsilon_0
-        )
-        charges[np.isinf(charges)] = 0
-    else:
-        sigma_conversion_factor = 1
-        epsilon_conversion_factor = 1
-        mass_conversion_factor = 1
     # lammps does not require the box to be centered at any a specific origin
     # min and max dimensions are therefore needed to write the file in a
     # consistent way the parmed structure only stores the box length.  It is
@@ -203,13 +189,14 @@ def write_lammpsdata(
     # NOTE: 0 to L is current default, mins and maxs should be passed by user
 
     if _check_minsmaxs(mins, maxs):
+        mins = np.array(mins) * NM_TO_ANG
+        maxs = np.array(maxs) * NM_TO_ANG
         box = Box.from_mins_maxs_angles(
             mins=mins, maxs=maxs, angles=structure.box[3:6]
-        )
-    else:
-        # Internally use nm
+        )  # box lengths input in nm, so convert to angstrom
+    else:  # Parmed internally converts box to angstroms
         box = Box(
-            lengths=np.array([0.1 * val for val in structure.box[0:3]]),
+            lengths=np.array([val for val in structure.box[0:3]]),
             angles=structure.box[3:6],
         )
 
@@ -222,11 +209,6 @@ def write_lammpsdata(
             "write_lammpsdata function or by passing box info to the save "
             "function."
         )
-    # Divide by conversion factor
-    Lx = box.Lx * (1 / sigma_conversion_factor)
-    Ly = box.Ly * (1 / sigma_conversion_factor)
-    Lz = box.Lz * (1 / sigma_conversion_factor)
-    box = Box(lengths=(Lx, Ly, Lz), angles=box.angles)
 
     # Lammps syntax depends on the functional form
     # Infer functional form based on the properties of the structure
@@ -258,6 +240,7 @@ def write_lammpsdata(
             "Forcefield XML and structure"
         )
 
+    # save atom index information for all bonded params in structure
     bonds = [[b.atom1.idx + 1, b.atom2.idx + 1] for b in structure.bonds]
     angles = [
         [angle.atom1.idx + 1, angle.atom2.idx + 1, angle.atom3.idx + 1]
@@ -289,6 +272,43 @@ def write_lammpsdata(
     if impropers and imp_dihedrals:
         raise ValueError("Use of multiple improper styles is not supported")
 
+    # Get lj conversion factors if they exist and apply lj params to charges and box
+    # Params are in read in mbuild units of angstrom, kcal/mol, amu and converted to lammps units
+    if unit_style == "lj":
+        sigma_conversion_factor = _evaluate_lj_conversion_factors(
+            structure, "sigma", sigma_conversion_factor
+        )
+        epsilon_conversion_factor = _evaluate_lj_conversion_factors(
+            structure, "epsilon", epsilon_conversion_factor
+        )
+        mass_conversion_factor = _evaluate_lj_conversion_factors(
+            structure, "mass", mass_conversion_factor
+        )
+        # Convert coordinates and charges to LJ units
+        xyz = xyz / sigma_conversion_factor
+        charges = (charges * ELEM_TO_COUL) / np.sqrt(
+            4
+            * np.pi
+            * sigma_conversion_factor
+            * NM_TO_ANG**-1
+            * epsilon_conversion_factor
+            * KCAL_TO_KJ
+            * epsilon_0
+            * 10**-6
+        )
+        charges[np.isinf(charges)] = 0
+    else:
+        sigma_conversion_factor = 1
+        epsilon_conversion_factor = 1
+        mass_conversion_factor = 1
+
+    # Divide by conversion factor
+    Lx = box.Lx * (1 / sigma_conversion_factor)
+    Ly = box.Ly * (1 / sigma_conversion_factor)
+    Lz = box.Lz * (1 / sigma_conversion_factor)
+    box = Box(lengths=(Lx, Ly, Lz), angles=box.angles)
+
+    # Get bonded parameter information from structure
     if bonds:
         if len(structure.bond_types) == 0:
             bond_types = np.ones(len(bonds), dtype=int)
@@ -313,6 +333,7 @@ def write_lammpsdata(
             imp_dihedral_types,
             unique_imp_dihedral_types,
         ) = _get_improper_dihedral_types(structure, epsilon_conversion_factor)
+
     if dihedrals:
         dihedral_types, unique_dihedral_types = _get_dihedral_types(
             structure,
@@ -327,8 +348,24 @@ def write_lammpsdata(
             structure, epsilon_conversion_factor
         )
 
+    # Write lammps data file https://docs.lammps.org/2001/data_format.html
     with open(filename, "w") as data:
-        data.write(f"{filename} - created by mBuild; units = {unit_style}\n\n")
+
+        data.write(f"{filename} - created by mBuild; units = {unit_style}\n")
+        if unit_style == "lj":
+            data.write("#Normalization factors: ")
+            data.write(
+                "sigma - {:.3E} (angstrom), ".format(sigma_conversion_factor)
+            )
+            data.write(
+                "epsilon - {:.3E} (kcal/mol), ".format(
+                    epsilon_conversion_factor
+                )
+            )
+            data.write("mass - {:.3E} (amu)".format(mass_conversion_factor))
+        data.write("\n")
+
+        # Write counts of bonded interactions
         data.write("{:d} atoms\n".format(len(structure.atoms)))
         if atom_style in ["full", "molecular"]:
             data.write("{:d} bonds\n".format(len(bonds)))
@@ -338,6 +375,7 @@ def write_lammpsdata(
                 "{:d} impropers\n\n".format(len(impropers) + len(imp_dihedrals))
             )
 
+        # Write counts of unique bonded types
         data.write("{:d} atom types\n".format(len(set(types))))
         if atom_style in ["full", "molecular"]:
             if bonds:
@@ -358,409 +396,77 @@ def write_lammpsdata(
                 )
 
         data.write("\n")
-        # Box data
+        # Write box data
         # NOTE: Needs better logic handling maxs and mins of a bounding box
-        # NOTE: JBG, "this should be a method/attribute of Compound?"
-        if np.allclose(box.angles, 90.0, atol=1e-5) and (mins is None):
-            for i, dim in enumerate(["x", "y", "z"]):
-                data.write(
-                    "{0:.6f} {1:.6f} {2}lo {2}hi\n".format(
-                        0.0, 10.0 * box.lengths[i], dim
-                    )
-                )
-        # NOTE:
-        # currently non-orthogonal bounding box translates
-        # Compound such that mins are new origin
-        else:
-            a = 10.0 * box.Lx
-            b = 10.0 * box.Ly
-            c = 10.0 * box.Lz
-            alpha, beta, gamma = np.radians(box.angles)
+        # NOTE: CCC, "could be an option to grab mins and maxs of the structure boundingbox"
+        # Lammps supports any box origin, so it is okay if it matches the structure positions
+        _write_box_information(box, data, mins)
 
-            xy = box.xy
-            xz = box.xz
-            yz = box.yz
-
-            # NOTE: using (0,0,0) as origin
-            xlo, ylo, zlo = (0.0, 0.0, 0.0)
-            xhi = xlo + a
-            yhi = ylo + b
-            zhi = zlo + c
-
-            xlo_bound = xlo + np.min([0.0, xy, xz, xy + xz])
-            xhi_bound = xhi + np.max([0.0, xy, xz, xy + xz])
-            ylo_bound = ylo + np.min([0.0, yz])
-            yhi_bound = yhi + np.max([0.0, yz])
-            zlo_bound = zlo
-            zhi_bound = zhi
-
-            data.write("{0:.6f} {1:.6f} xlo xhi\n".format(xlo_bound, xhi_bound))
-            data.write("{0:.6f} {1:.6f} ylo yhi\n".format(ylo_bound, yhi_bound))
-            data.write("{0:.6f} {1:.6f} zlo zhi\n".format(zlo_bound, zhi_bound))
-            data.write("{0:.6f} {1:.6f} {2:6f} xy xz yz\n".format(xy, xz, yz))
-
-        # Mass data
-        if not forcefield:
-            masses = (
-                np.array([atom.mass for atom in structure.atoms])
-                / mass_conversion_factor
-            )
-        else:
-            tmp_masses = list()
-            for atom in structure.atoms:
-                # handle case where atomtype does not contain a mass
-                try:
-                    tmp_masses.append(atom.atom_type.mass)
-                except AttributeError:
-                    warn(
-                        f"No mass or defined atomtype for atom: {atom}. Using atom mass of {atom.mass / mass_conversion_factor}"
-                    )
-                    tmp_masses.append(atom.mass)
-            masses = np.asarray(tmp_masses) / mass_conversion_factor
-
-        mass_dict = dict(
-            [
-                (unique_types.index(atom_type) + 1, mass)
-                for atom_type, mass in zip(types, masses)
-            ]
+        # Write mass data
+        _write_mass_information(
+            structure,
+            data,
+            mass_conversion_factor,
+            forcefield,
+            unique_types,
+            types,
         )
-        data.write("\nMasses\n\n")
-        for atom_type, mass in sorted(mass_dict.items()):
-            data.write(
-                "{:d}\t{:.6f}\t# {}\n".format(
-                    atom_type, mass, unique_types[atom_type - 1]
-                )
-            )
 
         if forcefield:
-            epsilons = (
-                np.array([atom.epsilon for atom in structure.atoms])
-                / epsilon_conversion_factor
-            )
-            sigmas = (
-                np.array([atom.sigma for atom in structure.atoms])
-                / sigma_conversion_factor
-            )
-            forcefields = [atom.type for atom in structure.atoms]
-            epsilon_dict = dict(
-                [
-                    (unique_types.index(atom_type) + 1, epsilon)
-                    for atom_type, epsilon in zip(types, epsilons)
-                ]
-            )
-            sigma_dict = dict(
-                [
-                    (unique_types.index(atom_type) + 1, sigma)
-                    for atom_type, sigma in zip(types, sigmas)
-                ]
-            )
-            forcefield_dict = dict(
-                [
-                    (unique_types.index(atom_type) + 1, forcefield)
-                    for atom_type, forcefield in zip(types, forcefields)
-                ]
+            # Write pair coefficients data
+            _write_pair_information(
+                structure,
+                data,
+                forcefield,
+                sigma_conversion_factor,
+                epsilon_conversion_factor,
+                unique_types,
+                types,
+                pair_coeff_label,
+                unit_style,
+                nbfix_in_data_file,
             )
 
-            # Modified cross-interactions
-            if structure.has_NBFIX():
-                params = ParameterSet.from_structure(structure)
-                # Sort keys (maybe they should be sorted in ParmEd)
-                new_nbfix_types = OrderedDict()
-                for key in params.nbfix_types.keys():
-                    sorted_key = tuple(sorted(key))
-                    if sorted_key in new_nbfix_types:
-                        warn("Sorted key matches an existing key")
-                        if new_nbfix_types[sorted_key]:
-                            warn(
-                                "nbfixes are not symmetric, overwriting old "
-                                "nbfix"
-                            )
-                    new_nbfix_types[sorted_key] = params.nbfix_types[key]
-                params.nbfix_types = new_nbfix_types
-                warn(
-                    "Explicitly writing cross interactions using mixing rule: "
-                    "{}".format(structure.combining_rule)
-                )
-                coeffs = OrderedDict()
-                for combo in it.combinations_with_replacement(unique_types, 2):
-                    # Attempt to find pair coeffis in nbfixes
-                    if combo in params.nbfix_types:
-                        type1 = unique_types.index(combo[0]) + 1
-                        type2 = unique_types.index(combo[1]) + 1
-                        epsilon = params.nbfix_types[combo][
-                            0
-                        ]  # kcal OR lj units
-                        rmin = params.nbfix_types[combo][
-                            1
-                        ]  # Angstrom OR lj units
-                        sigma = rmin / 2 ** (1 / 6)
-                        coeffs[(type1, type2)] = (
-                            round(sigma, 8),
-                            round(epsilon, 8),
-                        )
-                    else:
-                        type1 = unique_types.index(combo[0]) + 1
-                        type2 = unique_types.index(combo[1]) + 1
-                        # Might not be necessary to be this explicit
-                        if type1 == type2:
-                            sigma = sigma_dict[type1]
-                            epsilon = epsilon_dict[type1]
-                        else:
-                            if structure.combining_rule == "lorentz":
-                                sigma = (
-                                    sigma_dict[type1] + sigma_dict[type2]
-                                ) * 0.5
-                            elif structure.combining_rule == "geometric":
-                                sigma = (
-                                    sigma_dict[type1] * sigma_dict[type2]
-                                ) ** 0.5
-                            else:
-                                raise ValueError(
-                                    "Only lorentz and geometric combining "
-                                    "rules are supported"
-                                )
-                            epsilon = (
-                                epsilon_dict[type1] * epsilon_dict[type2]
-                            ) ** 0.5
-                        coeffs[(type1, type2)] = (
-                            round(sigma, 8),
-                            round(epsilon, 8),
-                        )
-                if nbfix_in_data_file:
-                    if pair_coeff_label:
-                        data.write(
-                            "\nPairIJ Coeffs # {}\n".format(pair_coeff_label)
-                        )
-                    else:
-                        data.write("\nPairIJ Coeffs # modified lj\n")
-
-                    data.write(
-                        "# type1 type2\tepsilon (kcal/mol)\tsigma (Angstrom)\n"
-                    )
-
-                    for (type1, type2), (sigma, epsilon) in coeffs.items():
-                        data.write(
-                            "{0} \t{1} \t{2} \t\t{3}\t\t# {4}\t{5}\n".format(
-                                type1,
-                                type2,
-                                epsilon,
-                                sigma,
-                                forcefield_dict[type1],
-                                forcefield_dict[type2],
-                            )
-                        )
-                else:
-                    if pair_coeff_label:
-                        data.write(
-                            "\nPair Coeffs # {}\n".format(pair_coeff_label)
-                        )
-                    else:
-                        data.write("\nPair Coeffs # lj\n")
-
-                    for idx, epsilon in sorted(epsilon_dict.items()):
-                        data.write(
-                            "{}\t{:.5f}\t{:.5f}\n".format(
-                                idx, epsilon, sigma_dict[idx]
-                            )
-                        )
-                    print("Copy these commands into your input script:\n")
-                    print(
-                        "# type1 type2\tepsilon (kcal/mol)\tsigma (Angstrom)\n"
-                    )
-                    for (type1, type2), (sigma, epsilon) in coeffs.items():
-                        print(
-                            "pair_coeff\t{0} \t{1} \t{2} \t\t{3} \t\t# {4} \t{5}".format(
-                                type1,
-                                type2,
-                                epsilon,
-                                sigma,
-                                forcefield_dict[type1],
-                                forcefield_dict[type2],
-                            )
-                        )
-
-            # Pair coefficients
-            else:
-                if pair_coeff_label:
-                    data.write("\nPair Coeffs # {}\n".format(pair_coeff_label))
-                else:
-                    data.write("\nPair Coeffs # lj\n")
-
-                if unit_style == "real":
-                    data.write("#\tepsilon (kcal/mol)\t\tsigma (Angstrom)\n")
-                elif unit_style == "lj":
-                    data.write("#\treduced_epsilon \t\treduced_sigma \n")
-                for idx, epsilon in sorted(epsilon_dict.items()):
-                    data.write(
-                        "{}\t{:.5f}\t\t{:.5f}\t\t# {}\n".format(
-                            idx, epsilon, sigma_dict[idx], forcefield_dict[idx]
-                        )
-                    )
-
-            # Bond coefficients
+            # Write bond coefficients
             if bonds:
-                data.write("\nBond Coeffs # harmonic\n")
-                if unit_style == "real":
-                    data.write("#\tk(kcal/mol/angstrom^2)\t\treq(angstrom)\n")
-                elif unit_style == "lj":
-                    data.write("#\treduced_k\t\treduced_req\n")
-                sorted_bond_types = {
-                    k: v
-                    for k, v in sorted(
-                        unique_bond_types.items(), key=lambda item: item[1]
-                    )
-                }
-                for params, idx in sorted_bond_types.items():
-                    data.write(
-                        "{}\t{}\t\t{}\t\t# {}\t{}\n".format(
-                            idx,
-                            params[0],
-                            params[1],
-                            params[2][0],
-                            params[2][1],
-                        )
-                    )
+                _write_bond_information(
+                    structure, data, unique_bond_types, unit_style
+                )
 
-            # Angle coefficients
+            # Write angle coefficients
             if angles:
-                sorted_angle_types = {
-                    k: v
-                    for k, v in sorted(
-                        unique_angle_types.items(), key=lambda item: item[1]
-                    )
-                }
-                if use_urey_bradleys:
-                    data.write("\nAngle Coeffs # charmm\n")
-                    data.write(
-                        "#\tk(kcal/mol/rad^2)\t\ttheteq(deg)\tk(kcal/mol/angstrom^2)\treq(angstrom)\n"
-                    )
-                    for params, idx in sorted_angle_types.items():
-                        data.write(
-                            "{}\t{}\t{:.5f}\t{:.5f}\t{:.5f}\n".format(
-                                idx, *params
-                            )
-                        )
+                _write_angle_information(
+                    structure,
+                    data,
+                    unique_angle_types,
+                    use_urey_bradleys,
+                    unit_style,
+                )
 
-                else:
-                    data.write("\nAngle Coeffs # harmonic\n")
-                    data.write("#\treduced_k\t\ttheteq(deg)\n")
-                    for params, idx in sorted_angle_types.items():
-                        data.write(
-                            "{}\t{}\t\t{:.5f}\t# {}\t{}\t{}\n".format(
-                                idx,
-                                params[0],
-                                params[1],
-                                params[3][0],
-                                params[2],
-                                params[3][1],
-                            )
-                        )
-
-            # Dihedral coefficients
+            # Write dihedral coefficients
             if dihedrals:
-                sorted_dihedral_types = {
-                    k: v
-                    for k, v in sorted(
-                        unique_dihedral_types.items(), key=lambda item: item[1]
-                    )
-                }
-                if use_rb_torsions:
-                    data.write("\nDihedral Coeffs # opls\n")
-                    if unit_style == "real":
-                        data.write(
-                            "#\tf1(kcal/mol)\tf2(kcal/mol)\tf3(kcal/mol)\tf4(kcal/mol)\n"
-                        )
-                    elif unit_style == "lj":
-                        data.write("#\tf1\tf2\tf3\tf4 (all lj reduced units)\n")
-                    for params, idx in sorted_dihedral_types.items():
-                        opls_coeffs = RB_to_OPLS(
-                            params[0],
-                            params[1],
-                            params[2],
-                            params[3],
-                            params[4],
-                            params[5],
-                            error_if_outside_tolerance=False,
-                        )
-                        data.write(
-                            "{}\t{:.5f}\t{:.5f}\t\t{:.5f}\t\t{:.5f}\t# {}\t{}\t{}\t{}\n".format(
-                                idx,
-                                opls_coeffs[1],
-                                opls_coeffs[2],
-                                opls_coeffs[3],
-                                opls_coeffs[4],
-                                params[8],
-                                params[9],
-                                params[10],
-                                params[11],
-                            )
-                        )
-                elif use_dihedrals:
-                    data.write("\nDihedral Coeffs # charmm\n")
-                    data.write("#k, n, phi, weight\n")
-                    for params, idx in sorted_dihedral_types.items():
-                        data.write(
-                            "{}\t{:.5f}\t{:d}\t{:d}\t{:.5f}\t# {}\t{}\t{}\t{}\n".format(
-                                idx,
-                                params[0],
-                                params[1],
-                                params[2],
-                                params[3],
-                                params[6],
-                                params[7],
-                                params[8],
-                                params[9],
-                            )
-                        )
+                _write_dihedral_information(
+                    structure,
+                    data,
+                    unique_dihedral_types,
+                    unit_style,
+                    use_rb_torsions,
+                    use_dihedrals,
+                )
 
-            # Improper coefficients
+            # Write improper coefficients
             if impropers:
-                sorted_improper_types = {
-                    k: v
-                    for k, v in sorted(
-                        unique_improper_types.items(), key=lambda item: item[1]
-                    )
-                }
-                data.write("\nImproper Coeffs # harmonic\n")
-                data.write("#k, phi\n")
-                for params, idx in sorted_improper_types.items():
-                    data.write(
-                        "{}\t{:.5f}\t{:.5f}\t# {}\t{}\t{}\t{}\n".format(
-                            idx,
-                            params[0],
-                            params[1],
-                            params[2],
-                            params[3],
-                            params[4],
-                            params[5],
-                        )
-                    )
+                _write_improper_information(
+                    structure, data, unique_improper_types, unit_style
+                )
+                # Write improper dihedrals
             elif imp_dihedrals:
-                # Improper dihedral coefficients
-                sorted_imp_dihedral_types = {
-                    k: v
-                    for k, v in sorted(
-                        unique_imp_dihedral_types.items(),
-                        key=lambda item: item[1],
-                    )
-                }
-                data.write("\nImproper Coeffs # cvff\n")
-                data.write("#K, d, n\n")
-                for params, idx in sorted_imp_dihedral_types.items():
-                    data.write(
-                        "{}\t{:.5f}\t{:d}\t{:d}\t# {}\t{}\t{}\t{}\n".format(
-                            idx,
-                            params[0],
-                            params[1],
-                            params[2],
-                            params[5],
-                            params[6],
-                            params[7],
-                            params[8],
-                        )
-                    )
+                _write_imp_dihedral_information(
+                    structure, data, unique_imp_dihedral_types, unit_style
+                )
 
-        # Atom data
+        # Write Atom data
+        # _write_atom_data(atom_style, unit_style)
         data.write("\nAtoms # {}\n\n".format(atom_style))
         if atom_style == "atomic":
             atom_line = "{index:d}\t{type_index:d}\t{x:.6f}\t{y:.6f}\t{z:.6f}\n"
@@ -857,28 +563,82 @@ def write_lammpsdata(
                     )
 
 
+def _evaluate_lj_conversion_factors(
+    structure, conversion_name, conversion_factor
+):
+    """Get Lennard Jones style conversion factors. `conversion_name`` can be sigma, epsilon, or mass."""
+    if conversion_factor is None:
+        # Check if structure is parametrized
+        if any([atom.sigma for atom in structure.atoms]) is None:
+            raise ValueError(
+                "LJ units specified but one or more atoms has undefined LJ "
+                "parameters."
+            )
+        else:
+            conversion_factor = np.max(
+                [getattr(atom, conversion_name) for atom in structure.atoms]
+            )
+            warn(
+                f"Assuming {conversion_name} conversion factor of "
+                + str(conversion_factor)
+            )
+        if conversion_factor == 0:
+            conversion_factor = 1
+            warn(
+                f"{conversion_name} conversion factor cannot be inferred from the maximum {conversion_name} value in the ParmEd Structure. "
+                "Setting the {conversion_name} conversion factor to 1"
+            )
+    elif conversion_factor <= 0:
+        raise ValueError(
+            f"The {conversion_name} conversion factor to convert to LJ units should be greater than 0."
+        )
+    else:
+        # assume conversion factor passed in mbuild units, convert to lammps real units
+        if conversion_name == "sigma":
+            conversion_factor *= NM_TO_ANG
+        elif conversion_name == "epsilon":
+            conversion_factor *= 1 / KCAL_TO_KJ
+        elif conversion_name == "mass":
+            pass
+    return conversion_factor
+
+
+def _check_minsmaxs(mins, maxs):
+    """Return True if both mins and maxs have been defined, and each have length 3 otherwise returns False."""
+    if mins and maxs:
+        if len(mins) == 3 and len(maxs) == 3:
+            return True
+        else:
+            warn(
+                "mins and maxs passed to write_lammpsdata, but list size is "
+                "incorrect. mins and maxs will be ignored."
+            )
+            return False
+    else:
+        return False
+
+
 def _get_bond_types(
     structure, bonds, sigma_conversion_factor, epsilon_conversion_factor
 ):
-    unique_bond_types = dict(
+    """Will get the bond types from a parmed structure and convert them to lammps real units."""
+    unique_bond_types = OrderedDict(
         enumerate(
-            set(
-                [
-                    (
-                        round(
-                            bond.type.k
-                            * (
-                                sigma_conversion_factor**2
-                                / epsilon_conversion_factor
-                            ),
-                            3,
+            [
+                (
+                    round(
+                        bond.type.k
+                        * (
+                            sigma_conversion_factor**2
+                            / epsilon_conversion_factor
                         ),
-                        round(bond.type.req / sigma_conversion_factor, 3),
-                        tuple(sorted((bond.atom1.type, bond.atom2.type))),
-                    )
-                    for bond in structure.bonds
-                ]
-            )
+                        3,
+                    ),
+                    round(bond.type.req / sigma_conversion_factor, 3),
+                    tuple(sorted((bond.atom1.type, bond.atom2.type))),
+                )
+                for bond in structure.bonds
+            ]
         )
     )
     unique_bond_types = OrderedDict(
@@ -909,6 +669,11 @@ def _get_angle_types(
     sigma_conversion_factor,
     epsilon_conversion_factor,
 ):
+    """
+    Will get the angle types from a parmed structure and convert them to lammps real units.
+
+    Can get the parameters if urey bradleys or harmonic angles.
+    """
     if use_urey_bradleys:
         charmm_angle_types = []
         for angle in structure.angles:
@@ -935,7 +700,7 @@ def _get_angle_types(
                 )
             )
 
-        unique_angle_types = dict(enumerate(set(charmm_angle_types)))
+        unique_angle_types = OrderedDict(enumerate(set(charmm_angle_types)))
         unique_angle_types = OrderedDict(
             [(y, x + 1) for x, y in unique_angle_types.items()]
         )
@@ -944,26 +709,20 @@ def _get_angle_types(
         ]
 
     else:
-        unique_angle_types = dict(
+        unique_angle_types = OrderedDict(
             enumerate(
-                set(
-                    [
-                        (
-                            round(
-                                angle.type.k
-                                * (
-                                    sigma_conversion_factor**2
-                                    / epsilon_conversion_factor
-                                ),
-                                3,
-                            ),
-                            round(angle.type.theteq, 3),
-                            angle.atom2.type,
-                            tuple(sorted((angle.atom1.type, angle.atom3.type))),
-                        )
-                        for angle in structure.angles
-                    ]
-                )
+                [
+                    (
+                        round(
+                            angle.type.k * (1 / epsilon_conversion_factor),
+                            3,
+                        ),
+                        round(angle.type.theteq, 3),
+                        angle.atom2.type,
+                        tuple(sorted((angle.atom1.type, angle.atom3.type))),
+                    )
+                    for angle in structure.angles
+                ]
             )
         )
         unique_angle_types = OrderedDict(
@@ -973,11 +732,7 @@ def _get_angle_types(
             unique_angle_types[
                 (
                     round(
-                        angle.type.k
-                        * (
-                            sigma_conversion_factor**2
-                            / epsilon_conversion_factor
-                        ),
+                        angle.type.k * (1 / epsilon_conversion_factor),
                         3,
                     ),
                     round(angle.type.theteq, 3),
@@ -998,29 +753,32 @@ def _get_dihedral_types(
     epsilon_conversion_factor,
     zero_dihedral_weighting_factor,
 ):
-    lj_unit = 1 / epsilon_conversion_factor
+    """
+    Will get the dihedral types from a parmed structure and convert them to lammps real units.
+
+    Can be in the form of rb_torsions or charmm dihedrals.
+    """
+    lj_unit = 1.0 / epsilon_conversion_factor
     if use_rb_torsions:
-        unique_dihedral_types = dict(
+        unique_dihedral_types = OrderedDict(
             enumerate(
-                set(
-                    [
-                        (
-                            round(dihedral.type.c0 * lj_unit, 3),
-                            round(dihedral.type.c1 * lj_unit, 3),
-                            round(dihedral.type.c2 * lj_unit, 3),
-                            round(dihedral.type.c3 * lj_unit, 3),
-                            round(dihedral.type.c4 * lj_unit, 3),
-                            round(dihedral.type.c5 * lj_unit, 3),
-                            round(dihedral.type.scee, 1),
-                            round(dihedral.type.scnb, 1),
-                            dihedral.atom1.type,
-                            dihedral.atom2.type,
-                            dihedral.atom3.type,
-                            dihedral.atom4.type,
-                        )
-                        for dihedral in structure.rb_torsions
-                    ]
-                )
+                [
+                    (
+                        round(dihedral.type.c0 * lj_unit, 5),
+                        round(dihedral.type.c1 * lj_unit, 5),
+                        round(dihedral.type.c2 * lj_unit, 5),
+                        round(dihedral.type.c3 * lj_unit, 5),
+                        round(dihedral.type.c4 * lj_unit, 5),
+                        round(dihedral.type.c5 * lj_unit, 5),
+                        round(dihedral.type.scee, 1),
+                        round(dihedral.type.scnb, 1),
+                        dihedral.atom1.type,
+                        dihedral.atom2.type,
+                        dihedral.atom3.type,
+                        dihedral.atom4.type,
+                    )
+                    for dihedral in structure.rb_torsions
+                ]
             )
         )
         unique_dihedral_types = OrderedDict(
@@ -1029,12 +787,12 @@ def _get_dihedral_types(
         dihedral_types = [
             unique_dihedral_types[
                 (
-                    round(dihedral.type.c0 * lj_unit, 3),
-                    round(dihedral.type.c1 * lj_unit, 3),
-                    round(dihedral.type.c2 * lj_unit, 3),
-                    round(dihedral.type.c3 * lj_unit, 3),
-                    round(dihedral.type.c4 * lj_unit, 3),
-                    round(dihedral.type.c5 * lj_unit, 3),
+                    round(dihedral.type.c0 * lj_unit, 5),
+                    round(dihedral.type.c1 * lj_unit, 5),
+                    round(dihedral.type.c2 * lj_unit, 5),
+                    round(dihedral.type.c3 * lj_unit, 5),
+                    round(dihedral.type.c4 * lj_unit, 5),
+                    round(dihedral.type.c5 * lj_unit, 5),
                     round(dihedral.type.scee, 1),
                     round(dihedral.type.scnb, 1),
                     dihedral.atom1.type,
@@ -1057,9 +815,9 @@ def _get_dihedral_types(
                 for dih_type in dihedral.type:
                     charmm_dihedrals.append(
                         (
-                            round(dih_type.phi_k * lj_unit, 3),
+                            dih_type.phi_k * lj_unit,
                             int(round(dih_type.per, 0)),
-                            int(round(dih_type.phase, 0)),
+                            round(dih_type.phase, 3),
                             round(weight, 4),
                             round(dih_type.scee, 1),
                             round(dih_type.scnb, 1),
@@ -1070,7 +828,7 @@ def _get_dihedral_types(
                         )
                     )
 
-        unique_dihedral_types = dict(enumerate(set(charmm_dihedrals)))
+        unique_dihedral_types = OrderedDict(enumerate(set(charmm_dihedrals)))
         unique_dihedral_types = OrderedDict(
             [(y, x + 1) for x, y in unique_dihedral_types.items()]
         )
@@ -1083,6 +841,11 @@ def _get_dihedral_types(
 
 
 def _get_improper_dihedral_types(structure, epsilon_conversion_factor):
+    """
+    Will get the improper types from a parmed structure and convert them to lammps real units.
+
+    Type harmonic https://docs.lammps.org/improper_harmonic.html.
+    """
     lj_unit = 1 / epsilon_conversion_factor
     improper_dihedrals = []
     for dihedral in structure.dihedrals:
@@ -1121,6 +884,11 @@ def _get_improper_dihedral_types(structure, epsilon_conversion_factor):
 
 
 def _get_impropers(structure, epsilon_conversion_factor):
+    """
+    Will get the improper types from a parmed structure and convert them to lammps real units.
+
+    Type cvff https://docs.lammps.org/improper_cvff.html
+    """
     lj_unit = 1 / epsilon_conversion_factor
     unique_improper_types = dict(
         enumerate(
@@ -1159,7 +927,415 @@ def _get_impropers(structure, epsilon_conversion_factor):
     return improper_types, unique_improper_types
 
 
-def _get_box_information(
-    structure,
+def _write_box_information(box, data, mins):
+    """Write box information to lammps data file, can handle non-orthogonal boxes."""
+    if np.allclose(box.angles, 90.0, atol=1e-5) and (mins is None):
+        for i, dim in enumerate(["x", "y", "z"]):
+            data.write(
+                "{0:.6f} {1:.6f} {2}lo {2}hi\n".format(
+                    0.0,
+                    box.lengths[i],
+                    dim,
+                )
+            )
+    # NOTE:
+    # currently non-orthogonal bounding box translates
+    # Compound such that mins are new origin
+    else:
+        a = box.Lx
+        b = box.Ly
+        c = box.Lz
+        # alpha, beta, gamma = np.radians(box.angles)
+
+        xy = box.xy
+        xz = box.xz
+        yz = box.yz
+
+        # NOTE: using (0,0,0) as origin
+        xlo, ylo, zlo = (0.0, 0.0, 0.0)
+        xhi = xlo + a
+        yhi = ylo + b
+        zhi = zlo + c
+
+        xlo_bound = xlo + np.min([0.0, xy, xz, xy + xz])
+        xhi_bound = xhi + np.max([0.0, xy, xz, xy + xz])
+        ylo_bound = ylo + np.min([0.0, yz])
+        yhi_bound = yhi + np.max([0.0, yz])
+        zlo_bound = zlo
+        zhi_bound = zhi
+
+        data.write("{0:.6f} {1:.6f} xlo xhi\n".format(xlo_bound, xhi_bound))
+        data.write("{0:.6f} {1:.6f} ylo yhi\n".format(ylo_bound, yhi_bound))
+        data.write("{0:.6f} {1:.6f} zlo zhi\n".format(zlo_bound, zhi_bound))
+        data.write("{0:.6f} {1:.6f} {2:6f} xy xz yz\n".format(xy, xz, yz))
+
+
+def _write_mass_information(
+    structure, data, mass_conversion_factor, forcefield, unique_types, types
 ):
-    pass
+    """Write mass information from structure to lammps data file."""
+    if not forcefield:
+        masses = (
+            np.array([atom.mass for atom in structure.atoms])
+            / mass_conversion_factor
+        )
+    else:
+        tmp_masses = list()
+        for atom in structure.atoms:
+            # handle case where atomtype does not contain a mass
+            try:
+                tmp_masses.append(atom.atom_type.mass)
+            except AttributeError:
+                warn(
+                    f"No mass or defined atomtype for atom: {atom}. Using atom mass of {atom.mass / mass_conversion_factor}"
+                )
+                tmp_masses.append(atom.mass)
+        masses = np.asarray(tmp_masses) / mass_conversion_factor
+
+    mass_dict = OrderedDict(
+        [
+            (unique_types.index(atom_type) + 1, mass)
+            for atom_type, mass in zip(types, masses)
+        ]
+    )
+    data.write("\nMasses\n\n")
+    for atom_type, mass in sorted(mass_dict.items()):
+        data.write(
+            "{:d}\t{:.6f}\t# {}\n".format(
+                atom_type, mass, unique_types[atom_type - 1]
+            )
+        )
+
+
+def _write_pair_information(
+    structure,
+    data,
+    forcefield,
+    sigma_conversion_factor,
+    epsilon_conversion_factor,
+    unique_types,
+    types,
+    pair_coeff_label,
+    unit_style,
+    nbfix_in_data_file,
+):
+    """Write nonbonded pair information to lammps data file."""
+    epsilons = (
+        np.array([atom.epsilon for atom in structure.atoms])
+        / epsilon_conversion_factor
+    )
+    sigmas = (
+        np.array([atom.sigma for atom in structure.atoms])
+        / sigma_conversion_factor
+    )
+    forcefields = [atom.type for atom in structure.atoms]
+    epsilon_dict = dict(
+        [
+            (unique_types.index(atom_type) + 1, epsilon)
+            for atom_type, epsilon in zip(types, epsilons)
+        ]
+    )
+    sigma_dict = dict(
+        [
+            (unique_types.index(atom_type) + 1, sigma)
+            for atom_type, sigma in zip(types, sigmas)
+        ]
+    )
+    forcefield_dict = dict(
+        [
+            (unique_types.index(atom_type) + 1, forcefield)
+            for atom_type, forcefield in zip(types, forcefields)
+        ]
+    )
+
+    # Modified cross-interactions
+    if structure.has_NBFIX():
+        params = ParameterSet.from_structure(structure)
+        # Sort keys (maybe they should be sorted in ParmEd)
+        new_nbfix_types = OrderedDict()
+        for key in params.nbfix_types.keys():
+            sorted_key = tuple(sorted(key))
+            if sorted_key in new_nbfix_types:
+                warn("Sorted key matches an existing key")
+                if new_nbfix_types[sorted_key]:
+                    warn("nbfixes are not symmetric, overwriting old " "nbfix")
+            new_nbfix_types[sorted_key] = params.nbfix_types[key]
+        params.nbfix_types = new_nbfix_types
+        warn(
+            "Explicitly writing cross interactions using mixing rule: "
+            "{}".format(structure.combining_rule)
+        )
+        coeffs = OrderedDict()
+        for combo in it.combinations_with_replacement(unique_types, 2):
+            # Attempt to find pair coeffis in nbfixes
+            if combo in params.nbfix_types:
+                type1 = unique_types.index(combo[0]) + 1
+                type2 = unique_types.index(combo[1]) + 1
+                epsilon = params.nbfix_types[combo][0]  # kcal OR lj units
+                rmin = params.nbfix_types[combo][1]  # Angstrom OR lj units
+                sigma = rmin / 2 ** (1 / 6)
+                coeffs[(type1, type2)] = (
+                    round(sigma, 8),
+                    round(epsilon, 8),
+                )
+            else:
+                type1 = unique_types.index(combo[0]) + 1
+                type2 = unique_types.index(combo[1]) + 1
+                # Might not be necessary to be this explicit
+                if type1 == type2:
+                    sigma = sigma_dict[type1]
+                    epsilon = epsilon_dict[type1]
+                else:
+                    if structure.combining_rule == "lorentz":
+                        sigma = (sigma_dict[type1] + sigma_dict[type2]) * 0.5
+                    elif structure.combining_rule == "geometric":
+                        sigma = (sigma_dict[type1] * sigma_dict[type2]) ** 0.5
+                    else:
+                        raise ValueError(
+                            "Only lorentz and geometric combining "
+                            "rules are supported"
+                        )
+                    epsilon = (epsilon_dict[type1] * epsilon_dict[type2]) ** 0.5
+                coeffs[(type1, type2)] = (
+                    round(sigma, 8),
+                    round(epsilon, 8),
+                )
+        if nbfix_in_data_file:
+            if pair_coeff_label:
+                data.write("\nPairIJ Coeffs # {}\n".format(pair_coeff_label))
+            else:
+                data.write("\nPairIJ Coeffs # modified lj\n")
+
+            data.write("# type1 type2\tepsilon (kcal/mol)\tsigma (Angstrom)\n")
+
+            for (type1, type2), (sigma, epsilon) in coeffs.items():
+                data.write(
+                    "{0} \t{1} \t{2} \t\t{3}\t\t# {4}\t{5}\n".format(
+                        type1,
+                        type2,
+                        epsilon,
+                        sigma,
+                        forcefield_dict[type1],
+                        forcefield_dict[type2],
+                    )
+                )
+        else:
+            if pair_coeff_label:
+                data.write("\nPair Coeffs # {}\n".format(pair_coeff_label))
+            else:
+                data.write("\nPair Coeffs # lj\n")
+
+            for idx, epsilon in sorted(epsilon_dict.items()):
+                data.write(
+                    "{}\t{:.5f}\t{:.5f}\n".format(idx, epsilon, sigma_dict[idx])
+                )
+            print("Copy these commands into your input script:\n")
+            print("# type1 type2\tepsilon (kcal/mol)\tsigma (Angstrom)\n")
+            for (type1, type2), (sigma, epsilon) in coeffs.items():
+                print(
+                    "pair_coeff\t{0} \t{1} \t{2} \t\t{3} \t\t# {4} \t{5}".format(
+                        type1,
+                        type2,
+                        epsilon,
+                        sigma,
+                        forcefield_dict[type1],
+                        forcefield_dict[type2],
+                    )
+                )
+
+    # Pair coefficients
+    else:
+        if pair_coeff_label:
+            data.write("\nPair Coeffs # {}\n".format(pair_coeff_label))
+        else:
+            data.write("\nPair Coeffs # lj\n")
+
+        if unit_style == "real":
+            data.write("#\tepsilon (kcal/mol)\t\tsigma (Angstrom)\n")
+        elif unit_style == "lj":
+            data.write("#\treduced_epsilon \t\treduced_sigma \n")
+        for idx, epsilon in sorted(epsilon_dict.items()):
+            data.write(
+                "{}\t{:.5f}\t\t{:.5f}\t\t# {}\n".format(
+                    idx, epsilon, sigma_dict[idx], forcefield_dict[idx]
+                )
+            )
+
+
+def _write_bond_information(structure, data, unique_bond_types, unit_style):
+    """Write Bond Coeffs section of lammps data file."""
+    data.write("\nBond Coeffs # harmonic\n")
+    if unit_style == "real":
+        data.write("#\tk(kcal/mol/angstrom^2)\t\treq(angstrom)\n")
+    elif unit_style == "lj":
+        data.write("#\treduced_k\t\treduced_req\n")
+    sorted_bond_types = {
+        k: v
+        for k, v in sorted(unique_bond_types.items(), key=lambda item: item[1])
+    }
+    for params, idx in sorted_bond_types.items():
+        data.write(
+            "{}\t{}\t\t{}\t\t# {}\t{}\n".format(
+                idx,
+                params[0],
+                params[1],
+                params[2][0],
+                params[2][1],
+            )
+        )
+
+
+def _write_angle_information(
+    structure, data, unique_angle_types, use_urey_bradleys, unit_style
+):
+    """Write Angle Coeffs section of lammps data file."""
+    sorted_angle_types = {
+        k: v
+        for k, v in sorted(unique_angle_types.items(), key=lambda item: item[1])
+    }
+    if use_urey_bradleys:
+        data.write("\nAngle Coeffs # charmm\n")
+        data.write(
+            "#\tk(kcal/mol/rad^2)\t\ttheteq(deg)\tk(kcal/mol/angstrom^2)\treq(angstrom)\n"
+        )
+        for params, idx in sorted_angle_types.items():
+            data.write("{}\t{}\t{:.5f}\t{:.5f}\t{:.5f}\n".format(idx, *params))
+
+    else:
+        data.write("\nAngle Coeffs # harmonic\n")
+
+        if unit_style == "lj":
+            data.write("#\treduced_k\t\ttheteq(deg)\n")
+        else:
+            data.write("#\tk(kcal/mol/rad^2)\t\ttheteq(deg)\n")
+
+        for params, idx in sorted_angle_types.items():
+            data.write(
+                "{}\t{}\t\t{:.5f}\t# {}\t{}\t{}\n".format(
+                    idx,
+                    params[0],
+                    params[1],
+                    params[3][0],
+                    params[2],
+                    params[3][1],
+                )
+            )
+
+
+def _write_dihedral_information(
+    structure,
+    data,
+    unique_dihedral_types,
+    unit_style,
+    use_rb_torsions,
+    use_dihedrals,
+):
+    """Write Dihedral Coeffs section of lammps data file."""
+    sorted_dihedral_types = {
+        k: v
+        for k, v in sorted(
+            unique_dihedral_types.items(), key=lambda item: item[1]
+        )
+    }
+    if use_rb_torsions:
+        data.write("\nDihedral Coeffs # opls\n")
+        if unit_style == "real":
+            data.write(
+                "#\tf1(kcal/mol)\tf2(kcal/mol)\tf3(kcal/mol)\tf4(kcal/mol)\n"
+            )
+        elif unit_style == "lj":
+            data.write("#\tf1\tf2\tf3\tf4 (all lj reduced units)\n")
+        for params, idx in sorted_dihedral_types.items():
+            opls_coeffs = RB_to_OPLS(
+                params[0],
+                params[1],
+                params[2],
+                params[3],
+                params[4],
+                params[5],
+                error_if_outside_tolerance=False,
+            )
+            data.write(
+                "{}\t{:.5f}\t{:.5f}\t\t{:.5f}\t\t{:.5f}\t# {}\t{}\t{}\t{}\n".format(
+                    idx,
+                    opls_coeffs[1],
+                    opls_coeffs[2],
+                    opls_coeffs[3],
+                    opls_coeffs[4],
+                    params[8],
+                    params[9],
+                    params[10],
+                    params[11],
+                )
+            )
+    elif use_dihedrals:
+        data.write("\nDihedral Coeffs # charmm\n")
+        data.write("#k, n, phi, weight\n")
+        for params, idx in sorted_dihedral_types.items():
+            data.write(
+                "{}\t{:.5f}\t{:d}\t{:.2f}\t{:.5f}\t# {}\t{}\t{}\t{}\n".format(
+                    idx,
+                    params[0],
+                    params[1],
+                    params[2],
+                    params[3],
+                    params[6],
+                    params[7],
+                    params[8],
+                    params[9],
+                )
+            )
+
+
+def _write_improper_information(
+    structure, data, unique_improper_types, unit_style
+):
+    """Write Impropers Coeffs section of lammps data file."""
+    sorted_improper_types = {
+        k: v
+        for k, v in sorted(
+            unique_improper_types.items(), key=lambda item: item[1]
+        )
+    }
+    data.write("\nImproper Coeffs # harmonic\n")
+    data.write("#k, phi\n")
+    for params, idx in sorted_improper_types.items():
+        data.write(
+            "{}\t{:.5f}\t{:.5f}\t# {}\t{}\t{}\t{}\n".format(
+                idx,
+                params[0],
+                params[1],
+                params[2],
+                params[3],
+                params[4],
+                params[5],
+            )
+        )
+
+
+def _write_imp_dihedral_information(
+    structure, data, unique_imp_dihedral_types, unit_style
+):
+    """Write Impropers Coeffs section of lammps data file."""
+    sorted_imp_dihedral_types = {
+        k: v
+        for k, v in sorted(
+            unique_imp_dihedral_types.items(),
+            key=lambda item: item[1],
+        )
+    }
+    data.write("\nImproper Coeffs # cvff\n")
+    data.write("#K, d, n\n")
+    for params, idx in sorted_imp_dihedral_types.items():
+        data.write(
+            "{}\t{:.5f}\t{:d}\t{:d}\t# {}\t{}\t{}\t{}\n".format(
+                idx,
+                params[0],
+                params[1],
+                params[2],
+                params[5],
+                params[6],
+                params[7],
+                params[8],
+            )
+        )

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -552,16 +552,16 @@ class TestLammpsData(BaseTest):
         fn = lj_save(ethane, Path.cwd())
         checked_section = False
         ethane_bondsk = (
-            np.array([224262.4, 284512.0]) * (0.35) ** 2 / (0.276144) / 2
+            np.array([284512.0, 224262.4]) * (0.35) ** 2 / (0.276144) / 2
         )  # kj/mol/nm**2 to lammps
-        ethane_bondsreq = np.array([0.1529, 0.109]) * 0.35**-1  # unitless
+        ethane_bondsreq = np.array([0.109, 0.1529]) * 0.35**-1  # unitless
         ethane_lj_bonds = zip(ethane_bondsk, ethane_bondsreq)
         with open(fn, "r") as fi:
             while not checked_section:
                 line = fi.readline()
                 if "Bond Coeffs" in line:
                     fi.readline()
-                    for bond_params in ethane_lj_bonds:
+                    for i,bond_params in enumerate(ethane_lj_bonds):
                         print(bond_params)
                         line = fi.readline()
                         assert np.allclose(
@@ -569,15 +569,16 @@ class TestLammpsData(BaseTest):
                             bond_params,
                             atol=1e-3,
                         )
+                    assert int(line.split()[0]) == i + 1
                     checked_section = True
 
     def test_real_bonds(self, ethane, real_save):
         fn = real_save(ethane, Path.cwd())
         checked_section = False
         ethane_bondsk = (
-            np.array([224262.4, 284512.0]) / KCAL_TO_KJ * ANG_TO_NM**2 / 2
+            np.array([284512.0, 224262.4]) / KCAL_TO_KJ * ANG_TO_NM**2 / 2
         )  # kj/mol/nm**2 to lammps
-        ethane_bondsreq = np.array([0.1529, 0.109]) / ANG_TO_NM
+        ethane_bondsreq = np.array([0.109, 0.1529]) / ANG_TO_NM
         ethane_real_bonds = zip(ethane_bondsk, ethane_bondsreq)
         with open(fn, "r") as fi:
             while not checked_section:
@@ -632,12 +633,13 @@ class TestLammpsData(BaseTest):
                 line = fi.readline()
                 if "Angle Coeffs" in line:
                     fi.readline()
-                    for angle_params in ethane_real_angles:
+                    for i,angle_params in enumerate(ethane_real_angles):
                         line = fi.readline()
                         assert np.allclose(
                             (float(line.split()[1]), float(line.split()[2])),
                             angle_params,
                         )
+                        assert int(line.split()[0]) == i + 1
                     checked_section = True
 
     def test_lj_dihedrals(self, ethane, lj_save):
@@ -682,6 +684,7 @@ class TestLammpsData(BaseTest):
                         ),
                         ethane_diheds,
                     )
+                    assert int(line.split()[0]) == 1
                     checked_section = True
 
     def test_lj_charges(self, ethane, lj_save):

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -186,6 +186,7 @@ class TestLammpsData(BaseTest):
                 assert "# harmonic" in line
                 assert "k, phi" in out_lammps[i + 1]
                 assert len(out_lammps[i + 2].split("#")[0].split()) == 3
+                assert out_lammps[i + 2].split("#")[0].split()[0] == "1"
                 found_impropers = True
         assert found_impropers
 
@@ -214,18 +215,21 @@ class TestLammpsData(BaseTest):
                     "#\tk(kcal/mol/rad^2)\t\ttheteq(deg)" in out_lammps[i + 1]
                 )
                 assert len(out_lammps[i + 2].split("#")[0].split()) == 3
+                assert out_lammps[i + 2].split("#")[0].split()[0] == "1"
                 found_angles = True
             elif "Dihedral Coeffs" in line:
                 assert "# charmm" in line
                 assert "#k, n, phi, weight" in out_lammps[i + 1]
                 assert len(out_lammps[i + 2].split("#")[0].split()) == 5
                 assert float(out_lammps[i + 2].split("#")[0].split()[4]) == 0.0
+                assert out_lammps[i + 2].split("#")[0].split()[0] == "1"
                 found_dihedrals = True
             elif "Improper Coeffs" in line:
                 assert "# cvff" in line
                 assert "#K, d, n" in out_lammps[i + 1]
                 assert len(out_lammps[i + 2].split("#")[0].split()) == 4
                 assert out_lammps[i + 2].split("#")[0].split()[2] == "-1"
+                assert out_lammps[i + 2].split("#")[0].split()[0] == "1"
                 found_impropers = True
             else:
                 pass

--- a/mbuild/tests/test_lammpsdata.py
+++ b/mbuild/tests/test_lammpsdata.py
@@ -1,17 +1,62 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
+from ele.element import element_from_symbol
 from pytest import FixtureRequest
+from scipy.constants import epsilon_0
 
 import mbuild as mb
 from mbuild.formats.lammpsdata import write_lammpsdata
 from mbuild.tests.base_test import BaseTest
 from mbuild.utils.io import get_fn, has_foyer
 
+KCAL_TO_KJ = 4.184
+ANG_TO_NM = 0.10
+ELEM_TO_COUL = 1.602176634e-19
+
 
 @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
 class TestLammpsData(BaseTest):
     def test_save(self, ethane):
         ethane.save(filename="ethane.lammps")
+
+    @pytest.fixture(scope="session")
+    def lj_save(self, tmpdir_factory, sigma=None, epsilon=None, mass=None):
+        def _create_lammps(
+            ethane, tmp, sigma=sigma, epsilon=epsilon, mass=mass
+        ):
+            from foyer import Forcefield
+
+            OPLSAA = Forcefield(name="oplsaa")
+            structure = OPLSAA.apply(ethane)
+            fn = tmpdir_factory.mktemp("data").join("lj.lammps")
+            write_lammpsdata(
+                filename=str(fn),
+                structure=structure,
+                unit_style="lj",
+                sigma_conversion_factor=sigma,
+                epsilon_conversion_factor=epsilon,
+                mass_conversion_factor=mass,
+            )
+            return str(fn)
+
+        return _create_lammps
+
+    @pytest.fixture(scope="session")
+    def real_save(self, tmpdir_factory):
+        def _create_lammps(ethane, tmp):
+            from foyer import Forcefield
+
+            OPLSAA = Forcefield(name="oplsaa")
+            structure = OPLSAA.apply(ethane)
+            fn = tmpdir_factory.mktemp("data").join("lj.lammps")
+            write_lammpsdata(
+                filename=str(fn), structure=structure, unit_style="real"
+            )
+            return str(fn)
+
+        return _create_lammps
 
     @pytest.mark.parametrize("unit_style", ["real", "lj"])
     def test_save_forcefield(self, ethane, unit_style):
@@ -40,8 +85,6 @@ class TestLammpsData(BaseTest):
     @pytest.mark.skipif(not has_foyer, reason="Foyer package not installed")
     def test_save_charmm(self):
         from foyer import Forcefield
-
-        from mbuild.formats.lammpsdata import write_lammpsdata
 
         cmpd = mb.load(get_fn("charmm_dihedral.mol2"))
         for i in cmpd.particles():
@@ -167,7 +210,9 @@ class TestLammpsData(BaseTest):
         for i, line in enumerate(out_lammps):
             if "Angle Coeffs" in line:
                 assert "# harmonic" in line
-                assert "#\treduced_k\t\ttheteq(deg)" in out_lammps[i + 1]
+                assert (
+                    "#\tk(kcal/mol/rad^2)\t\ttheteq(deg)" in out_lammps[i + 1]
+                )
                 assert len(out_lammps[i + 2].split("#")[0].split()) == 3
                 found_angles = True
             elif "Dihedral Coeffs" in line:
@@ -234,6 +279,7 @@ class TestLammpsData(BaseTest):
 
         OPLSAA = Forcefield(name="oplsaa")
         structure = OPLSAA.apply(ethane)
+        structure.combining_rule = "lorentz"
         # Add nbfixes
         types = list(set([a.atom_type for a in structure.atoms]))
         types[0].add_nbfix(types[1].name, 1.2, 2.1)
@@ -265,6 +311,17 @@ class TestLammpsData(BaseTest):
                 # Break if PairIJ Coeffs is not found
                 if "Atoms" in line:
                     break
+        structure.combining_rule = "geometric"
+        write_lammpsdata(filename="nbfix.lammps", structure=structure)
+        write_lammpsdata(
+            filename="nbfix.lammps",
+            structure=structure,
+            nbfix_in_data_file=False,
+        )
+        with pytest.raises(ValueError) as exc_info:
+            structure.combining_rule = "error"
+            write_lammpsdata(filename="nbfix.lammps", structure=structure)
+        assert str(exc_info.value).startswith("combining_rule must be")
 
     def test_save_triclinic_box(self, ethane):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]), angles=[60, 70, 80])
@@ -392,40 +449,30 @@ class TestLammpsData(BaseTest):
 
                     checked_section = True
 
-    def test_lj_box(self, ethane):
-        from foyer import Forcefield
-
-        OPLSAA = Forcefield(name="oplsaa")
-        structure = OPLSAA.apply(ethane)
-        write_lammpsdata(
-            filename="lj.lammps", structure=structure, unit_style="lj"
-        )
-
+    def test_lj_box(self, ethane, lj_save):
+        fn = lj_save(ethane, Path.cwd())
         checked_section = False
-        with open("lj.lammps", "r") as fi:
+        ethane_sigma = 0.35  # nm
+        box_length = np.array(ethane.get_boundingbox().lengths) + [
+            0.5,
+            0.5,
+            0.5,
+        ]  # 0.5nm buffer around box
+        box_length /= ethane_sigma  # Unitless
+        with open(str(fn), "r") as fi:
             while not checked_section:
                 line = fi.readline()
-                if "dihedral types" in line:
+                if "dihedral types" in line:  # line before box info
                     fi.readline()
-                    line = float(fi.readline().split()[1])
-                    assert np.isclose(float(line), 2.04)
-                    line = float(fi.readline().split()[1])
-                    assert np.isclose(line, 2.268)
-                    line = float(fi.readline().split()[1])
-                    assert np.isclose(line, 1.898857)
+                    for i in range(len(box_length)):
+                        line = float(fi.readline().split()[1])
+                        assert np.isclose(float(line), box_length[i])
                     checked_section = True
 
-    def test_lj_masses(self, ethane):
-        from foyer import Forcefield
-
-        OPLSAA = Forcefield(name="oplsaa")
-        structure = OPLSAA.apply(ethane)
-        write_lammpsdata(
-            filename="lj.lammps", structure=structure, unit_style="lj"
-        )
-
+    def test_lj_masses(self, ethane, lj_save):
+        fn = lj_save(ethane, Path.cwd())
         checked_section = False
-        with open("lj.lammps", "r") as fi:
+        with open(fn, "r") as fi:
             while not checked_section:
                 line = fi.readline()
                 if "Masses" in line:
@@ -434,17 +481,22 @@ class TestLammpsData(BaseTest):
                     assert np.isclose(line, 1.00)
                     checked_section = True
 
-    def test_lj_pairs(self, ethane):
-        from foyer import Forcefield
-
-        OPLSAA = Forcefield(name="oplsaa")
-        structure = OPLSAA.apply(ethane)
-        write_lammpsdata(
-            filename="lj.lammps", structure=structure, unit_style="lj"
-        )
-
+    def test_real_masses(self, ethane, real_save):
+        fn = real_save(ethane, Path.cwd())
         checked_section = False
-        with open("lj.lammps", "r") as fi:
+        with open(fn, "r") as fi:
+            while not checked_section:
+                line = fi.readline()
+                if "Masses" in line:
+                    fi.readline()
+                    line = float(fi.readline().split()[1])
+                    assert np.isclose(line, 12.010780)
+                    checked_section = True
+
+    def test_lj_pairs(self, ethane, lj_save):
+        fn = lj_save(ethane, Path.cwd())
+        checked_section = False
+        with open(fn, "r") as fi:
             while not checked_section:
                 line = fi.readline()
                 if "Pair Coeffs" in line:
@@ -456,65 +508,230 @@ class TestLammpsData(BaseTest):
                     assert np.isclose(sigma, 1.00)
                     checked_section = True
 
-    def test_lj_bonds(self, ethane):
-        from foyer import Forcefield
-
-        OPLSAA = Forcefield(name="oplsaa")
-        structure = OPLSAA.apply(ethane)
-        write_lammpsdata(
-            filename="lj.lammps", structure=structure, unit_style="lj"
+    def test_lj_passed_pairs(self, ethane, lj_save):
+        fn = lj_save(
+            ethane,
+            Path.cwd(),
+            sigma=1,
+            epsilon=1,
         )
-
         checked_section = False
-        with open("lj.lammps", "r") as fi:
+        with open(fn, "r") as fi:
+            while not checked_section:
+                line = fi.readline()
+                if "Pair Coeffs" in line:
+                    fi.readline()
+                    line = fi.readline().split()
+                    epsilon = float(line[1])
+                    sigma = float(line[2])
+                    assert np.isclose(epsilon, 0.276144, atol=1e-5)
+                    assert np.isclose(sigma, 0.35)
+                    checked_section = True
+
+        with pytest.raises(ValueError) as exc_info:
+            lj_save(ethane, Path.cwd(), sigma=0)
+        exception_str = "The sigma conversion factor to convert to LJ"
+        assert str(exc_info.value).startswith(exception_str)
+
+    def test_real_pairs(self, ethane, real_save):
+        fn = real_save(ethane, Path.cwd())
+        checked_section = False
+        with open(fn, "r") as fi:
+            while not checked_section:
+                line = fi.readline()
+                if "Pair Coeffs" in line:
+                    fi.readline()
+                    line = fi.readline().split()
+                    epsilon = float(line[1])
+                    sigma = float(line[2])
+                    assert np.isclose(epsilon, 0.066)
+                    assert np.isclose(sigma, 3.5)
+                    checked_section = True
+
+    def test_lj_bonds(self, ethane, lj_save):
+        fn = lj_save(ethane, Path.cwd())
+        checked_section = False
+        ethane_bondsk = (
+            np.array([224262.4, 284512.0]) * (0.35) ** 2 / (0.276144) / 2
+        )  # kj/mol/nm**2 to lammps
+        ethane_bondsreq = np.array([0.1529, 0.109]) * 0.35**-1  # unitless
+        ethane_lj_bonds = zip(ethane_bondsk, ethane_bondsreq)
+        with open(fn, "r") as fi:
             while not checked_section:
                 line = fi.readline()
                 if "Bond Coeffs" in line:
                     fi.readline()
-                    bonds = list()
-                    bonds.append(float(fi.readline().split()[1]))
-                    bonds.append(float(fi.readline().split()[1]))
-                    assert np.allclose(sorted(bonds), [49742.424, 63106.06])
+                    for bond_params in ethane_lj_bonds:
+                        print(bond_params)
+                        line = fi.readline()
+                        assert np.allclose(
+                            (float(line.split()[1]), float(line.split()[2])),
+                            bond_params,
+                            atol=1e-3,
+                        )
                     checked_section = True
 
-    def test_lj_angles(self, ethane):
-        from foyer import Forcefield
-
-        OPLSAA = Forcefield(name="oplsaa")
-        structure = OPLSAA.apply(ethane)
-        write_lammpsdata(
-            filename="lj.lammps", structure=structure, unit_style="lj"
-        )
-
+    def test_real_bonds(self, ethane, real_save):
+        fn = real_save(ethane, Path.cwd())
         checked_section = False
-        with open("lj.lammps", "r") as fi:
+        ethane_bondsk = (
+            np.array([224262.4, 284512.0]) / KCAL_TO_KJ * ANG_TO_NM**2 / 2
+        )  # kj/mol/nm**2 to lammps
+        ethane_bondsreq = np.array([0.1529, 0.109]) / ANG_TO_NM
+        ethane_real_bonds = zip(ethane_bondsk, ethane_bondsreq)
+        with open(fn, "r") as fi:
+            while not checked_section:
+                line = fi.readline()
+                if "Bond Coeffs" in line:
+                    fi.readline()
+                    for bond_params in ethane_real_bonds:
+                        print(bond_params)
+                        line = fi.readline()
+                        assert np.allclose(
+                            (float(line.split()[1]), float(line.split()[2])),
+                            bond_params,
+                            atol=1e-3,
+                        )
+                    checked_section = True
+
+    def test_lj_angles(self, ethane, lj_save):
+        fn = lj_save(ethane, Path.cwd())
+        checked_section = False
+        ethane_anglesk = (
+            np.array([313.8, 276.144]) / 0.276144 / 2
+        )  # kj/mol/nm**2 to lammps
+        ethane_anglesreq = (
+            np.array([1.93207948196, 1.88146493365]) * 180 / np.pi
+        )  # radians to lammps
+        ethane_lj_angles = zip(ethane_anglesk, ethane_anglesreq)
+        with open(fn, "r") as fi:
             while not checked_section:
                 line = fi.readline()
                 if "Angle Coeffs" in line:
                     fi.readline()
-                    angles = list()
-                    angles.append(float(fi.readline().split()[1]))
-                    angles.append(float(fi.readline().split()[1]))
-
-                    assert np.allclose(sorted(angles), [6125.0, 6960.227])
+                    for angle_params in ethane_lj_angles:
+                        line = fi.readline()
+                        assert np.allclose(
+                            (float(line.split()[1]), float(line.split()[2])),
+                            angle_params,
+                        )
                     checked_section = True
 
-    def test_lj_dihedrals(self, ethane):
-        from foyer import Forcefield
-
-        OPLSAA = Forcefield(name="oplsaa")
-        structure = OPLSAA.apply(ethane)
-        write_lammpsdata(
-            filename="lj.lammps", structure=structure, unit_style="lj"
-        )
-
+    def test_real_angles(self, ethane, real_save):
+        fn = real_save(ethane, Path.cwd())
         checked_section = False
-        with open("lj.lammps", "r") as fi:
+        ethane_anglesk = (
+            np.array([313.8, 276.144]) / 2 / KCAL_TO_KJ
+        )  # kj/mol to lammps kcal/mol
+        ethane_anglesreq = (
+            np.array([1.93207948196, 1.88146493365]) * 180 / np.pi
+        )  # radians to lammps
+        ethane_real_angles = zip(ethane_anglesk, ethane_anglesreq)
+        with open(fn, "r") as fi:
+            while not checked_section:
+                line = fi.readline()
+                if "Angle Coeffs" in line:
+                    fi.readline()
+                    for angle_params in ethane_real_angles:
+                        line = fi.readline()
+                        assert np.allclose(
+                            (float(line.split()[1]), float(line.split()[2])),
+                            angle_params,
+                        )
+                    checked_section = True
+
+    def test_lj_dihedrals(self, ethane, lj_save):
+        fn = lj_save(ethane, Path.cwd())
+        checked_section = False
+        ethane_diheds = (
+            np.array([-0.00000, -0.00000, 0.30000, -0.00000]) / 0.066
+        )  # kcal/mol to lammps
+        with open(fn, "r") as fi:
             while not checked_section:
                 line = fi.readline()
                 if "Dihedral Coeffs" in line:
                     fi.readline()
-                    dihedrals = fi.readline().split()[1:5]
-                    dihedrals = [float(i) for i in dihedrals]
-                    assert np.allclose(dihedrals, [0.0005, 0.0, 4.5455, -0.0])
+                    line = fi.readline()
+                    assert np.allclose(
+                        (
+                            float(line.split()[1]),
+                            float(line.split()[2]),
+                            float(line.split()[3]),
+                            float(line.split()[4]),
+                        ),
+                        ethane_diheds,
+                    )
+                    checked_section = True
+
+    def test_real_dihedrals(self, ethane, real_save):
+        fn = real_save(ethane, Path.cwd())
+        checked_section = False
+        ethane_diheds = np.array([-0.00000, -0.00000, 0.30000, -0.00000])
+        with open(fn, "r") as fi:
+            while not checked_section:
+                line = fi.readline()
+                if "Dihedral Coeffs" in line:
+                    fi.readline()
+                    line = fi.readline()
+                    assert np.allclose(
+                        (
+                            float(line.split()[1]),
+                            float(line.split()[2]),
+                            float(line.split()[3]),
+                            float(line.split()[4]),
+                        ),
+                        ethane_diheds,
+                    )
+                    checked_section = True
+
+    def test_lj_charges(self, ethane, lj_save):
+        fn = lj_save(ethane, Path.cwd())
+        checked_section = False
+        charge_dict = {"C": -0.18, "H": 0.06}
+        ethane_charges = np.array(
+            [charge_dict[part.name] for part in ethane.particles()]
+        )
+        # in coulombs, convert to lj units
+        ethane_charges /= (
+            np.sqrt(4 * np.pi * 0.276144 * 0.35 * epsilon_0 * 10**-6)
+            / ELEM_TO_COUL
+        )
+        print(ethane_charges)
+        with open(fn, "r") as fi:
+            while not checked_section:
+                line = fi.readline()
+                if "Atoms " in line:
+                    fi.readline()
+                    assert np.allclose(
+                        float(fi.readline().split()[3]),
+                        ethane_charges[0],
+                        atol=1e-15,
+                    )
+                    assert np.allclose(
+                        float(fi.readline().split()[3]),
+                        ethane_charges[1],
+                        atol=1e-15,
+                    )
+                    checked_section = True
+
+    def test_real_charges(self, ethane, real_save):
+        fn = real_save(ethane, Path.cwd())
+        checked_section = False
+        charge_dict = {"C": -0.18, "H": 0.06}
+        ethane_charges = [charge_dict[part.name] for part in ethane.particles()]
+        print(ethane_charges)
+        # in coulombs
+        with open(fn, "r") as fi:
+            while not checked_section:
+                line = fi.readline()
+                if "Atoms " in line:
+                    fi.readline()
+                    assert np.allclose(
+                        float(fi.readline().split()[3]),
+                        ethane_charges[0],
+                    )
+                    assert np.allclose(
+                        float(fi.readline().split()[3]),
+                        ethane_charges[1],
+                    )
                     checked_section = True


### PR DESCRIPTION
### PR Summary: This PR will use the implemented orderedset utility in mBuild to make sure the unique angle, bond, and dihedral types are written starting from 1 and numbered up accordingly. The old method was to use the Set() function which does not retain order of its elements, and was removed because of this problem. However, this introduced a new bug that the listed unique parameters would start from the number of that parameter in the system, not starting from 1 and moving upwards from there.

Unit tests were added to check for the indexing on each of these terms.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
