### PR TITLE
Modify bond graph to include independent particle 

### DIFF
--- a/mbuild/bond_graph.py
+++ b/mbuild/bond_graph.py
@@ -151,7 +151,8 @@ class BondGraph(object):
         for node, neighbors in graph._adj.items():
             if self.has_node(node):
                 (adj[node].add(neighbor) for neighbor in neighbors)
-            elif neighbors:
+            else:
+                # Add new node even if it has no bond/neighbor
                 adj[node] = neighbors
 
     def subgraph(self, nodes):

--- a/mbuild/bond_graph.py
+++ b/mbuild/bond_graph.py
@@ -96,10 +96,6 @@ class BondGraph(object):
         if self.has_node(node1) and self.has_node(node2):
             adj[node1].remove(node2)
             adj[node2].remove(node1)
-            if not adj[node1]:
-                del adj[node1]
-            if not adj[node2]:
-                del adj[node2]
         else:
             raise ValueError(
                 "There is no edge between {} and {}".format(node1, node2)

--- a/mbuild/bond_graph.py
+++ b/mbuild/bond_graph.py
@@ -66,6 +66,7 @@ class BondGraph(object):
         for other_node in self.nodes():
             if node in adj[other_node]:
                 self.remove_edge(node, other_node)
+        del adj[node]
 
     def has_node(self, node):
         """Determine whether the graph contains a node."""

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2803,6 +2803,9 @@ class Compound(object):
     def _clone_bonds(self, clone_of=None):
         """Clone the bond of the source compound to clone compound."""
         newone = clone_of[self]
+        newone.bond_graph = BondGraph()
+        for particle in self.particles():
+            newone.bond_graph.add_node(clone_of[particle])
         for c1, c2 in self.bonds():
             try:
                 newone.add_bond((clone_of[c1], clone_of[c2]))

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -860,7 +860,7 @@ class Compound(object):
         if removed_part.rigid_id is not None:
             for ancestor in removed_part.ancestors():
                 ancestor._check_if_contains_rigid_bodies = True
-        if self.root.bond_graph and self.root.bond_graph.has_node(removed_part):
+        if self.root.bond_graph.has_node(removed_part):
             for neighbor in self.root.bond_graph.neighbors(removed_part):
                 self.root.remove_bond((removed_part, neighbor))
             self.root.bond_graph.remove_node(removed_part)

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1336,7 +1336,7 @@ class Compound(object):
         if not self.parent:
             # This is the very top level, and hence have to be independent
             return True
-        elif not self.root.bond_graph:
+        elif not self.root.bond_graph.edges():
             # If there is no bond in the top level, then everything is independent
             return True
         else:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2431,6 +2431,7 @@ class Compound(object):
             Set preexisting atoms in compound to coordinates given by Topology.
         infer_hierarchy : bool, optional, default=True
             If True, infer compound hierarchy from Topology residue, to be implemented.
+            Pending new GMSO release.
 
         Returns
         -------
@@ -2440,10 +2441,11 @@ class Compound(object):
             topology=topology,
             compound=self,
             coords_only=coords_only,
-            infer_hierarchy=infer_hierarchy,
+            # infer_hierarchy=infer_hierarchy,
+            # TO DO: enable this with new release of GMSO
         )
 
