### PR TITLE
Trim coordinate_transform.py, new features for spin method

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2417,7 +2417,7 @@ class Compound(object):
         new_positions = _rotate(self.xyz_with_ports, theta, around)
         self.xyz_with_ports = new_positions
 
-    def spin(self, theta, around):
+    def spin(self, theta, around, anchor=None):
         """Rotate Compound in place around an arbitrary vector.
 
         Parameters
@@ -2426,12 +2426,23 @@ class Compound(object):
             The angle by which to rotate the Compound, in radians.
         around : np.ndarray, shape=(3,), dtype=float
             The axis about which to spin the Compound.
+        anchor : mb.Compound, optional, default=None (self)
+            Anchor compound/particle to perform spinning.
+            If the anchor is not a particle, the spin will be
+            around the center of the anchor Compound.
         """
         around = np.asarray(around).reshape(3)
-        center_pos = self.center
-        self.translate(-center_pos)
+
+        if anchor:
+            msg = f"{anchor} is not part of {self}."
+            assert anchor in self.successors(), msg
+        else:
+            anchor = self
+        anchor_pos = anchor.center
+
+        self.translate(-anchor_pos)
         self.rotate(theta, around)
-        self.translate(center_pos)
+        self.translate(anchor_pos)
 
     def rotate_dihedral(self, bond, phi):
         """Rotate a dihedral about a central bond.

--- a/mbuild/coordinate_transform.py
+++ b/mbuild/coordinate_transform.py
@@ -11,6 +11,7 @@ __all__ = [
     "x_axis_transform",
     "y_axis_transform",
     "z_axis_transform",
+    "equivalence_transform",
 ]
 
 

--- a/mbuild/coordinate_transform.py
+++ b/mbuild/coordinate_transform.py
@@ -6,25 +6,11 @@ simplefilter("always", DeprecationWarning)
 import numpy as np
 from numpy.linalg import inv, norm, svd
 
-from mbuild.utils.exceptions import RemovedFuncError
-
 __all__ = [
     "force_overlap",
     "x_axis_transform",
     "y_axis_transform",
     "z_axis_transform",
-    # Deprecated
-    "equivalence_transform",
-    "rotate",
-    "rotate_around_x",
-    "rotate_around_y",
-    "rotate_around_z",
-    "spin",
-    "spin_x",
-    "spin_y",
-    "spin_z",
-    "translate",
-    "translate_to",
 ]
 
 
@@ -450,36 +436,6 @@ def _choose_correct_port(from_port, to_port):
     return [(correct_port, to_port["up"])], T
 
 
-def translate(compound, pos):
-    """Translate a compound by a vector.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being translated.
-    pos : np.ndarray, shape=(3,), dtype=float
-        The vector to translate the compound by.
-    """
-    raise RemovedFuncError(
-        "translate()", "Compound.translate()", "0.7.0", "0.11.0"
-    )
-
-
-def translate_to(compound, pos):
-    """Translate a compound to a coordinate.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being translated.
-    pos : np.ndarray, shape=(3,), dtype=float
-        The coordinate to translate the compound to.
-    """
-    raise RemovedFuncError(
-        "translate_to()", "Compound.translate_to()", "0.7.0", "0.11.0"
-    )
-
-
 def _translate(coordinates, by):
     """Translate a set of coordinates by a vector.
 
@@ -525,81 +481,6 @@ def _rotate(coordinates, theta, around):
     return Rotation(theta, around).apply_to(coordinates)
 
 
