### PR TITLE
default mass and charge of Compound to  None

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -147,8 +147,8 @@ class Compound(object):
         subcompounds=None,
         name=None,
         pos=None,
-        mass=0.0,
-        charge=0.0,
+        mass=None,
+        charge=None,
         periodicity=None,
         box=None,
         element=None,
@@ -202,7 +202,7 @@ class Compound(object):
                 raise MBuildError(
                     "Can't set the mass of a Compound with subcompounds. "
                 )
-            self._charge = 0.0
+            self._charge = None
             self._mass = mass
             self.add(subcompounds)
         else:
@@ -386,7 +386,13 @@ class Compound(object):
     @property
     def charge(self):
         """Get the charge of the Compound."""
-        return sum([particle._charge for particle in self.particles()])
+        return sum(
+            [
+                particle._charge
+                for particle in self.particles()
+                if particle._charge is not None
+            ]
+        )
 
     @charge.setter
     def charge(self, value):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -361,9 +361,13 @@ class Compound(object):
             particle_masses = [self._particle_mass(p) for p in self.particles()]
             if None in particle_masses:
                 warn(
-                    f"Some particle in this Compound has not had their mass set."
+                    f"Some particle of {self} does not have mass."
+                    "They will not be accounted for during this calculation."
                 )
-            return sum([self._particle_mass(p) for p in self.particles()])
+            filtered_masses = [
+                mass for mass in particle_masses if mass is not None
+            ]
+            return sum(filtered_masses) if filtered_masses else None
 
     @staticmethod
     def _particle_mass(particle):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -358,6 +358,11 @@ class Compound(object):
         if self._contains_only_ports():
             return self._particle_mass(self)
         else:
+            particle_masses = [self._particle_mass(p) for p in self.particles()]
+            if None in particle_masses:
+                warn(
+                    f"Some particle in this Compound has not had their mass set."
+                )
             return sum([self._particle_mass(p) for p in self.particles()])
 
     @staticmethod
@@ -368,7 +373,7 @@ class Compound(object):
             if particle.element:
                 return particle.element.mass
             else:
-                warn(f"Particle {particle} has no element or assigned mass.")
+                return None
 
     @mass.setter
     def mass(self, value):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -91,11 +91,11 @@ class Compound(object):
         The type of Compound.
     pos : np.ndarray, shape=(3,), dtype=float, optional, default=[0, 0, 0]
         The position of the Compound in Cartestian space
-    mass : float, optional, default=0.0
+    mass : float, optional, default=None
         The mass of the compound. If none is set, then will try to
         infer the mass from a compound's element attribute.
         If neither `mass` or `element` are specified, then the
-        mass will be zero.
+        mass will be None.
     charge : float, optional, default=0.0
         Currently not used. Likely removed in next release.
     periodicity : tuple of bools, length=3, optional, default=None
@@ -362,13 +362,13 @@ class Compound(object):
 
     @staticmethod
     def _particle_mass(particle):
-        if particle._mass:
+        if particle._mass is not None:
             return particle._mass
         else:
             if particle.element:
                 return particle.element.mass
             else:
-                return 0
+                warn(f"Particle {particle} has no element or assigned mass.")
 
     @mass.setter
     def mass(self, value):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -395,13 +395,14 @@ class Compound(object):
     @property
     def charge(self):
         """Get the charge of the Compound."""
-        return sum(
-            [
-                particle._charge
-                for particle in self.particles()
-                if particle._charge is not None
-            ]
-        )
+        charges = [p._charge for p in self.particles()]
+        if None in charges:
+            warn(
+                f"Some particle of {self} does not have a charge."
+                "They will not be accounted for during this calculation."
+            )
+        filtered_charges = [charge for charge in charges if charge is not None]
+        return sum(filtered_charges) if filtered_charges else None
 
     @charge.setter
     def charge(self, value):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -679,7 +679,7 @@ class Compound(object):
                 "Only objects that inherit from mbuild.Compound can be added "
                 f"to Compounds. You tried to add '{new_child}'."
             )
