### PR TITLE
Patches for element reading in lattice builder

### DIFF
--- a/mbuild/tests/test_cif.py
+++ b/mbuild/tests/test_cif.py
@@ -170,3 +170,14 @@ class TestCif(BaseTest):
         assert np.all(np.isclose(manual_lengths, list(periodic_box.lengths)))
         assert np.all(np.isclose(manual_angles, list(periodic_box.angles)))
         assert len(periodic_boxed_molecule.children) == manual_num_atoms
+        assert None not in list(
+            map(lambda x: x.element, periodic_boxed_molecule.particles())
+        )
+
+    def test_cif_raise_warnings(self):
+        with pytest.warns(
+            UserWarning,
+            match=r"Element assumed from cif file to be Element: silicon, symbol: Si, atomic number: 14, mass: 28.085.",
+        ):
+            lattice_cif = load_cif(file_or_path=get_fn("ETV_triclinic.cif"))
+            periodic_boxed_molecule = lattice_cif.populate(x=1, y=1, z=1)

--- a/mbuild/tests/test_lattice.py
+++ b/mbuild/tests/test_lattice.py
@@ -310,3 +310,33 @@ class TestLattice(BaseTest):
         assert isinstance(mylat.box, mb.Box)
         np.testing.assert_allclose([90, 90, 120], mylat.box.angles)
         np.testing.assert_allclose(expected_lengths, mylat.box.lengths)
+
+    def test_populate_with_element_symbol(self):
+        lattice = mb.Lattice(
+            lattice_spacing=[0.5, 0.5, 1],
+            angles=[90, 90, 120],
+            lattice_points={"O": [[0, 0, 0]]},
+        )
+        cpd_lat = lattice.populate(x=1, y=1, z=1)
+        for part in cpd_lat:
+            assert part.element.name == "oxygen"
+
+    def test_populate_with_element_name(self):
+        lattice = mb.Lattice(
+            lattice_spacing=[0.5, 0.5, 1],
+            angles=[90, 90, 120],
+            lattice_points={"Oxygen": [[0, 0, 0]]},
+        )
+        cpd_lat = lattice.populate(x=1, y=1, z=1)
+        for part in cpd_lat:
+            assert part.element.name == "oxygen"
+
+    def test_populate_no_element(self):
+        lattice = mb.Lattice(
+            lattice_spacing=[0.5, 0.5, 1],
+            angles=[90, 90, 120],
+            lattice_points={"A": [[0, 0, 0]]},
+        )
+        cpd_lat = lattice.populate(x=1, y=1, z=1)
+        for part in cpd_lat:
+            assert part.element is None


### PR DESCRIPTION
### PR Summary:
This is a small patch to check for element information from the lattice reader. This is relevant if the user doesn't pass a compund dict of the form {name(STR): compound(mb.Compound)} to map the lattice points to a specific compound. In this case, the only information the populate function has is the key for each lattice point, which is a string. We can then use the `ele` package to check if that is supposed to be an element. Like always, if this is a coarse grained bead without element information, use an `_NAME` syntax to denote that, and no element information will be found.


### Usage:
```python
lattice = mb.Lattice(
             lattice_spacing=[0.5, 0.5, 1],
             angles=[90, 90, 120],
             lattice_points={"O": [[0, 0, 0]]},
 )
 cpd_lat = lattice.populate(x=1, y=1, z=1)
 for part in cpd_lat:
     assert part.element.name == "oxygen" # the oxygen is identified from the lattice_points dict.
```
### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?

Closes #1065.