### PR TITLE
updating open babel energy minimization to no longer use temp file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
     - id: trailing-whitespace
       exclude: setup.cfg
 - repo: https://github.com/psf/black
-  rev: 22.10.0
+  rev: 22.12.0
   hooks:
     - id: black
       args: [--line-length=80]
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.11.1
   hooks:
     - id: isort
       name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,13 +22,13 @@ repos:
     - id: black
       args: [--line-length=80]
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.1
+  rev: 5.11.4
   hooks:
     - id: isort
       name: isort (python)
       args: [--profile=black, --line-length=80]
 - repo: https://github.com/pycqa/pydocstyle
-  rev: '6.1.1'
+  rev: '6.2.3'
   hooks:
     - id: pydocstyle
       exclude: ^(mbuild/tests/|docs/|devtools/|setup.py|setup.cfg|mbuild/formats/charmm_writer.py|mbuild/formats/gomc_conf_writer.py|mbuild/utils/specific_ff_to_residue.py)

--- a/docs/topic_guides/coordinate_transforms.rst
+++ b/docs/topic_guides/coordinate_transforms.rst
@@ -12,10 +12,10 @@ The following utility functions provide mechanisms for spatial transformations f
 
 .. autofunction:: mbuild.coordinate_transform.z_axis_transform
 
-.. autofunction:: mbuild.compound.translate
+.. autofunction:: mbuild.compound.Compound.translate
 
-.. autofunction:: mbuild.compound.translate_to
+.. autofunction:: mbuild.compound.Compound.translate_to
 
-.. autofunction:: mbuild.compound.rotate
+.. autofunction:: mbuild.compound.Compound.rotate
 
-.. autofunction:: mbuild.compound.spin
+.. autofunction:: mbuild.compound.Compound.spin

--- a/docs/topic_guides/coordinate_transforms.rst
+++ b/docs/topic_guides/coordinate_transforms.rst
@@ -4,13 +4,13 @@ Coordinate Transformations
 The following utility functions provide mechanisms for spatial transformations for mbuild compounds:
 
 
-.. autofunction:: mbuild.compound.translate
+.. autofunction:: mbuild.compound.compound.translate
 
-.. autofunction:: mbuild.compound.translate_to
+.. autofunction:: mbuild.compound.compound.translate_to
 
-.. autofunction:: mbuild.compound.rotate
+.. autofunction:: mbuild.compound.compound.rotate
 
-.. autofunction:: mbuild.compound.spin
+.. autofunction:: mbuild.compound.compound.spin
 
 .. autofunction:: mbuild.coordinate_transform.force_overlap
 

--- a/docs/topic_guides/coordinate_transforms.rst
+++ b/docs/topic_guides/coordinate_transforms.rst
@@ -12,4 +12,10 @@ The following utility functions provide mechanisms for spatial transformations f
 
 .. autofunction:: mbuild.coordinate_transform.z_axis_transform
 
-.. autofunction:: mbuild.compound.compound
+.. autofunction:: mbuild.compound.translate
+
+.. autofunction:: mbuild.compound.translate_to
+
+.. autofunction:: mbuild.compound.rotate
+
+.. autofunction:: mbuild.compound.spin

--- a/docs/topic_guides/coordinate_transforms.rst
+++ b/docs/topic_guides/coordinate_transforms.rst
@@ -3,15 +3,16 @@ Coordinate Transformations
 ==========================
 The following utility functions provide mechanisms for spatial transformations for mbuild compounds:
 
+
+.. autofunction:: mbuild.compound.translate
+
+.. autofunction:: mbuild.compound.translate_to
+
+.. autofunction:: mbuild.compound.rotate
+
+.. autofunction:: mbuild.compound.spin
+
 .. autofunction:: mbuild.coordinate_transform.force_overlap
