### PR TITLE
Set periodicity correctly in freud_generate_bonds

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -28,5 +28,5 @@ dependencies:
   - pytest-azurepipelines
   - pytest-cov
   - python>=3.7
-  - rdkit
+  - rdkit>=2021
   - scipy

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -24,7 +24,7 @@ dependencies:
   - protobuf
   - py3Dmol
   - pycifrw
-  - pytest
+  - pytest=7.0
   - pytest-azurepipelines
   - pytest-cov
   - python>=3.7

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - protobuf
   - py3Dmol
   - pycifrw
-  - pytest>=3.0
+  - pytest=7.0
   - pytest-cov
   - python>=3.7
   - rdkit>=2021

--- a/environment-win.yml
+++ b/environment-win.yml
@@ -26,5 +26,5 @@ dependencies:
   - pytest>=3.0
   - pytest-cov
   - python>=3.7
-  - rdkit
+  - rdkit>=2021
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - packmol>=18
   - parmed>=3.4.3
   - python<=3.8
-  - rdkit
+  - rdkit>=2021
   - scipy

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -476,6 +476,26 @@ class TestCompound(BaseTest):
         ch3.generate_bonds("H", "H", dmin=0.01, dmax=2.0)
         assert ch3.n_bonds == 3 + 3
 
+    @pytest.makr.skipif(not has_freud, reason="Freud not installed.")
+    def test_freud_generated_bonds_periodicity(self, ch3):
+        bounding_box = ch3.get_boundingbox()
+
+        ch3_clone = mb.cloe(ch3)
+        ch3_clone.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
+        ch3_clone.periodicity = (True, True, True)
+        ch3_clone.freud_generate_bonds(
+            "H", "H", dmin=0.01, dmax=0.2, exclude_ii=True
+        )
+        assert ch3_clone.n_bonds == 3 + 3
+
+        ch3_clone2 = mb.cloe(ch3)
+        ch3_clone2.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
+        ch3_clone2.periodicity = (True, True, False)
+        ch3_clone2.freud_generate_bonds(
+            "H", "H", dmin=0.01, dmax=0.2, exclude_ii=True
+        )
+        assert ch3_clone2.n_bonds == 3 + 3
+
     @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
     def test_freud_generate_bonds(self, ch3):
         bounding_box = ch3.get_boundingbox()

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -480,7 +480,7 @@ class TestCompound(BaseTest):
     def test_freud_generated_bonds_periodicity(self, ch3):
         bounding_box = ch3.get_boundingbox()
 
-        ch3_clone = mb.cloe(ch3)
+        ch3_clone = mb.clone(ch3)
         ch3_clone.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3_clone.periodicity = (True, True, True)
         ch3_clone.freud_generate_bonds(
@@ -488,7 +488,7 @@ class TestCompound(BaseTest):
         )
         assert ch3_clone.n_bonds == 3 + 3
 
-        ch3_clone2 = mb.cloe(ch3)
+        ch3_clone2 = mb.clone(ch3)
         ch3_clone2.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3_clone2.periodicity = (True, True, False)
         ch3_clone2.freud_generate_bonds(

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -476,7 +476,7 @@ class TestCompound(BaseTest):
         ch3.generate_bonds("H", "H", dmin=0.01, dmax=2.0)
         assert ch3.n_bonds == 3 + 3
 
-    @pytest.makr.skipif(not has_freud, reason="Freud not installed.")
+    @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
     def test_freud_generated_bonds_periodicity(self, ch3):
         bounding_box = ch3.get_boundingbox()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,19 +6,19 @@ message = Bump to version {new_version}
 tag_name = {new_version}
 
 [coverage:run]
-omit = 
+omit =
 	mbuild/examples/*
 	mbuild/tests/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
-	
+
 	if 0:
 	if __name__ == .__main__.:
 	def __repr__
 	except ImportError
-omit = 
+omit =
 	mbuild/examples/*
 	mbuild/tests/*
 


### PR DESCRIPTION
### PR Summary:

Previously, `mbuild.Compound.freud_generate_bonds()` method was silently
ignoring the provided periodicity of the compound and would not generate
non-periodic bonds at the boundary of the boxes.

This has been remedied, and since `freud` currently does not support
pair finding for non-periodic systems, a fix has been implemented to
support this by creating pseudo-periodic box dimensions for non-periodic
directions. No changes are needed by the user.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
