### PR TITLE
improve performance of is_independent

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1337,7 +1337,7 @@ class Compound(object):
         else:
             # Cover the other cases
             bond_graph_dict = self.root.bond_graph._adj
-            for particle in self:
+            for particle in self.particles():
                 for neigh in bond_graph_dict[particle]:
                     if neigh not in self.particles():
                         return False

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1339,7 +1339,7 @@ class Compound(object):
             bond_graph_dict = self.root.bond_graph._adj
             for particle in self:
                 for neigh in bond_graph_dict[particle]:
-                    if neigh not in self:
+                    if neigh not in self.particles():
                         return False
             return True
 


### PR DESCRIPTION
### PR Summary:
The current `Compound.is_independent()` is not very performant and @CalCraven found out that changing the check from `if neigh not in self` to if `neigh not in self.particles()` will significantly speed thing up. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