-
-.. autofunction:: mbuild.coordinate_transform.translate
-
-.. autofunction:: mbuild.coordinate_transform.translate_to
-
-.. autofunction:: mbuild.coordinate_transform.rotate
-
-.. autofunction:: mbuild.coordinate_transform.spin
 
 .. autofunction:: mbuild.coordinate_transform.x_axis_transform
 

--- a/docs/topic_guides/coordinate_transforms.rst
+++ b/docs/topic_guides/coordinate_transforms.rst
@@ -4,14 +4,6 @@ Coordinate Transformations
 The following utility functions provide mechanisms for spatial transformations for mbuild compounds:
 
 
-.. autofunction:: mbuild.compound.compound.translate
-
-.. autofunction:: mbuild.compound.compound.translate_to
-
-.. autofunction:: mbuild.compound.compound.rotate
-
-.. autofunction:: mbuild.compound.compound.spin
-
 .. autofunction:: mbuild.coordinate_transform.force_overlap
 
 .. autofunction:: mbuild.coordinate_transform.x_axis_transform
@@ -19,3 +11,5 @@ The following utility functions provide mechanisms for spatial transformations f
 .. autofunction:: mbuild.coordinate_transform.y_axis_transform
 
 .. autofunction:: mbuild.coordinate_transform.z_axis_transform
+
+.. autofunction:: mbuild.compound.compound

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2384,7 +2384,7 @@ class Compound(object):
             # if a user passes single constraint as a 1-D array,
             # i.e., [(p1,p2), 2.0]  rather than [[(p1,p2), 2.0]],
             # just add it to a list so we can use the same looping code
-            if len(np.array(distance_constraints).shape) == 1:
+            if len(np.array(distance_constraints, dtype=object).shape) == 1:
                 distance_constraints = [distance_constraints]
 
             for con_temp in distance_constraints:
@@ -2415,7 +2415,7 @@ class Compound(object):
 
             # if fixed_compounds is a 1-d array and it is of length 2, we need to determine whether it is
             # a list of two Compounds or if fixed_compounds[1] should correspond to the directions to constrain
-            if len(np.array(fixed_compounds).shape) == 1:
+            if len(np.array(fixed_compounds, dtype=object).shape) == 1:
                 if len(fixed_compounds) == 2:
                     if not isinstance(fixed_compounds[1], Compound):
                         # if it is not a list of two Compounds, make a 2d array so we can use the same looping code
@@ -2493,7 +2493,7 @@ class Compound(object):
                                 ob_constraints.AddAtomZConstraint(pid)
 
         if ignore_compounds is not None:
