### PR TITLE
drop py3.7 from testing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
         exclude:
           - os: windows-latest
             python-version: 3.8

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
         exclude:
           - os: windows-latest
             python-version: 3.8

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,13 @@
 version: 2
 formats:
   - htmlzip
+  - pdf
 conda:
   environment: docs/environment-docs.yml
-
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "mambaforge-4.10"
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -25,6 +25,6 @@ dependencies:
   - pycifrw
   - pytest
   - pytest-cov
-  - python>=3.7
+  - python
   - rdkit>=2021
   - scipy

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,6 +27,6 @@ dependencies:
   - pytest
   - pytest-azurepipelines
   - pytest-cov
-  - python>=3.7
+  - python
   - rdkit>=2021
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,6 @@ dependencies:
   - packmol>=18
   - gmso>=0.9.0
   - parmed>=3.4.3
-  - python<=3.8
+  - python
   - rdkit>=2021
   - scipy

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -983,8 +983,7 @@ class Compound(object):
         See Also
         --------
         bond_graph.edges_iter : Iterates over all edges in a BondGraph
-        Compound.n_bonds : Returns the total number of bonds in the Compound
-        and sub-Compounds
+        Compound.n_bonds : Returns the total number of bonds in the Compound and sub-Compounds
         """
         if self.root.bond_graph:
             if self.root == self:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -962,7 +962,7 @@ class Compound(object):
         See Also
         --------
         bond_graph.edges_iter : Iterations over all edges in a BondGraph
-        Compound.n_direct_bonds() : Returns the number of bonds a particle contains
+        Compound.n_direct_bonds : Returns the number of bonds a particle contains
         """
         if list(self.particles()) != [self]:
             raise MBuildError(
@@ -983,7 +983,7 @@ class Compound(object):
         See Also
         --------
         bond_graph.edges_iter : Iterates over all edges in a BondGraph
-        Compound.n_bonds() : Returns the total number of bonds in the Compound
+        Compound.n_bonds : Returns the total number of bonds in the Compound
         and sub-Compounds
         """
         if self.root.bond_graph:


### PR DESCRIPTION
### PR Summary:
Drop python 3.7 and add test for python 3.10, in coordination with similar move in foyer and gmso.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