-def rotate(compound, theta, around):
-    """Rotate a compound around an arbitrary vector.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being rotated.
-    theta : float
-        The angle by which to rotate the compound, in radians.
-    around : np.ndarray, shape=(3,), dtype=float
-        The vector about which to rotate the compound.
-    """
-    raise RemovedFuncError("rotate()", "Compound.rotate()", "0.7.0", "0.11.0")
-
-
-def rotate_around_x(compound, theta):
-    """Rotate a compound around the x axis.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being rotated.
-    theta : float
-        The angle by which to rotate the compound.
-    """
-    raise RemovedFuncError(
-        "rotate_around_x()", "Compound.rotate()", "0.7.0", "0.11.0"
-    )
-
-
-def rotate_around_y(compound, theta):
-    """Rotate a compound around the y axis.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being rotated.
-    theta : float
-        The angle by which to rotate the compound.
-    """
-    raise RemovedFuncError(
-        "rotate_around_y()", "Compound.rotate()", "0.7.0", "0.11.0"
-    )
-
-
-def rotate_around_z(compound, theta):
-    """Rotate a compound around the z axis.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being rotated.
-    theta : float
-        The angle by which to rotate the compound.
-    """
-    raise RemovedFuncError(
-        "rotate_around_z()", "Compound.rotate()", "0.7.0", "0.11.0"
-    )
-
-
-def spin(compound, theta, around):
-    """Rotate a compound in place around an arbitrary vector.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being rotated.
-    theta : float
-        The angle by which to rotate the compound, in radians.
-    around : np.ndarray, shape=(3,), dtype=float
-        The axis about which to spin the compound.
-    """
-    raise RemovedFuncError("spin()", "Compound.spin()", "0.7.0", "0.11.0")
-
-
 def _spin(coordinates, theta, around):
     """Rotate a set of coordinates in place around an arbitrary vector.
 
@@ -620,45 +501,6 @@ def _spin(coordinates, theta, around):
     coordinates = _rotate(coordinates, theta, around)
     coordinates += center_pos
     return coordinates
-
-
-def spin_x(compound, theta):
-    """Rotate a compound in place around the x axis.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being rotated.
-    theta : float
-        The angle by which to rotate the compound.
-    """
-    raise RemovedFuncError("spin_x()", "Compound.spin_x()", "0.7.0", "0.11.0")
-
-
-def spin_y(compound, theta):
-    """Rotate a compound in place around the y axis.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being rotated.
-    theta : float
-        The angle by which to rotate the compound.
-    """
-    raise RemovedFuncError("spin_y()", "Compound.spin_y()", "0.7.0", "0.11.0")
-
-
-def spin_z(compound, theta):
-    """Rotate a compound in place around the z axis.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound being rotated.
-    theta : float
-        The angle by which to rotate the compound.
-    """
-    raise RemovedFuncError("spin_z()", "Compound.spin_z()", "0.7.0", "0.11.0")
 
 
 def x_axis_transform(

--- a/mbuild/tests/test_coordinate_transform.py
+++ b/mbuild/tests/test_coordinate_transform.py
@@ -125,6 +125,14 @@ class TestCoordinateTransform(BaseTest):
         methane.spin(6.9, [1, 0, 0])
         methane.spin(6.9, (1, 0, 0))
 
+    def test_spin_with_anchor(self, methane):
+        original_posH = methane[1].pos
+        original_posC = methane[0].pos
+        methane.spin(6.9, [1, 0, 0], anchor=methane[1])
+
+        assert all(methane[1].pos == original_posH)
+        assert any(methane[0].pos != original_posC)
+
     def test_rotate_inputs(self, methane):
         methane.rotate(6.9, [1, 0, 0])
         methane.rotate(6.9, (1, 0, 0))

--- a/mbuild/tests/test_coordinate_transform.py
+++ b/mbuild/tests/test_coordinate_transform.py
@@ -17,22 +17,11 @@ from mbuild.coordinate_transform import (
     _spin,
     angle,
     force_overlap,
-    rotate,
-    rotate_around_x,
-    rotate_around_y,
-    rotate_around_z,
-    spin,
-    spin_x,
-    spin_y,
-    spin_z,
-    translate,
-    translate_to,
     x_axis_transform,
     y_axis_transform,
     z_axis_transform,
 )
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.exceptions import RemovedFuncError
 
 
 class TestCoordinateTransform(BaseTest):
@@ -248,36 +237,12 @@ class TestCoordinateTransform(BaseTest):
         compound2.spin(np.pi * 1.23456789, around=np.asarray([0, 0, 1]))
         assert np.allclose(compound2.xyz, sixpoints.xyz, atol=1e-16)
 
-    def test_spin_deprecated_x(self, sixpoints):
-        with pytest.raises(RemovedFuncError):
-            spin_x(sixpoints, np.pi * 3 / 2)
-
-    def test_spin_deprecated_y(self, sixpoints):
-        with pytest.raises(RemovedFuncError):
-            spin_y(sixpoints, np.pi * 3 / 2)
-
-    def test_spin_deprecated_z(self, sixpoints):
-        with pytest.raises(RemovedFuncError):
-            spin_z(sixpoints, 69)
-
     def test_spin_arbitraty(self, sixpoints):
         before = mb.clone(sixpoints)
         sixpoints.spin(np.pi, np.asarray([1, 1, 0]))
         assert np.allclose(
             sixpoints["up"].xyz, before["right"].xyz, atol=1e-16
         ) and np.allclose(sixpoints["down"].xyz, before["left"].xyz, atol=1e-16)
-
-    def test_error_rotate_x(self, methane):
-        with pytest.raises(RemovedFuncError):
-            rotate_around_x(methane, np.pi)
-
-    def test_error_rotate_y(self, methane):
-        with pytest.raises(RemovedFuncError):
-            rotate_around_y(methane, np.pi)
-
-    def test_error_rotate_z(self, methane):
-        with pytest.raises(RemovedFuncError):
-            rotate_around_z(methane, np.pi)
 
     def test_spin_relative_compound_coordinates(self, sixpoints):
         """Check compounds's relative coordinates don't change upon spinning"""


### PR DESCRIPTION
### PR Summary:
Remove the removed methods from `coordinate_transform.py`. Add anchor option for `Compound.spin()`, so now the compound can choose an anchor to be any of its successors instead of just its center. 

Pending unit tests.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