-            temp1 = np.array(ignore_compounds)
+            temp1 = np.array(ignore_compounds, dtype=object)
             if len(temp1.shape) == 2:
                 ignore_compounds = list(temp1.reshape(-1))
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2831,7 +2831,6 @@ class Compound(object):
         topology : gmso.Topology
             The converted gmso Topology
         """
-
         return conversion.to_gmso(self, **kwargs)
 
     # Interface to Trajectory for reading/writing .pdb and .mol2 files.

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2070,7 +2070,7 @@ class Compound(object):
                 )
 
             self.update_coordinates(os.path.join(tmp_dir, "minimized.pdb"))
-            
+
         if shift_com:
             self.translate_to(com)
 
@@ -2523,14 +2523,16 @@ class Compound(object):
         obConversion.SetInAndOutFormats("mol2", "pdb")
         mol = openbabel.OBMol()
 
-        #obConversion.ReadFile(mol, os.path.join(tmp_dir, "un-minimized.mol2"))
-        
+        # obConversion.ReadFile(mol, os.path.join(tmp_dir, "un-minimized.mol2"))
+
         # convert compound to openbabel mol
         ids = {}
         for i, part in enumerate(self):
-            ids[id(part)] = i+1
+            ids[id(part)] = i + 1
             a = mol.NewAtom()
-            a.SetVector(part.pos[0]*10.0, part.pos[1]*10.0, part.pos[2]*10.0)
+            a.SetVector(
+                part.pos[0] * 10.0, part.pos[1] * 10.0, part.pos[2] * 10.0
+            )
             a.SetAtomicNum(part.element.atomic_number)
             a.SetType(part.element.symbol)
 
@@ -2538,7 +2540,7 @@ class Compound(object):
         # we will set bond order to 1 and call PerceiveBondOrders
         for bond in self.bonds():
             mol.AddBond(ids[id(bond[0])], ids[id(bond[1])], 1)
-        
+
         mol.PerceiveBondOrders()
         mol.SetAtomTypesPerceived()
 
@@ -2585,14 +2587,13 @@ class Compound(object):
             )
         ff.UpdateCoordinates(mol)
 
-        #obConversion.WriteFile(mol, os.path.join(tmp_dir, "minimized.pdb"))
-        #update the coordinates in the Compound
+        # obConversion.WriteFile(mol, os.path.join(tmp_dir, "minimized.pdb"))
+        # update the coordinates in the Compound
         for i, obatom in enumerate(openbabel.OBMolAtomIter(mol)):
-            x = obatom.GetX()/10.0
-            y = obatom.GetY()/10.0
-            z = obatom.GetZ()/10.0
-            self[i].pos = np.array([x,y,z])
-
+            x = obatom.GetX() / 10.0
+            y = obatom.GetY() / 10.0
+            z = obatom.GetZ() / 10.0
+            self[i].pos = np.array([x, y, z])
 
     def save(
         self,

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2527,7 +2527,9 @@ class Compound(object):
             ids[id(part)] = i + 1
             a = mol.NewAtom()
             a.SetVector(
-                np.round(part.pos[0] * 10.0, 4), np.round(part.pos[1] * 10.0, 4), np.round(part.pos[2] * 10.0, 4)
+                np.round(part.pos[0] * 10.0, 4),
+                np.round(part.pos[1] * 10.0, 4),
+                np.round(part.pos[2] * 10.0, 4),
             )
             a.SetAtomicNum(part.element.atomic_number)
             a.SetType(part.element.symbol)
@@ -2847,7 +2849,7 @@ class Compound(object):
         topology : gmso.Topology
             The converted gmso Topology
         """
-        return conversion.to_gmso(self,**kwargs)
+        return conversion.to_gmso(self, **kwargs)
 
     # Interface to Trajectory for reading/writing .pdb and .mol2 files.
     # -----------------------------------------------------------------

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2518,27 +2518,10 @@ class Compound(object):
                             particle_idx[id(particle)] + 1
                         )  # openbabel indices start at 1
                         ob_constraints.AddIgnore(pid)
-
-        mol = openbabel.OBMol()
-
-        # convert compound to openbabel mol
-        ids = {}
-        for i, part in enumerate(self):
-            ids[id(part)] = i + 1
-            a = mol.NewAtom()
-            a.SetVector(
-                np.round(part.pos[0] * 10.0, 4),
-                np.round(part.pos[1] * 10.0, 4),
-                np.round(part.pos[2] * 10.0, 4),
-            )
-            a.SetAtomicNum(part.element.atomic_number)
-            a.SetType(part.element.symbol)
-
-        # since mbuild doesn't consider bond order,
-        # we will set bond order to 1 and call PerceiveBondOrders
-        for bond in self.bonds():
-            mol.AddBond(ids[id(bond[0])], ids[id(bond[1])], 1)
-
+        
+        mol = self.to_pybel()
+        mol = mol.OBMol
+        
         mol.PerceiveBondOrders()
         mol.SetAtomTypesPerceived()
 

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2519,11 +2519,8 @@ class Compound(object):
                         )  # openbabel indices start at 1
                         ob_constraints.AddIgnore(pid)
 
-        obConversion = openbabel.OBConversion()
-        obConversion.SetInAndOutFormats("mol2", "pdb")
         mol = openbabel.OBMol()
 