-    def to_gmso(self):
+    def to_gmso(self, **kwargs):
         """Create a GMSO Topology from a mBuild Compound.
 
         Parameters

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -705,13 +705,12 @@ class Compound(object):
             new_child.parent = self
 
             if new_child.bond_graph is not None:
-                if (
-                    len(self.root.bond_graph.nodes()) == 1
-                    and self.root.bond_graph.nodes()[0] == self
-                ):
-                    self.root.bond_graph = new_child.bond_graph
-                else:
-                    self.root.bond_graph.compose(new_child.bond_graph)
+                # If anything is added at self level, it is no longer a particle
+                # search for self in self.root.bond_graph and remove self
+                if self.root.bond_graph.has_node(self):
+                    self.root.bond_graph.remove_node(self)
+                # Compose bond_graph of new child
+                self.root.bond_graph.compose(new_child.bond_graph)
 
                 new_child.bond_graph = None
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -175,7 +175,9 @@ class Compound(object):
         self.labels = OrderedDict()
         self.referrers = set()
 
-        self.bond_graph = None
+        self.bond_graph = BondGraph()
+        self.bond_graph.add_node(self)
+
         self.port_particle = port_particle
 
         self._rigid_id = None
@@ -703,7 +705,10 @@ class Compound(object):
             new_child.parent = self
 
             if new_child.bond_graph is not None:
-                if self.root.bond_graph is None:
+                if (
+                    len(self.root.bond_graph.nodes()) == 1
+                    and self.root.bond_graph.nodes()[0] == self
+                ):
                     self.root.bond_graph = new_child.bond_graph
                 else:
                     self.root.bond_graph.compose(new_child.bond_graph)

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -953,11 +953,8 @@ class Compound(object):
                 "The direct_bonds method can only "
                 "be used on compounds at the bottom of their hierarchy."
             )
-        if not self.root.bond_graph:
-            return iter(())
-        elif self.root.bond_graph.has_node(self):
-            for i in self.root.bond_graph._adj[self]:
-                yield i
+        for i in self.root.bond_graph._adj[self]:
+            yield i
 
     def bonds(self):
         """Return all bonds in the Compound and sub-Compounds.

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -704,7 +704,7 @@ class Compound(object):
             self.children.add(new_child)
             new_child.parent = self
 
-            if new_child.bond_graph is not None:
+            if new_child.bond_graph is not None and not isinstance(self, Port):
                 # If anything is added at self level, it is no longer a particle
                 # search for self in self.root.bond_graph and remove self
                 if self.root.bond_graph.has_node(self):

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1633,7 +1633,7 @@ def _iterate_children(compound, nodes, edges, names_only=False):
     return nodes, edges
 
 
-def to_gmso(compound, box=None, parse_label=True, **kwargs):
+def to_gmso(compound, box=None, **kwargs):
     """Create a GMSO Topology from a mBuild Compound.
 
     Parameters
@@ -1642,8 +1642,7 @@ def to_gmso(compound, box=None, parse_label=True, **kwargs):
         The mb.Compound to be converted.
     box : mb.Box, optional, default=None
         The mb.Box to be converted, if different that compound.box
-    parse_label : bool, optional, default=True
-        Option to parse hierarchy information into sites' labels
+
     Returns
     -------
     topology : gmso.Topology
@@ -1651,7 +1650,7 @@ def to_gmso(compound, box=None, parse_label=True, **kwargs):
     """
     from gmso.external.convert_mbuild import from_mbuild
 
