### PR TITLE
add refer_inhierarchy to gmso conversion

### DIFF
--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -6,7 +6,7 @@ dependencies:
   - bump2version
   - codecov
   - ele
-  - gmso>=0.7.3
+  - gmso>=0.9.0
   - foyer>=0.11.0
   - garnett>=0.7.1
   - gsd>=1.2

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ dependencies:
   - bump2version
   - codecov
   - ele
-  - gmso>=0.7.3
+  - gmso>=0.9.0
   - foyer>=0.11.0
   - freud>=2.0.0
   - garnett>=0.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - ele
   - numpy
   - packmol>=18
-  - gmso>=0.7.3
+  - gmso>=0.9.0
   - parmed>=3.4.3
   - python<=3.8
   - rdkit>=2021

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -433,8 +433,7 @@ def load_file(
             topology=top,
             compound=compound,
             coords_only=coords_only,
-            # infer_hierarchy=infer_hierarchy,
-            # TODO: enable this with new release of GMSO
+            infer_hierarchy=infer_hierarchy,
         )
 
     # Then pybel reader
@@ -910,16 +909,14 @@ def from_gmso(
     if not compound:
         return to_mbuild(
             topology,
-            # infer_hierarchy=infer_hierarchy,
-            # TODO: enable this with new release of GMSO
+            infer_hierarchy=infer_hierarchy,
             **kwargs,
         )
     else:
         compound.add(
             to_mbuild(
                 topology,
-                # infer_hierarchy=infer_hierarchy),
-                # TODP: enable this with new release of GMSO
+                infer_hierarchy=infer_hierarchy,
                 **kwargs,
             )
         )

--- a/mbuild/tests/test_gmso.py
+++ b/mbuild/tests/test_gmso.py
@@ -51,3 +51,19 @@ class TestGMSO(BaseTest):
         meth = mb.load("C", smiles=True)
         with pytest.raises(ValueError):
             meth.from_gmso(gmso_eth, coords_only=True)
+
+    def test_infer_hier(selfs, ethane):
+        # Create an ethane box, should be a four structure
+        eth_box = mb.packing.fill_box(compound=ethane, n_compounds=1, density=1)
+
+        # infer_hierarchy=False
+        unlabeled_top = eth_box.to_gmso(infer_hierarchy=False)
+        for site in unlabeled_top.sites:
+            assert not site.residue or site.molecule or site.group
+
+        # infer_hierarchy=True
+        labeled_top = eth_box.to_gmso(infer_hierarchy=True)
+        for site in labeled_top.sites:
+            assert site.group == "Ethane"
+            assert site.molecule.name == "Ethane"
+            assert site.residue.name == "CH3"


### PR DESCRIPTION
### PR Summary:
With the new gmso release, the `refer_hierarchy` option can now be passed to gmso conversion methods. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