-        # obConversion.ReadFile(mol, os.path.join(tmp_dir, "un-minimized.mol2"))
 
         # convert compound to openbabel mol
         ids = {}
@@ -2587,7 +2584,6 @@ class Compound(object):
             )
         ff.UpdateCoordinates(mol)
 
-        # obConversion.WriteFile(mol, os.path.join(tmp_dir, "minimized.pdb"))
         # update the coordinates in the Compound
         for i, obatom in enumerate(openbabel.OBMolAtomIter(mol)):
             x = obatom.GetX() / 10.0

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2527,7 +2527,7 @@ class Compound(object):
             ids[id(part)] = i + 1
             a = mol.NewAtom()
             a.SetVector(
-                part.pos[0] * 10.0, part.pos[1] * 10.0, part.pos[2] * 10.0
+                np.round(part.pos[0] * 10.0, 4), np.round(part.pos[1] * 10.0, 4), np.round(part.pos[2] * 10.0, 4)
             )
             a.SetAtomicNum(part.element.atomic_number)
             a.SetType(part.element.symbol)
@@ -2847,7 +2847,7 @@ class Compound(object):
         topology : gmso.Topology
             The converted gmso Topology
         """
-        return conversion.to_gmso(self)
+        return conversion.to_gmso(self,**kwargs)
 
     # Interface to Trajectory for reading/writing .pdb and .mol2 files.
     # -----------------------------------------------------------------

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2040,16 +2040,16 @@ class Compound(object):
                     f"Anchor: {anchor} is not part of the Compound: {self}"
                     "that you are trying to energy minimize."
                 )
-        tmp_dir = tempfile.mkdtemp()
         original = clone(self)
         self._kick()
         extension = os.path.splitext(forcefield)[-1]
         openbabel_ffs = ["MMFF94", "MMFF94s", "UFF", "GAFF", "Ghemical"]
         if forcefield in openbabel_ffs:
             self._energy_minimize_openbabel(
-                tmp_dir, forcefield=forcefield, steps=steps, **kwargs
+                forcefield=forcefield, steps=steps, **kwargs
             )
         else:
+            tmp_dir = tempfile.mkdtemp()
             self.save(os.path.join(tmp_dir, "un-minimized.mol2"))
 
             if extension == ".xml":
@@ -2265,7 +2265,6 @@ class Compound(object):
 
     def _energy_minimize_openbabel(
         self,
-        tmp_dir,
         steps=1000,
         algorithm="cg",
         forcefield="UFF",

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2849,7 +2849,9 @@ class Compound(object):
         topology : gmso.Topology
             The converted gmso Topology
         """
+
         return conversion.to_gmso(self, **kwargs)
+        #return conversion.to_gmso(self)
 
     # Interface to Trajectory for reading/writing .pdb and .mol2 files.
     # -----------------------------------------------------------------

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2359,7 +2359,7 @@ class Compound(object):
         for particle in self.particles():
             if particle.element is None:
                 try:
-                    element_from_symbol(particle.name)
+                    particle._element = element_from_symbol(particle.name)
                 except ElementError:
                     try:
                         element_from_name(particle.name)