-    return from_mbuild(compound, box=None, parse_label=parse_label, **kwargs)
+    return from_mbuild(compound, box=None, **kwargs)
 
 
 def to_intermol(compound, molecule_types=None):  # pragma: no cover

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -906,9 +906,11 @@ def from_gmso(
 
     # Convert gmso Topology to mbuild Compound
     if not compound:
-        return to_mbuild(topology, **kwargs)
+        return to_mbuild(topology, infer_hierarchy=infer_hierarchy, **kwargs)
     else:
-        compound.add(to_mbuild(topology), **kwargs)
+        compound.add(
+            to_mbuild(topology, infer_hierarchy=infer_hierarchy), **kwargs
+        )
     return compound
 
 
@@ -1619,14 +1621,17 @@ def _iterate_children(compound, nodes, edges, names_only=False):
     return nodes, edges
 
 
-def to_gmso(compound):
+def to_gmso(compound, box=None, parse_label=True, **kwargs):
     """Create a GMSO Topology from a mBuild Compound.
 
     Parameters
     ----------
     compound : mb.Compound
         The mb.Compound to be converted.
-
+    box : mb.Box, optional, default=None
+        The mb.Box to be converted, if different that compound.box
+    parse_label : bool, optional, default=True
+        Option to parse hierarchy information into sites' labels
     Returns
     -------
     topology : gmso.Topology
@@ -1634,7 +1639,7 @@ def to_gmso(compound):
     """
     from gmso.external.convert_mbuild import from_mbuild
 
-    return from_mbuild(compound)
+    return from_mbuild(compound, box=None, parse_label=parse_label**kwargs)
 
 
 def to_intermol(compound, molecule_types=None):  # pragma: no cover

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -433,7 +433,8 @@ def load_file(
             topology=top,
             compound=compound,
             coords_only=coords_only,
-            infer_hierarchy=infer_hierarchy,
+            # infer_hierarchy=infer_hierarchy,
+            # TODO: enable this with new release of GMSO
         )
 
     # Then pybel reader
@@ -877,6 +878,7 @@ def from_gmso(
         Set preexisting atoms in compound to coordinates given by Topology.
     infer_hierarchy : bool, optional, default=True
         If True, infer compound hierarchy from Topology residue, to be implemented.
+        Pending new GMSO release.
 
     Returns
     -------
@@ -906,10 +908,20 @@ def from_gmso(
 
     # Convert gmso Topology to mbuild Compound
     if not compound:
-        return to_mbuild(topology, infer_hierarchy=infer_hierarchy, **kwargs)
+        return to_mbuild(
+            topology,
+            # infer_hierarchy=infer_hierarchy,
+            # TODO: enable this with new release of GMSO
+            **kwargs,
+        )
     else:
         compound.add(
-            to_mbuild(topology, infer_hierarchy=infer_hierarchy), **kwargs
+            to_mbuild(
+                topology,
+                # infer_hierarchy=infer_hierarchy),
+                # TODP: enable this with new release of GMSO
+                **kwargs,
+            )
         )
     return compound
 

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1639,7 +1639,7 @@ def to_gmso(compound, box=None, parse_label=True, **kwargs):
     """
     from gmso.external.convert_mbuild import from_mbuild
 
-    return from_mbuild(compound, box=None, parse_label=parse_label**kwargs)
+    return from_mbuild(compound, box=None, parse_label=parse_label, **kwargs)
 
 
 def to_intermol(compound, molecule_types=None):  # pragma: no cover

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -40,8 +40,8 @@ class Port(Compound):
 
     def __init__(self, anchor=None, orientation=None, separation=0):
         super(Port, self).__init__(name="Port", port_particle=True)
+        self.bond_graph = None
         self.anchor = anchor
-
         default_direction = np.array([0, 1, 0])
         if orientation is None:
             orientation = [0, 1, 0]

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1097,14 +1097,20 @@ class TestCompound(BaseTest):
         )
 
         ch3_nobonds = mb.clone(ch3)
-        for bond in ch3_nobonds.bonds():
+        bonds_list = list(ch3_nobonds.bonds())
+        for bond in bonds_list:
             ch3_nobonds.remove_bond(bond)
         compound.add(ch3_nobonds)
         assert compound.n_bonds == 3
-        assert not any(
+        assert all(
             compound.bond_graph.has_node(particle)
             for particle in ch3_nobonds.particles()
         )
+        assert not any(
+            compound.bond_graph.has_edge(bond[0], bond[1])
+            for bond in bonds_list
+        )
+        assert compound.bond_graph.has_edge
 
         carbons = list(compound.particles_by_name("C"))
         compound.add_bond((carbons[0], carbons[1]))
@@ -1118,7 +1124,7 @@ class TestCompound(BaseTest):
         )
 
         compound.remove_bond((carbons[0], carbons[1]))
-        assert not any(
+        assert all(
             compound.bond_graph.has_node(particle)
             for particle in ch3_nobonds.particles()
         )


### PR DESCRIPTION
### PR Summary:
Currently, compound bond graph only include bonded particles. This PR modify `mb.Compound` so that its bond graph also include independent/non-bonded particle. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
