### PR TITLE
Write LJ parameters with 5 decimal places instead of 3 with MCF writer.

### DIFF
--- a/mbuild/formats/cassandramcf.py
+++ b/mbuild/formats/cassandramcf.py
@@ -377,7 +377,7 @@ def _write_atom_information(mcf_file, structure, in_ring, IG_CONSTANT_KCAL):
     for i in range(len(structure.atoms)):
         mcf_file.write(
             "{:<4d}  {:<6s}  {:<2s}  {:7.3f}  {:12.8f}  "
-            "{:3s}  {:8.3f}  {:8.3f}".format(
+            "{:3s}  {:8.5f}  {:8.5f}".format(
                 i + 1,
                 types[i],
                 elements[i],

--- a/mbuild/tests/test_cassandramcf.py
+++ b/mbuild/tests/test_cassandramcf.py
@@ -220,13 +220,13 @@ class TestCassandraMCF(BaseTest):
         assert isclose(float(mcf_data[atom_section_start + 2][3]), 12.011)
         assert isclose(float(mcf_data[atom_section_start + 2][4]), -0.18)
         assert mcf_data[atom_section_start + 2][5] == "LJ"
-        assert isclose(float(mcf_data[atom_section_start + 2][6]), 33.212)
+        assert isclose(float(mcf_data[atom_section_start + 2][6]), 33.21249)
         assert isclose(float(mcf_data[atom_section_start + 2][7]), 3.500)
 
         # Bond info
         assert mcf_data[bond_section_start + 1][0] == "7"
         passed_test = False
-        for line in mcf_data[bond_section_start + 2 : angle_section_start - 6]:
+        for line in mcf_data[bond_section_start + 2: angle_section_start - 6]:
             a1 = line[1]
             a2 = line[2]
             if (a1 == "1" and a2 == "2") or (a2 == "1" and a1 == "2"):
@@ -240,7 +240,7 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[angle_section_start + 1][0] == "12"
         passed_test = False
         for line in mcf_data[
-            angle_section_start + 2 : dihedral_section_start - 8
+            angle_section_start + 2: dihedral_section_start - 8
         ]:
             if line[2] == "5":
                 a1 = line[1]
@@ -257,7 +257,7 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[dihedral_section_start + 1][0] == "9"
         passed_test = False
         for line in mcf_data[
-            dihedral_section_start + 2 : improper_section_start - 5
+            dihedral_section_start + 2: improper_section_start - 5
         ]:
             a1 = line[1]
             a2 = line[2]
@@ -317,14 +317,14 @@ class TestCassandraMCF(BaseTest):
         assert isclose(float(mcf_data[atom_section_start + 2][3]), 12.011)
         assert isclose(float(mcf_data[atom_section_start + 2][4]), -0.115)
         assert mcf_data[atom_section_start + 2][5] == "LJ"
-        assert isclose(float(mcf_data[atom_section_start + 2][6]), 35.225)
+        assert isclose(float(mcf_data[atom_section_start + 2][6]), 35.22537)
         assert isclose(float(mcf_data[atom_section_start + 2][7]), 3.550)
         assert mcf_data[atom_section_start + 2][8] == "ring"
 
         # Bond info
         assert mcf_data[bond_section_start + 1][0] == "12"
         passed_test = False
-        for line in mcf_data[bond_section_start + 2 : angle_section_start - 6]:
+        for line in mcf_data[bond_section_start + 2: angle_section_start - 6]:
             a1 = line[1]
             a2 = line[2]
             if (a1 == "1" and a2 == "2") or (a2 == "1" and a1 == "2"):
@@ -338,7 +338,7 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[angle_section_start + 1][0] == "18"
         passed_test = False
         for line in mcf_data[
-            angle_section_start + 2 : dihedral_section_start - 8
+            angle_section_start + 2: dihedral_section_start - 8
         ]:
             if line[2] == "2":
                 a1 = line[1]
@@ -354,7 +354,7 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[dihedral_section_start + 1][0] == "24"
         passed_test = False
         for line in mcf_data[
-            dihedral_section_start + 2 : improper_section_start - 5
+            dihedral_section_start + 2: improper_section_start - 5
         ]:
             a1 = line[1]
             a2 = line[2]

--- a/mbuild/tests/test_cassandramcf.py
+++ b/mbuild/tests/test_cassandramcf.py
@@ -226,7 +226,7 @@ class TestCassandraMCF(BaseTest):
         # Bond info
         assert mcf_data[bond_section_start + 1][0] == "7"
         passed_test = False
-        for line in mcf_data[bond_section_start + 2: angle_section_start - 6]:
+        for line in mcf_data[bond_section_start + 2 : angle_section_start - 6]:
             a1 = line[1]
             a2 = line[2]
             if (a1 == "1" and a2 == "2") or (a2 == "1" and a1 == "2"):
@@ -240,7 +240,7 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[angle_section_start + 1][0] == "12"
         passed_test = False
         for line in mcf_data[
-            angle_section_start + 2: dihedral_section_start - 8
+            angle_section_start + 2 : dihedral_section_start - 8
         ]:
             if line[2] == "5":
                 a1 = line[1]
@@ -257,7 +257,7 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[dihedral_section_start + 1][0] == "9"
         passed_test = False
         for line in mcf_data[
-            dihedral_section_start + 2: improper_section_start - 5
+            dihedral_section_start + 2 : improper_section_start - 5
         ]:
             a1 = line[1]
             a2 = line[2]
@@ -324,7 +324,7 @@ class TestCassandraMCF(BaseTest):
         # Bond info
         assert mcf_data[bond_section_start + 1][0] == "12"
         passed_test = False
-        for line in mcf_data[bond_section_start + 2: angle_section_start - 6]:
+        for line in mcf_data[bond_section_start + 2 : angle_section_start - 6]:
             a1 = line[1]
             a2 = line[2]
             if (a1 == "1" and a2 == "2") or (a2 == "1" and a1 == "2"):
@@ -338,7 +338,7 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[angle_section_start + 1][0] == "18"
         passed_test = False
         for line in mcf_data[
-            angle_section_start + 2: dihedral_section_start - 8
+            angle_section_start + 2 : dihedral_section_start - 8
         ]:
             if line[2] == "2":
                 a1 = line[1]
@@ -354,7 +354,7 @@ class TestCassandraMCF(BaseTest):
         assert mcf_data[dihedral_section_start + 1][0] == "24"
         passed_test = False
         for line in mcf_data[
-            dihedral_section_start + 2: improper_section_start - 5
+            dihedral_section_start + 2 : improper_section_start - 5
         ]:
             a1 = line[1]
             a2 = line[2]


### PR DESCRIPTION
### PR Summary:
This PR increases the number of decimal places for LJ parameters from 3 to 5 in the Cassandra MCF writer.  See #1093  .

Closes #1093 .


### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
