### PR TITLE
Update structure.defaults.comb_rule when saving

### DIFF
--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1051,7 +1051,12 @@ def save(
         if not foyer_kwargs:
             foyer_kwargs = {}
         structure = ff.apply(structure, **foyer_kwargs)
+        # Raise warning
         structure.combining_rule = combining_rule
+        if structure.defaults:
+            structure.defaults.comb_rule = (
+                2 if combining_rule == "lorentz" else 3
+            )
 
     total_charge = sum([atom.charge for atom in structure])
     if round(total_charge, 4) != 0.0:


### PR DESCRIPTION
### PR Summary:
When saving out a Compound to a gromacs `top` file, the combining rule parameter was not being passed in properly, which result in some unexpected behavior. This is because setting `structure.combining_rule` do not update other relevant information such as `structure.defaults.comb_rule` and `structure.adjusts`. This PR will make sure that `structure.defaults.com_rule` got updated properly and also raise warning about `structure.adjusts` not being updated. 
### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