-        if self._mass != 0.0 and not isinstance(new_child, Port):
+        if self._mass is not None and not isinstance(new_child, Port):
             warn(
                 f"{self} has a pre-defined mass of {self._mass}, "
                 "which will be reset to zero now that it contains children "

--- a/mbuild/formats/protobuf.py
+++ b/mbuild/formats/protobuf.py
@@ -93,7 +93,7 @@ def _mb_to_proto(cmpd, proto):
     """Given mb.Compound, parse propertes into compound_pb2.Compound."""
     proto.name = cmpd.name
     proto.pos.x, proto.pos.y, proto.pos.z = cmpd.pos
-    proto.charge = cmpd.charge
+    proto.charge = cmpd.charge if cmpd.charge else 0.0
     proto.id = id(cmpd)
     (
         proto.periodicity.x,

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -772,9 +772,10 @@ def _validate_mass(compound, n_compounds):
     found_zero_mass = False
     total_mass = 0
     for c, n in zip(compound, n_compounds):
-        comp_masses = [c._particle_mass(p) for p in c.particles()]
-        if 0.0 in comp_masses:
+        comp_masses = np.array([c._particle_mass(p) for p in c.particles()])
+        if 0.0 in comp_masses or None in comp_masses:
             found_zero_mass = True
+        comp_masses[comp_masses == None] = 0.0
         total_mass += np.sum(comp_masses) * n
 
     if total_mass == 0:
@@ -788,7 +789,7 @@ def _validate_mass(compound, n_compounds):
     if found_zero_mass:
         warnings.warn(
             "Some of the compounds or subcompounds in `compound` "
-            "have a mass of zero. This may have an effect on "
+            "have a mass of zero/None. This may have an effect on "
             "density calculations"
         )
     return total_mass

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -462,6 +462,22 @@ class TestCompound(BaseTest):
         A.add(mb.Port())
         assert A.mass == 2.0
 
+    def test_none_mass(self):
+        A = mb.Compound()
+        assert A.mass == None
+
+        container = mb.Compound(subcompounds=[A])
+        with pytest.warns(UserWarning):
+            container_mass = container.mass
+            assert container_mass == None
+
+        A.mass = 1
+        B = mb.Compound()
+        container.add(B)
+        with pytest.warns(UserWarning):
+            container_mass = container.mass
+            assert container_mass == A.mass == 1
+
     def test_add_existing_parent(self, ethane, h2o):
         water_in_water = mb.clone(h2o)
         h2o.add(water_in_water)
@@ -474,7 +490,7 @@ class TestCompound(BaseTest):
             ethane.add(mb.clone(h2o), label="water")
 
     def test_set_pos(self, ethane):
-        with pytest.raises(MBuildError):
+        with pytest.raises(MBuildErrorq):
             ethane.pos = [0, 0, 0]
 
     def test_xyz(self, ch3):

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -396,7 +396,7 @@ class TestCompound(BaseTest):
         assert bead_overwrite.mass == 1.0
 
         bead_no_mass = mb.Compound(name="A")
-        assert bead_no_mass.mass == 0.0
+        assert bead_no_mass.mass == None
 
     def test_init_with_bad_mass(self):
         with pytest.raises(MBuildError):

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1266,7 +1266,7 @@ class TestCompound(BaseTest):
         compound = Compound(charge=2.0)
         assert compound.charge == 2.0
         compound2 = Compound()
-        assert compound2.charge == 0.0
+        assert compound2.charge == None
 
         ch2[0].charge = 0.5
         ch2[1].charge = -0.25
@@ -1292,6 +1292,20 @@ class TestCompound(BaseTest):
         benzene[0].charge = 0.25
         with pytest.warns(UserWarning):
             benzene.save("charge-test.mol2")
+
+    def test_none_charge(self):
+        A = mb.Compound()
+        with pytest.warns(UserWarning):
+            A.charge
+
+        A.charge = 1
+        B = mb.Compound()
+        container = mb.Compound(subcompounds=[A, B])
+        with pytest.warns(UserWarning):
+            container_charge = container.charge
+            assert A.charge == 1
+            assert B.charge == None
+            assert container_charge == 1
 
     @pytest.mark.skipif(
         not has_openbabel, reason="Open Babel package not installed"

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -490,7 +490,7 @@ class TestCompound(BaseTest):
             ethane.add(mb.clone(h2o), label="water")
 
     def test_set_pos(self, ethane):
-        with pytest.raises(MBuildErrorq):
+        with pytest.raises(MBuildError):
             ethane.pos = [0, 0, 0]
 
     def test_xyz(self, ch3):


### PR DESCRIPTION
### PR Summary:
Changing the default value of `Compound.charge` and `Compound.mass` to `None`. The purpose is to distinct between whether the user intentionally setting the value of `charge` and `mass` or just haven't initiated those properties.  

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
