### PR TITLE
Add smiles string conversion using pybel backend

### DIFF
--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -25,6 +25,6 @@ dependencies:
   - pycifrw
   - pytest
   - pytest-cov
-  - python
+  - python<3.10
   - rdkit>=2021
   - scipy

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,6 +27,6 @@ dependencies:
   - pytest
   - pytest-azurepipelines
   - pytest-cov
-  - python
+  - python<3.10
   - rdkit>=2021
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,6 @@ dependencies:
   - packmol>=18
   - gmso>=0.9.0
   - parmed>=3.4.3
-  - python
+  - python<3.10
   - rdkit>=2021
   - scipy

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2728,6 +2728,22 @@ class Compound(object):
             show_ports=show_ports,
         )
 
+    def to_smiles(self, backend="pybel"):
+        """Create a SMILES string from an mbuild compound.
+
+        Parameters
+        ----------
+        compound : mb.Compound.
+            The mbuild compound to be converted.
+        backend : str, optional, default="pybel"
+            Backend used to do the conversion.
+
+        Return
+        ------
+        smiles_string : str
+        """
+        return conversion.to_smiles(self, backend)
+
     def from_pybel(
         self,
         pybel_mol,

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1564,6 +1564,35 @@ def to_pybel(
     return pybelmol
 
 
+def to_smiles(compound, backend="pybel"):
+    """Create a SMILES string from an mbuild compound.
+
+    Parameters
+    ----------
+    compound : mb.Compound.
+        The mbuild compound to be converted.
+    backend : str, optional, default="pybel"
+        Backend used to do the conversion.
+
+    Return
+    ------
+    smiles_string : str
+    """
+    if backend == "pybel":
+        mol = to_pybel(compound)
+
+        warn(
+            "The bond orders will be guessed using pybel"
+            "OBMol.PerceviedBondOrders()"
+        )
+        mol.OBMol.PerceiveBondOrders()
+        smiles_string = mol.write("smi").replace("\t", " ").split(" ")[0]
+
+        return smiles_string
+    else:
+        raise NotImplementedError(f"Backend {backend} not implemented.")
+
+
 def to_networkx(compound, names_only=False):
     """Create a NetworkX graph representing the hierarchy of a Compound.
 

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -800,6 +800,22 @@ class TestCompound(BaseTest):
         assert p3ht1.n_particles == 33
         assert p3ht1.n_bonds == 33
 
+    @pytest.mark.skipif(
+        not has_openbabel, reason="Open Bable package not installed"
+    )
+    def test_to_smiles(self, ethane, benzene):
+        # Test predefined molecule
+        eth_smiles = "CC"
+        benzene_smiles = "c1ccccc1"
+
+        assert ethane.to_smiles() == eth_smiles
+        assert benzene.to_smiles() == benzene_smiles
+
+        # Test molecules loaded in with smiles string
+        for smiles in ["CCO", "CC(O)O", "Cc1ccccc1"]:
+            compound = mb.load(smiles, smiles=True)
+            assert compound.to_smiles() == smiles
+
     @pytest.mark.parametrize(
         "extension", [(".xyz"), (".pdb"), (".mol2"), (".gro")]
     )


### PR DESCRIPTION
### PR Summary:
A quick path to go from mbuild compound to smiles string through openbabel. I am using openbabel to guess the bond orders of the resulted molecule and output a smile string. This can be a temp solution before we can have our own smiles string writer. Pending unit tests. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
