### PR TITLE
Top down approach for identifying molecules

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2807,7 +2807,7 @@ class Compound(object):
                     "Particles outside of its containment hierarchy."
                 )
 
-    def group_by_molecules(compound):
+    def group_by_molecules(self):
         """Create a restructured compound where each molecule is grouped together.
 
         This top down method looks through the children in a compound and identifies
@@ -2853,21 +2853,22 @@ class Compound(object):
 
         """
         grouped_compound = Compound()
-        molecule_list = compound._recursive_id_molecules()
+        molecule_list = self._recursive_id_molecules()
         if molecule_list:
             subtops = {}
             for molecule in molecule_list:
                 if subtops.get(molecule.name):
                     subtops[molecule.name].add(clone(molecule))
                 else:
-                    subtops[molecule.name] = mb.Compound(name=molecule.name)
+                    subtops[molecule.name] = Compound(name=molecule.name)
                     subtops[molecule.name].add(clone(molecule))
             for subtop in subtops.values():
                 grouped_compound.add(subtop)
             return grouped_compound
-        msg = f"No molecules were found in {compound.name}. Verify that your molecule\
-            has independent structure in its hierarchy."
-        raise MBuildError(msg)
+        else:
+            msg = f"""No molecules were found in {self.name}. Verify that the molecule
+                has independent structure in its hierarchy."""
+            raise MBuildError(msg)
 
     def _recursive_id_molecules(self, molecule_list=None):
         """Iterate through the compound top down to identify independent structures."""
@@ -2876,9 +2877,11 @@ class Compound(object):
         for child in self.children:
             if not child.is_independent():
                 molecule_list.append(self)
-                break
+                return molecule_list
             else:
-                child._recursive_id_molecules(molecule_list=molecule_list)
+                molecule_list = child._recursive_id_molecules(
+                    molecule_list=molecule_list
+                )
 
         return molecule_list
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1337,9 +1337,9 @@ class Compound(object):
         else:
             # Cover the other cases
             bond_graph_dict = self.root.bond_graph._adj
-            for particle in self:
+            for particle in self.particles():
                 for neigh in bond_graph_dict[particle]:
-                    if neigh not in self:
+                    if neigh not in self.particles():
                         return False
             return True
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2924,6 +2924,12 @@ class Compound(object):
         """Iterate through the compound top down to identify independent structures."""
         if not molecule_list:
             molecule_list = []
+
+        # Handle the case where self is a lone particle
+        if not self.children and self.is_independent():
+            molecule_list.append(self)
+            return molecule_list
+
         for child in self.children:
             if not child.is_independent():
                 molecule_list.append(self)

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2917,7 +2917,7 @@ class Compound(object):
             return grouped_compound
         else:
             msg = f"""No molecules were found in {self.name}. Return molecule as is."""
-            warnings.warn(msg)
+            warn(msg)
             return self
 
     def _recursive_id_molecules(self, molecule_list=None):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2916,9 +2916,9 @@ class Compound(object):
                 grouped_compound.add(subtop)
             return grouped_compound
         else:
-            msg = f"""No molecules were found in {self.name}. Verify that the molecule
-                has independent structure in its hierarchy."""
-            raise MBuildError(msg)
+            msg = f"""No molecules were found in {self.name}. Return molecule as is."""
+            warnings.warn(msg)
+            return self
 
     def _recursive_id_molecules(self, molecule_list=None):
         """Iterate through the compound top down to identify independent structures."""

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2903,6 +2903,7 @@ class Compound(object):
 
         """
         grouped_compound = Compound()
+        grouped_compound.box = self.box
         molecule_list = self._recursive_id_molecules()
         if molecule_list:
             subtops = {}
@@ -2918,7 +2919,7 @@ class Compound(object):
         else:
             msg = f"""No molecules were found in {self.name}. Return molecule as is."""
             warn(msg)
-            return self
+            return mb.clone(self)
 
     def _recursive_id_molecules(self, molecule_list=None):
         """Iterate through the compound top down to identify independent structures."""

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2904,6 +2904,7 @@ class Compound(object):
         """
         grouped_compound = Compound()
         grouped_compound.box = self.box
+        grouped_compound.name = self.name
         molecule_list = self._recursive_id_molecules()
         if molecule_list:
             subtops = {}

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1836,3 +1836,22 @@ class TestCompound(BaseTest):
         for bond2, bond in zip(ethane2.bonds(), ethane.bonds()):
             assert bond2[0].name == bond[0].name
             assert all(bond2[0].pos == bond[0].pos)
+
+    def test_top_down_molecules(self):
+        cpd1 = mb.load("CCCC", smiles=True)
+        cpd1.name = "Butane"
+        cpd2 = mb.load("CCCCO", smiles=True)
+        cpd2.name = "Butanol"
+        box = mb.packing.solvate(
+            solvent=cpd1,
+            solute=cpd2,
+            box=mb.Box([5, 5, 5]),
+            n_solvent=100,
+        )
+        box2 = mb.packing.fill_box(cpd1, box=mb.Box([5, 5, 5]), n_compounds=50)
+        box2.translate([5, 0, 0])
+        box.add(box2)
+        partitioned_box = box.group_by_molecules()
+        names = [child.name for child in partitioned_box.children]
+        for molecule_name in ["Butane", "Butanol"]:
+            assert molecule_name in names


### PR DESCRIPTION
### PR Summary:
This PR adds two methods to a compound,
`_recursive_id_molecules`
and
`group_by_molecules`.
These functions let a user reconfigure an mBuild
compound using the top down approach of iterating through
children. The is_independent() method is checked on each children
until False is returned, which identifies when the hierarchy is made
of a bonded together "molecule". This will be of use when converting to
GMSO `Topology`, the subtop information can be parsed from this
reconfigured mBuild compound in order to speed up atomtyping.

These methods use the compound.name attribute to group molecules
together. With a generic name like "Compound", the top level child
will be a single compound.

**Note that these tests won't pass until PR #1037 is merged

* Add mbuild.compound.Compound._recursive_id_molecules method
* Add mbuild.compound.Compound.group_by_molecules method

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