--- a/mbuild/formats/hoomd_forcefield.py
+++ b/mbuild/formats/hoomd_forcefield.py
@@ -38,11 +38,11 @@ def create_hoomd_forcefield(
     r_cut : float
         Cutoff radius in simulation units
     ref_distance : float, optional, default=1.0
-        Reference distance for unit conversion (from Angstrom)
+        Reference distance for unit conversion ((Angstrom) / (desired units))
     ref_mass : float, optional, default=1.0
-        Reference mass for unit conversion (from Dalton)
+        Reference mass for unit conversion ((Dalton) / (desired units))
     ref_energy : float, optional, default=1.0
-        Reference energy for unit conversion (from kcal/mol)
+        Reference energy for unit conversion ((kcal/mol) / (desired units))
     auto_scale : bool, optional, default=False
         Scale to reduced units by automatically using the largest sigma value
         as ref_distance, largest mass value as ref_mass, and largest epsilon
@@ -66,13 +66,43 @@ def create_hoomd_forcefield(
     ReferenceValues : namedtuple
         Values used in scaling
 
-    Note
-    ----
+    Notes
+    -----
     If you pass a non-parametrized pmd.Structure, you will not have
     angle, dihedral, or force field information. You may be better off
-    creating a hoomd.Snapshot
-    Reference units should be expected to convert parmed Structure units :
-        angstroms, kcal/mol, and daltons
+    creating a hoomd.Snapshot.
+    See mbuild.formats.hoomd_snapshot.to_hoomdsnapshot()
+
+    About units: This method operates on a Parmed.Structure object
+    where the units used differ from those used in mBuild and Foyer
+    which may have been used when creating the typed Parmed.Structure.
+
+    The default units used when writing out the HOOMD Snapshot are:
+    Distance (Angstrom)
+    Mass (Dalton)
+    Energy (kcal/mol)
+
+    If you wish to convert this unit system to another, you can use the
+    reference parameters (ref_distance, ref_mass, ref_energy).
+    The values used here should be expected to convert from the Parmed
+    Structure units (above) to your desired units.
+    The Parmed.Structure values are divided by the reference values.
+
+    If you wish to used a reduced unit system, set auto_scale = True.
+    When auto_scale is True, the reference parameters won't be used.
+
+    Examples
+    --------
+        To convert the energy units from kcal/mol to kj/mol:
+            use ref_energy = 0.2390057 (kcal/kj)
+
+        To convert the distance units from Angstrom to nm:
+            use ref_distance = 10 (angstroms/nm)
+
+        To use a reduced unit system, where mass, sigma, and epsilon are
+        scaled by the largest value of each:
+            use auto_scale = True, ref_distance = ref_energy = ref_mass = 1
+
     """
     if isinstance(structure, mb.Compound):
         raise ValueError(

--- a/mbuild/formats/hoomd_forcefield.py
+++ b/mbuild/formats/hoomd_forcefield.py
@@ -93,15 +93,15 @@ def create_hoomd_forcefield(
 
     Examples
     --------
-        To convert the energy units from kcal/mol to kj/mol:
-            use ref_energy = 0.2390057 (kcal/kj)
+    To convert the energy units from kcal/mol to kj/mol:
+        use ref_energy = 0.2390057 (kcal/kj)
 
-        To convert the distance units from Angstrom to nm:
-            use ref_distance = 10 (angstroms/nm)
+    To convert the distance units from Angstrom to nm:
+        use ref_distance = 10 (angstroms/nm)
 
-        To use a reduced unit system, where mass, sigma, and epsilon are
-        scaled by the largest value of each:
-            use auto_scale = True, ref_distance = ref_energy = ref_mass = 1
+    To use a reduced unit system, where mass, sigma, and epsilon are
+    scaled by the largest value of each:
+        use auto_scale = True, ref_distance = ref_energy = ref_mass = 1
 
     """
     if isinstance(structure, mb.Compound):

--- a/mbuild/formats/hoomd_snapshot.py
+++ b/mbuild/formats/hoomd_snapshot.py
@@ -77,6 +77,7 @@ def from_snapshot(snapshot, scale=1.0):
         comp.add(atom, label=str(i))
 
     # Add bonds
+    particle_dict = {idx: p for idx, p in enumerate(comp.particles())}
     for i in range(bond_array.shape[0]):
         atom1 = int(bond_array[i][0])
         atom2 = int(bond_array[i][1])

--- a/mbuild/formats/hoomd_snapshot.py
+++ b/mbuild/formats/hoomd_snapshot.py
@@ -77,7 +77,6 @@ def from_snapshot(snapshot, scale=1.0):
         comp.add(atom, label=str(i))
 
     # Add bonds
-    particle_dict = {idx: p for idx, p in enumerate(comp.particles())}
     for i in range(bond_array.shape[0]):
         atom1 = int(bond_array[i][0])
         atom2 = int(bond_array[i][1])
@@ -103,12 +102,11 @@ def to_hoomdsnapshot(
     ----------
     structure : parmed.Structure
         ParmEd Structure object
-    ref_distance : float, optional, default=1.0
-        Reference distance for conversion to reduced units
+        Reference distance for unit conversion ((Angstrom) / (desired units))
     ref_mass : float, optional, default=1.0
-        Reference mass for conversion to reduced units
+        Reference mass for unit conversion ((Dalton) / (desired units))
     ref_energy : float, optional, default=1.0
-        Reference energy for conversion to reduced units
+        Reference energy for unit conversion ((kcal/mol) / (desired units))
     rigid_bodies : list of int, optional, default=None
         List of rigid body information. An integer value is required for
         each atom corresponding to the index of the rigid body the particle
@@ -134,10 +132,42 @@ def to_hoomdsnapshot(
     ReferenceValues : namedtuple
         Values used in scaling
 
-
     Notes
     -----
-    Force field parameters are not written to the hoomd_snapshot
+    This method does not create hoomd forcefield objects and
+    the snapshot returned does not store the forcefield parameters.
+    See mbuild.formats.hoomd_forcefield.create_hoomd_forcefield()
+
+    About units: This method operates on a Parmed.Structure object
+        where the units used differ from those used in mBuild and Foyer
+        which may have been used when creating the typed Parmed.Structure.
+
+    The default units used when writing out the HOOMD Snapshot are:
+    Distance (Angstrom)
+    Mass (Dalton)
+    Energy (kcal/mol)
+
+    If you wish to convert this unit system to another, you can use the
+    reference parameters (ref_distance, ref_mass, ref_energy).
+    The values used here should be expected to convert from the Parmed
+    Structure units (above) to your desired units.
+    The Parmed.Structure values are divided by the reference values.
+
+    If you wish to used a reduced unit system, set auto_scale = True.
+    When auto_scale is True, the reference parameters won't be used.
+
+    Examples
+    --------
+        To convert the energy units from kcal/mol to kj/mol:
+            use ref_energy = 0.2390057 (kcal/kj)
+
+        To convert the distance units from Angstrom to nm:
+            use ref_distance = 10 (angstroms/nm)
+
+        To use a reduced unit system, where mass, sigma, and epsilon are
+        scaled by the largest value of each:
+            use auto_scale = True, ref_distance = ref_energy = ref_mass = 1
+
     """
     if not isinstance(structure, (Compound, pmd.Structure)):
         raise ValueError(

--- a/mbuild/formats/hoomd_snapshot.py
+++ b/mbuild/formats/hoomd_snapshot.py
@@ -159,15 +159,15 @@ def to_hoomdsnapshot(
 
     Examples
     --------
-        To convert the energy units from kcal/mol to kj/mol:
-            use ref_energy = 0.2390057 (kcal/kj)
+    To convert the energy units from kcal/mol to kj/mol:
+        use ref_energy = 0.2390057 (kcal/kj)
 
-        To convert the distance units from Angstrom to nm:
-            use ref_distance = 10 (angstroms/nm)
+    To convert the distance units from Angstrom to nm:
+        use ref_distance = 10 (angstroms/nm)
 
-        To use a reduced unit system, where mass, sigma, and epsilon are
-        scaled by the largest value of each:
-            use auto_scale = True, ref_distance = ref_energy = ref_mass = 1
+    To use a reduced unit system, where mass, sigma, and epsilon are
+    scaled by the largest value of each:
+        use auto_scale = True, ref_distance = ref_energy = ref_mass = 1
 
     """
     if not isinstance(structure, (Compound, pmd.Structure)):

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1589,7 +1589,9 @@ class TestCompound(BaseTest):
         octane.energy_minimize()
         for particle in octane.particles():
             particle.name = "Q"
-        # Fail once names don't match elements
+            particle.element = None
+
+        # Fail once names cannot be set as elements
         with pytest.raises(MBuildError):
             octane.energy_minimize()
 

--- a/mbuild/tests/test_gmso.py
+++ b/mbuild/tests/test_gmso.py
@@ -56,17 +56,14 @@ class TestGMSO(BaseTest):
         # Create an ethane box, should be a four structure
         eth_box = mb.packing.fill_box(compound=ethane, n_compounds=1, density=1)
 
-        # TODO: once infer_hierarchy is implemented in gmso, changes these functions
 
-        # infer_hierarchy=False
-        # unlabeled_top = eth_box.to_gmso(infer_hierarchy=False)
-        unlabeled_top = eth_box.to_gmso()
+        # don't infer_hierarchy, parse_label=False
+        unlabeled_top = eth_box.to_gmso(parse_label=False)
         for site in unlabeled_top.sites:
             assert not site.residue or site.molecule or site.group
 
-        # infer_hierarchy=True
-        # labeled_top = eth_box.to_gmso(infer_hierarchy=True)
-        labeled_top = eth_box.to_gmso()
+        # infer_hierarchy
+        labeled_top = eth_box.to_gmso(parse_label=True)
         for site in labeled_top.sites:
             assert site.group == "Ethane"
             assert site.molecule.name == "Ethane"

--- a/mbuild/tests/test_gmso.py
+++ b/mbuild/tests/test_gmso.py
@@ -56,7 +56,6 @@ class TestGMSO(BaseTest):
         # Create an ethane box, should be a four structure
         eth_box = mb.packing.fill_box(compound=ethane, n_compounds=1, density=1)
 
-
         # don't infer_hierarchy, parse_label=False
         unlabeled_top = eth_box.to_gmso(parse_label=False)
         for site in unlabeled_top.sites:

--- a/mbuild/tests/test_gmso.py
+++ b/mbuild/tests/test_gmso.py
@@ -56,13 +56,17 @@ class TestGMSO(BaseTest):
         # Create an ethane box, should be a four structure
         eth_box = mb.packing.fill_box(compound=ethane, n_compounds=1, density=1)
 
+        #TODO: once infer_hierarchy is implemented in gmso, changes these functions
+
         # infer_hierarchy=False
-        unlabeled_top = eth_box.to_gmso(infer_hierarchy=False)
+        #unlabeled_top = eth_box.to_gmso(infer_hierarchy=False)
+        unlabeled_top = eth_box.to_gmso()
         for site in unlabeled_top.sites:
             assert not site.residue or site.molecule or site.group
 
         # infer_hierarchy=True
-        labeled_top = eth_box.to_gmso(infer_hierarchy=True)
+        #labeled_top = eth_box.to_gmso(infer_hierarchy=True)
+        labeled_top = eth_box.to_gmso()
         for site in labeled_top.sites:
             assert site.group == "Ethane"
             assert site.molecule.name == "Ethane"


### PR DESCRIPTION
### PR Summary:
This is related to issue #1077.   Rather that relying on a temporary .mol2 file to perform open babel energy minimization, this PR will directly set the relevant parameters in the open babel OBMol class, and extract energy minimized coordinates from this class for updating of the positions in the Compound. 

My initial plan was to simply store Compound.name information, overwrite it with Compound.element before generating the .mol2 file, and then revert Compound.name parameters to the original entries.  However, using the API directly to set the info seems like it would be better with less overhead.  

### PR Checklist
------------
 - [X] Includes appropriate unit test(s)
 - [X] Appropriate docstring(s) are added/updated
 - [X] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
