### PR TITLE
Turn off fail-fast

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,6 +22,7 @@ jobs:
         exclude:
           - os: windows-latest
             python-version: 3.8
+        fail-fast: false
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,13 +16,14 @@ jobs:
     name: mBuild Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.9"]
         exclude:
           - os: windows-latest
             python-version: 3.8
-        fail-fast: false
+
     defaults:
       run:
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ conda activate mbuild
 
 # for mbuild-dev
 conda env create -f environment-dev.yml
-conda activate mbuild
+conda activate mbuild-dev
 
 # install a non-editable version of mbuild
 pip install .

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ complex molecular systems for molecular dynamics simulations.
 
 To learn more, get started or contribute, check out our [website](http://mbuild.mosdef.org).
 
-#### mBuild within the MoSDeF Ecosystem
+### mBuild within the MoSDeF Ecosystem
 <p align="center">
   <img src="docs/images/mosdef.svg?raw=true" alt="mBuild within the MoSDeF Ecosystem" width="500" height="500"/>
 </p>
@@ -30,6 +30,46 @@ we also recommend users to follow the [TRUE](https://www.tandfonline.com/doi/ful
 (Transparent, Reproducible, Usable-by-others, and Extensible) standard, which is a set of common
 practices meant to improve the reproducibility of computational simulation research.
 
+Installation
+------------
+For full, detailed instructions, refer to the [documentation for installation](https://mbuild.mosdef.org/en/stable/getting_started/installation/installation_toc.html)
+
+#### `conda` installation quickstart
+`mBuild` is available on `conda` and can be installed as:
+```bash
+conda install -c conda-forge mbuild
+```
+
+#### Installing from source
+
+Dependencies of mBuild are listed in the files ``environment.yml`` (lightweight environment specification containing minimal dependencies) and ``environment-dev.yml`` (comprehensive environment specification including optional and testing packages for developers).
+The ``mbuild`` or ``mbuild-dev`` conda environments can be created with
+
+
+```.. code-block:: bash
+git clone https://github.com/mosdef-hub/mbuild.git
+cd mbuild
+# for mbuild conda environment
+conda env create -f environment.yml
+conda activate mbuild
+
+# for mbuild-dev
+conda env create -f environment-dev.yml
+conda activate mbuild
+
+# install a non-editable version of mbuild
+pip install .
+```
+
+#### Install an editable version from source
+
+Once all dependencies have been installed and the ``conda`` environment has been created, the ``mBuild`` itself can be installed.
+
+``` code-block:: bash
+cd mbuild
+conda activate mbuild-dev # or mbuild depending on your installation
+pip install -e .
+```
 #### Quick Start with Docker
 To use `mbuild` in a jupyter-notebook that runs from a docker container with all the dependencies installed use the following command:
 
@@ -47,7 +87,7 @@ $ docker run -it --name mbuild mosdef/mbuild:latest
 
 To learn more about using `mBuild` with docker, please refer to the documentation [here](https://mbuild.mosdef.org/en/latest/docker.html).
 
-#### Tutorials
+### Tutorials
 
 *Interactive tutorials can be found here:*
 
@@ -74,7 +114,7 @@ pmpc_layer = PMPCLayer(chain_length=20, pattern=pattern, tile_x=3, tile_y=2)
 ```
 
 ![Zwitterionic brushes on beta-cristobalite substrate](docs/images/pmpc.png)
-#### Community Recipes
+### Community Recipes
 Use case-specific systems can be generated via mBuild recipes.
 Some users have graciously contributed recipes for particular systems, including:
 
@@ -83,7 +123,7 @@ Some users have graciously contributed recipes for particular systems, including
 * [Coarse-grained DNA](https://github.com/zijiewu3/mbuild_ONA)
 * [Lipid bilayers](https://github.com/uppittu11/mbuild_bilayer)
 
-#### Citing mBuild
+### Citing mBuild
 
 If you use this package, please cite [our paper](http://dx.doi.org/10.1007/978-981-10-1128-3_5
 ). The BibTeX reference is
@@ -98,7 +138,7 @@ If you use this package, please cite [our paper](http://dx.doi.org/10.1007/978-9
 }
 ```
 
-#### [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
+### [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
 Various sub-portions of this library may be independently distributed under
 different licenses. See those files for their specific terms.

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2247,8 +2247,7 @@ class Compound(object):
         successors_list,
         check_if_particle=False,
     ):
-        """Provide routines commonly used to check constraint inputs"""
-
+        """Provide routines commonly used to check constraint inputs."""
         for part in particle_list:
             if not isinstance(part, Compound):
                 raise MBuildError(f"{part} is not a Compound.")

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1,5 +1,6 @@
 import os
 import time
+import sys
 
 import numpy as np
 import parmed as pmd
@@ -780,9 +781,7 @@ class TestCompound(BaseTest):
         assert len(ethane.all_ports()) == len(original_ports)
         assert ethane.all_ports()[0] == original_ports[0]
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
     def test_reload(self):
         # Create a compound and write it to file.
         p3ht1 = mb.load("CCCCCCC1=C(SC(=C1)C)C", smiles=True, backend="pybel")
@@ -1323,18 +1322,13 @@ class TestCompound(BaseTest):
             assert B.charge == None
             assert container_charge == 1
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize(self, octane):
         octane.energy_minimize()
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_shift_com(self, octane):
         com_old = octane.pos
         octane.energy_minimize()
@@ -1342,9 +1336,8 @@ class TestCompound(BaseTest):
         # has been shifted back to the original COM
         assert np.allclose(com_old, octane.pos)
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_shift_anchor(self, octane):
         anchor_compound = octane.labels["chain"].labels["CH3"][0]
         pos_old = anchor_compound.pos
@@ -1353,9 +1346,8 @@ class TestCompound(BaseTest):
         # has been shifted back to the original COM
         assert np.allclose(pos_old, anchor_compound.pos)
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_fix_compounds(self, octane):
         methyl_end0 = octane.labels["chain"].labels["CH3"][0]
         methyl_end1 = octane.labels["chain"].labels["CH3"][1]
@@ -1464,9 +1456,8 @@ class TestCompound(BaseTest):
                 fixed_compounds=[methyl_end0, (123.0, 231, "True")]
             )
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_ignore_compounds(self, octane):
         methyl_end0 = octane.labels["chain"].labels["CH3"][0]
         methyl_end1 = octane.labels["chain"].labels["CH3"][1]
@@ -1495,9 +1486,8 @@ class TestCompound(BaseTest):
         with pytest.raises(MBuildError):
             octane.energy_minimize(ignore_compounds=[1231, 123124])
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_distance_constraints(self, octane):
         methyl_end0 = octane.labels["chain"].labels["CH3"][0]
         methyl_end1 = octane.labels["chain"].labels["CH3"][1]
@@ -1549,31 +1539,29 @@ class TestCompound(BaseTest):
             )
 
     @pytest.mark.skipif(has_openbabel, reason="Open Babel package is installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_openbabel_warn(self, octane):
         with pytest.raises(MBuildError):
             octane.energy_minimize()
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_ff(self, octane):
         for ff in ["UFF", "GAFF", "MMFF94", "MMFF94s", "Ghemical"]:
             octane.energy_minimize(forcefield=ff)
         with pytest.raises(IOError):
             octane.energy_minimize(forcefield="fakeFF")
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_algorithm(self, octane):
         for algorithm in ["cg", "steep", "md"]:
             octane.energy_minimize(algorithm=algorithm)
         with pytest.raises(MBuildError):
             octane.energy_minimize(algorithm="fakeAlg")
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_non_element(self, octane):
         for particle in octane.particles():
             particle.element = None
@@ -1585,9 +1573,8 @@ class TestCompound(BaseTest):
         with pytest.raises(MBuildError):
             octane.energy_minimize()
 
-    @pytest.mark.skipif(
-        not has_openbabel, reason="Open Babel package not installed"
-    )
+    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
+    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
     def test_energy_minimize_ports(self, octane):
         distances = np.round(
             [

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1,6 +1,6 @@
 import os
-import time
 import sys
+import time
 
 import numpy as np
 import parmed as pmd
@@ -1323,12 +1323,16 @@ class TestCompound(BaseTest):
             assert container_charge == 1
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize(self, octane):
         octane.energy_minimize()
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_shift_com(self, octane):
         com_old = octane.pos
         octane.energy_minimize()
@@ -1337,7 +1341,9 @@ class TestCompound(BaseTest):
         assert np.allclose(com_old, octane.pos)
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_shift_anchor(self, octane):
         anchor_compound = octane.labels["chain"].labels["CH3"][0]
         pos_old = anchor_compound.pos
@@ -1347,7 +1353,9 @@ class TestCompound(BaseTest):
         assert np.allclose(pos_old, anchor_compound.pos)
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_fix_compounds(self, octane):
         methyl_end0 = octane.labels["chain"].labels["CH3"][0]
         methyl_end1 = octane.labels["chain"].labels["CH3"][1]
@@ -1457,7 +1465,9 @@ class TestCompound(BaseTest):
             )
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_ignore_compounds(self, octane):
         methyl_end0 = octane.labels["chain"].labels["CH3"][0]
         methyl_end1 = octane.labels["chain"].labels["CH3"][1]
@@ -1487,7 +1497,9 @@ class TestCompound(BaseTest):
             octane.energy_minimize(ignore_compounds=[1231, 123124])
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_distance_constraints(self, octane):
         methyl_end0 = octane.labels["chain"].labels["CH3"][0]
         methyl_end1 = octane.labels["chain"].labels["CH3"][1]
@@ -1539,13 +1551,17 @@ class TestCompound(BaseTest):
             )
 
     @pytest.mark.skipif(has_openbabel, reason="Open Babel package is installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_openbabel_warn(self, octane):
         with pytest.raises(MBuildError):
             octane.energy_minimize()
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_ff(self, octane):
         for ff in ["UFF", "GAFF", "MMFF94", "MMFF94s", "Ghemical"]:
             octane.energy_minimize(forcefield=ff)
@@ -1553,7 +1569,9 @@ class TestCompound(BaseTest):
             octane.energy_minimize(forcefield="fakeFF")
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_algorithm(self, octane):
         for algorithm in ["cg", "steep", "md"]:
             octane.energy_minimize(algorithm=algorithm)
@@ -1561,7 +1579,9 @@ class TestCompound(BaseTest):
             octane.energy_minimize(algorithm="fakeAlg")
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_non_element(self, octane):
         for particle in octane.particles():
             particle.element = None
@@ -1574,7 +1594,9 @@ class TestCompound(BaseTest):
             octane.energy_minimize()
 
     @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif("win" in sys.platform, reason="Unknown issue with Window's Open Babel ")
+    @pytest.mark.skipif(
+        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
+    )
     def test_energy_minimize_ports(self, octane):
         distances = np.round(
             [


### PR DESCRIPTION
### PR Summary:
Right now, if what of the check failed, all the other unfinished checks will get canceled, which miss the point of testing on different OS. This PR turns that off. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
