### PR TITLE
Fix bug related to `get_boundingbox()` 

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1450,7 +1450,8 @@ class Compound(object):
         has_dimension = [True, True, True]
         if not is_one_particle:
             missing_dimensions = np.all(
-                np.isclose(self.xyz, self.xyz[0, :],  atol=1e-2), axis=0,
+                np.isclose(self.xyz, self.xyz[0, :], atol=1e-2),
+                axis=0,
             )
             for i, truthy in enumerate(missing_dimensions):
                 has_dimension[i] = not truthy
@@ -1465,7 +1466,6 @@ class Compound(object):
             v3 = np.asarray((0.0, 0.0, self.maxs[2] - self.mins[2]))
         vecs = [v1, v2, v3]
 
-        
         # handle any missing dimensions (planar molecules)
         for i, dim in enumerate(has_dimension):
             if not dim:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1450,7 +1450,7 @@ class Compound(object):
         has_dimension = [True, True, True]
         if not is_one_particle:
             missing_dimensions = np.all(
-                np.isclose(self.xyz, self.xyz[0, :]), axis=0
+                np.isclose(self.xyz, self.xyz[0, :],  atol=1e-2), axis=0,
             )
             for i, truthy in enumerate(missing_dimensions):
                 has_dimension[i] = not truthy
@@ -1465,10 +1465,11 @@ class Compound(object):
             v3 = np.asarray((0.0, 0.0, self.maxs[2] - self.mins[2]))
         vecs = [v1, v2, v3]
 
+        
         # handle any missing dimensions (planar molecules)
         for i, dim in enumerate(has_dimension):
             if not dim:
-                vecs[i][i] = 1.0
+                vecs[i][i] = 0.1
 
         if pad_box is not None:
             if isinstance(pad_box, (int, float, str, Sequence)):

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1789,12 +1789,14 @@ class TestCompound(BaseTest):
         h2.pos = [0.07590747, -0.00182889, -0.00211742]
         container = mb.Compound([h1, h2])
         distances = container.maxs - container.mins
-        with pytest.raises(
-            MBuildError, match=r"The vectors to define the box are co\-linear\,"
-        ):
-            container.get_boundingbox()
+        # Behavior changed due to new co-linear tolerance define in Compound.get_boundingbox()
+        assert container.get_boundingbox()
+
         distance_list = [val for val in distances]
-        distance_list = [val + 1.0 for val in distance_list]
+        for i in range(len(distance_list)):
+            if np.isclose(distance_list[i], 0, atol=1e-2):
+                distance_list[i] = 0.1
+        distance_list = [val + 1 for val in distance_list]
         np.testing.assert_almost_equal(
             container.get_boundingbox(pad_box=1.0).lengths,
             distance_list,
@@ -1802,6 +1804,9 @@ class TestCompound(BaseTest):
         )
 
         distance_list = [val for val in distances]
+        for i in range(len(distance_list)):
+            if np.isclose(distance_list[i], 0, atol=1e-2):
+                distance_list[i] = 0.1
         distance_list[0] = distance_list[0] + 1.0
         distance_list[1] = distance_list[1] + 2.0
         distance_list[2] = distance_list[2] + 3.0


### PR DESCRIPTION
### PR Summary:

Fix bug related to get_boundingbox() when compound is in near-planar shape by defining tolerance when detecting missing dimension. Fix bug reported by Maxim in the dev channel.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
