### PR TITLE
speeding up add function for large compounds

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -511,7 +511,8 @@ class Compound(object):
         if self._contains_only_ports():
             return self._particle_mass(self)
         else:
-            particle_masses = [self._particle_mass(p) for p in self.particles()]
+            particle_masses = [self._particle_mass(
+                p) for p in self.particles()]
             if None in particle_masses:
                 warn(
                     f"Some particle of {self} does not have mass."
@@ -2506,7 +2507,8 @@ class Compound(object):
             if not isinstance(part, Compound):
                 raise MBuildError(f"{part} is not a Compound.")
             if id(part) != id(self) and id(part) not in successors_list:
-                raise MBuildError(f"{part} is not a member of Compound {self}.")
+                raise MBuildError(
+                    f"{part} is not a member of Compound {self}.")
 
             if check_if_particle:
                 if len(part.children) != 0:
@@ -2753,7 +2755,8 @@ class Compound(object):
 
             # Since the ignore_compounds can only be passed as a list
             # we can check the whole list at once before looping over it
-            self._check_openbabel_constraints(ignore_compounds, successors_list)
+            self._check_openbabel_constraints(
+                ignore_compounds, successors_list)
 
             for ignore in ignore_compounds:
                 p1 = ignore
@@ -3403,7 +3406,8 @@ class Compound(object):
             return list(self.particles())[selection]
         if isinstance(selection, str):
             if selection not in self.labels:
-                raise MBuildError(f"{self.name}['{selection}'] does not exist.")
+                raise MBuildError(
+                    f"{self.name}['{selection}'] does not exist.")
             return self.labels.get(selection)
 
     def __repr__(self):
@@ -3524,7 +3528,7 @@ Particle = Compound
 
 
 def _flatten_list(c_list):
-    """Flatten a list
+    """Flatten a list.
 
     Helper function to flatten a list that may be nested, e.g. [comp1, [comp2, comp3]].
     """

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -789,6 +789,7 @@ class Compound(object):
             if self.rigid_id:
                 if self.rigid_id > missing_rigid_id:
                     self.rigid_id -= 1
+
     # helper function to flattening a list that may be nested, in particular used for a list of labels
     def _flatten_list(self, c_list):
         if isinstance(c_list, list):
@@ -797,6 +798,7 @@ class Compound(object):
                     yield from self._flatten_list(c)
                 else:
                     yield c
+
     # helper function to flatten a list of Compounds that may be nested
     def _flatten_compound_list(self, c_list):
         if isinstance(c_list, Iterable):
@@ -871,7 +873,11 @@ class Compound(object):
             if len(temp_bond_graphs) != 0:
                 children_bond_graph = nx.compose_all(temp_bond_graphs)
 
-            if len(temp_bond_graphs) != 0 and not isinstance(self, Port) and children_bond_graph is not None:
+            if (
+                len(temp_bond_graphs) != 0
+                and not isinstance(self, Port)
+                and children_bond_graph is not None
+            ):
                 # If anything is added at self level, it is no longer a particle
                 # search for self in self.root.bond_graph and remove self
                 if self.root.bond_graph.has_node(self):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -803,8 +803,6 @@ class Compound(object):
                 else:
                     yield c
 
-
-
     def add(
         self,
         new_child,

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -870,13 +870,8 @@ class Compound(object):
             # compose children bond_graphs; make sure we actually have graphs to compose
             if len(temp_bond_graphs) != 0:
                 children_bond_graph = nx.compose_all(temp_bond_graphs)
-<<<<<<< HEAD
             
             if len(temp_bond_graphs) != 0 and not isinstance(self, Port) and children_bond_graph is not None:
-=======
-
-            if len(temp_bond_graphs) != 0 and not isinstance(self, Port):
->>>>>>> 3dfbfa514b377e5350be7b0e203f479dacc1ef74
                 # If anything is added at self level, it is no longer a particle
                 # search for self in self.root.bond_graph and remove self
                 if self.root.bond_graph.has_node(self):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -13,6 +13,7 @@ from warnings import warn
 import ele
 import networkx as nx
 import numpy as np
+from boltons.setutils import IndexedSet
 from ele.element import Element, element_from_name, element_from_symbol
 from ele.exceptions import ElementError
 from treelib import Tree
@@ -28,8 +29,6 @@ from mbuild.utils.exceptions import RemovedFuncError
 from mbuild.utils.io import import_, run_from_ipython
 from mbuild.utils.jsutils import overwrite_nglview_default
 from mbuild.utils.orderedset import OrderedSet
-from boltons.setutils import IndexedSet
-
 
 
 def clone(existing_compound, clone_of=None, root_container=None):
@@ -2002,7 +2001,6 @@ class Compound(object):
                     ancestors = ancestors.intersection(
                         IndexedSet(particle.ancestors())
                     )
-
 
             """Parse molecule information"""
             molecule_tag = ancestors[0]

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -791,23 +791,19 @@ class Compound(object):
                 if self.rigid_id > missing_rigid_id:
                     self.rigid_id -= 1
 
-    # helper function to flattening a list that may be nested, in particular used for a list of labels
     def _flatten_list(self, c_list):
-        if isinstance(c_list, list):
+        """Flatten a list
+
+        Helper function to flatten a list that may be nested, e.g. [comp1, [comp2, comp3]].
+        """
+        if isinstance(c_list, Iterable) and not isinstance(c_list, str):
             for c in c_list:
-                if isinstance(c, list):
+                if isinstance(c, Iterable) and not isinstance(c, str):
                     yield from self._flatten_list(c)
                 else:
                     yield c
 
-    # helper function to flatten a list of Compounds that may be nested
-    def _flatten_compound_list(self, c_list):
-        if isinstance(c_list, Iterable):
-            for c in c_list:
-                if isinstance(c, Iterable):
-                    yield from self._flatten_list(c)
-                else:
-                    yield c
+
 
     def add(
         self,
@@ -853,7 +849,7 @@ class Compound(object):
         from mbuild.port import Port
 
         if isinstance(new_child, Iterable) and not isinstance(new_child, str):
-            compound_list = [c for c in self._flatten_compound_list(new_child)]
+            compound_list = [c for c in self._flatten_list(new_child)]
             if label is not None and isinstance(label, list):
                 label_list = [c for c in self._flatten_list(label)]
                 if len(label_list) != len(compound_list):

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -511,7 +511,8 @@ class Compound(object):
         if self._contains_only_ports():
             return self._particle_mass(self)
         else:
-            particle_masses = [self._particle_mass(p) for p in self.particles()]
+            particle_masses = [self._particle_mass(
+                p) for p in self.particles()]
             if None in particle_masses:
                 warn(
                     f"Some particle of {self} does not have mass."
@@ -791,18 +792,6 @@ class Compound(object):
                 if self.rigid_id > missing_rigid_id:
                     self.rigid_id -= 1
 
-    def _flatten_list(self, c_list):
-        """Flatten a list
-
-        Helper function to flatten a list that may be nested, e.g. [comp1, [comp2, comp3]].
-        """
-        if isinstance(c_list, Iterable) and not isinstance(c_list, str):
-            for c in c_list:
-                if isinstance(c, Iterable) and not isinstance(c, str):
-                    yield from self._flatten_list(c)
-                else:
-                    yield c
-
     def add(
         self,
         new_child,
@@ -847,29 +836,29 @@ class Compound(object):
         from mbuild.port import Port
 
         if isinstance(new_child, Iterable) and not isinstance(new_child, str):
-            compound_list = [c for c in self._flatten_list(new_child)]
-            if label is not None and isinstance(label, list):
-                label_list = [c for c in self._flatten_list(label)]
+            compound_list = [c for c in _flatten_list(new_child)]
+            if label is not None and isinstance(label, (list, tuple)):
+                label_list = [c for c in _flatten_list(label)]
                 if len(label_list) != len(compound_list):
                     raise ValueError(
                         "The list-like object for label must be the same length as"
                         "the list-like object of child Compounds. "
-                        f"label total length {len(label_list)}, new_child '{len(new_child)}'."
+                        f"total length of labels: {len(label_list)}, new_child: {len(new_child)}."
                     )
             temp_bond_graphs = []
             for child in compound_list:
                 # create a list of bond graphs of the children to add
                 if containment:
-                    if child.bond_graph is not None and not isinstance(
-                        self, Port
-                    ):
+                    if child.bond_graph and not isinstance(self, Port):
                         temp_bond_graphs.append(child.bond_graph)
+
             # compose children bond_graphs; make sure we actually have graphs to compose
+            children_bond_graph = None
             if len(temp_bond_graphs) != 0:
                 children_bond_graph = nx.compose_all(temp_bond_graphs)
 
             if (
-                len(temp_bond_graphs) != 0
+                temp_bond_graphs
                 and not isinstance(self, Port)
                 and children_bond_graph is not None
             ):
@@ -1917,7 +1906,7 @@ class Compound(object):
         mdtraj = import_("mdtraj")
         from mdtraj.geometry.sasa import _ATOMIC_RADII
 
-        remove_digits = lambda x: "".join(
+        def remove_digits(x): return "".join(
             i for i in x if not i.isdigit() or i == "_"
         )
         for particle in self.particles():
@@ -2003,9 +1992,9 @@ class Compound(object):
             for child in [self.children]:
                 # Need to handle the case when child is a port
                 self.remove(child)
-                self.add(comp_list)
+            self.add(comp_list)
         else:
-            new_compound = Compound()
+            new_compound = Compound(name=self.name)
             new_compound.add(comp_list)
             return new_compound
 
@@ -2518,7 +2507,8 @@ class Compound(object):
             if not isinstance(part, Compound):
                 raise MBuildError(f"{part} is not a Compound.")
             if id(part) != id(self) and id(part) not in successors_list:
-                raise MBuildError(f"{part} is not a member of Compound {self}.")
+                raise MBuildError(
+                    f"{part} is not a member of Compound {self}.")
 
             if check_if_particle:
                 if len(part.children) != 0:
@@ -2664,8 +2654,10 @@ class Compound(object):
                         f"Cannot create a constraint between a Particle and itself: {p1} {p2} ."
                     )
 
-                pid_1 = particle_idx[id(p1)] + 1  # openbabel indices start at 1
-                pid_2 = particle_idx[id(p2)] + 1  # openbabel indices start at 1
+                # openbabel indices start at 1
+                pid_1 = particle_idx[id(p1)] + 1
+                # openbabel indices start at 1
+                pid_2 = particle_idx[id(p2)] + 1
                 dist = (
                     con_temp[1] * 10.0
                 )  # obenbabel uses angstroms, not nm, convert to angstroms
@@ -2763,7 +2755,8 @@ class Compound(object):
 
             # Since the ignore_compounds can only be passed as a list
             # we can check the whole list at once before looping over it
-            self._check_openbabel_constraints(ignore_compounds, successors_list)
+            self._check_openbabel_constraints(
+                ignore_compounds, successors_list)
 
             for ignore in ignore_compounds:
                 p1 = ignore
@@ -3413,7 +3406,8 @@ class Compound(object):
             return list(self.particles())[selection]
         if isinstance(selection, str):
             if selection not in self.labels:
-                raise MBuildError(f"{self.name}['{selection}'] does not exist.")
+                raise MBuildError(
+                    f"{self.name}['{selection}'] does not exist.")
             return self.labels.get(selection)
 
     def __repr__(self):
@@ -3531,3 +3525,16 @@ class Compound(object):
 
 
 Particle = Compound
+
+
+def _flatten_list(c_list):
+    """Flatten a list
+
+    Helper function to flatten a list that may be nested, e.g. [comp1, [comp2, comp3]].
+    """
+    if isinstance(c_list, Iterable) and not isinstance(c_list, str):
+        for c in c_list:
+            if isinstance(c, Iterable) and not isinstance(c, str):
+                yield from _flatten_list(c)
+            else:
+                yield c

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -511,8 +511,7 @@ class Compound(object):
         if self._contains_only_ports():
             return self._particle_mass(self)
         else:
-            particle_masses = [self._particle_mass(
-                p) for p in self.particles()]
+            particle_masses = [self._particle_mass(p) for p in self.particles()]
             if None in particle_masses:
                 warn(
                     f"Some particle of {self} does not have mass."
@@ -1906,9 +1905,9 @@ class Compound(object):
         mdtraj = import_("mdtraj")
         from mdtraj.geometry.sasa import _ATOMIC_RADII
 
-        def remove_digits(x): return "".join(
-            i for i in x if not i.isdigit() or i == "_"
-        )
+        def remove_digits(x):
+            return "".join(i for i in x if not i.isdigit() or i == "_")
+
         for particle in self.particles():
             particle.name = remove_digits(particle.name).upper()
             if not particle.name:
@@ -2507,8 +2506,7 @@ class Compound(object):
             if not isinstance(part, Compound):
                 raise MBuildError(f"{part} is not a Compound.")
             if id(part) != id(self) and id(part) not in successors_list:
-                raise MBuildError(
-                    f"{part} is not a member of Compound {self}.")
+                raise MBuildError(f"{part} is not a member of Compound {self}.")
 
             if check_if_particle:
                 if len(part.children) != 0:
@@ -2755,8 +2753,7 @@ class Compound(object):
 
             # Since the ignore_compounds can only be passed as a list
             # we can check the whole list at once before looping over it
-            self._check_openbabel_constraints(
-                ignore_compounds, successors_list)
+            self._check_openbabel_constraints(ignore_compounds, successors_list)
 
             for ignore in ignore_compounds:
                 p1 = ignore
@@ -3406,8 +3403,7 @@ class Compound(object):
             return list(self.particles())[selection]
         if isinstance(selection, str):
             if selection not in self.labels:
-                raise MBuildError(
-                    f"{self.name}['{selection}'] does not exist.")
+                raise MBuildError(f"{self.name}['{selection}'] does not exist.")
             return self.labels.get(selection)
 
     def __repr__(self):

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -558,7 +558,6 @@ def from_parmed(
     for chain, residues in chains.items():
         if len(chain) > 1:
             chain_compound = mb.Compound()
-            # compound.add(chain_compound, chain_id)
             chain_list.append(chain_compound)
         else:
             chain_compound = compound
@@ -566,7 +565,6 @@ def from_parmed(
         for residue in residues:
             if infer_hierarchy:
                 residue_compound = mb.Compound(name=residue.name)
-                # chain_compound.add(residue_compound)
                 parent_compound = residue_compound
                 res_list.append(residue_compound)
             else:
@@ -585,7 +583,6 @@ def from_parmed(
                 )
                 atom_list.append(new_atom)
                 atom_label_list.append("{0}[$]".format(atom.name))
-                # parent_compound.add(new_atom, label="{0}[$]".format(atom.name))
                 atom_mapping[atom] = new_atom
             parent_compound.add(atom_list, label=atom_label_list)
         if infer_hierarchy:

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -558,7 +558,7 @@ def from_parmed(
     for chain, residues in chains.items():
         if len(chain) > 1:
             chain_compound = mb.Compound()
-            #compound.add(chain_compound, chain_id)
+            # compound.add(chain_compound, chain_id)
             chain_list.append(chain_compound)
         else:
             chain_compound = compound
@@ -566,7 +566,7 @@ def from_parmed(
         for residue in residues:
             if infer_hierarchy:
                 residue_compound = mb.Compound(name=residue.name)
-                #chain_compound.add(residue_compound)
+                # chain_compound.add(residue_compound)
                 parent_compound = residue_compound
                 res_list.append(residue_compound)
             else:
@@ -585,14 +585,14 @@ def from_parmed(
                 )
                 atom_list.append(new_atom)
                 atom_label_list.append("{0}[$]".format(atom.name))
-                #parent_compound.add(new_atom, label="{0}[$]".format(atom.name))
+                # parent_compound.add(new_atom, label="{0}[$]".format(atom.name))
                 atom_mapping[atom] = new_atom
             parent_compound.add(atom_list, label=atom_label_list)
         if infer_hierarchy:
             chain_compound.add(res_list)
     if len(chain) > 1:
         compound.add(chain_list)
-        
+
     # Infer bonds information
     for bond in structure.bonds:
         atom1 = atom_mapping[bond.atom1]
@@ -885,7 +885,7 @@ def from_rdkit(rdkit_mol, compound=None, coords_only=False, smiles_seed=0):
             pos=xyz[i],
         )
         part_list.append(part)
-    
+
     comp.add(part_list)
 
     for bond in mymol.GetBonds():

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -653,7 +653,7 @@ def from_trajectory(
     # temporary lists to speed up add to the compound
     chains_list = []
     chains_list_label = []
-    
+
     for chain in traj.topology.chains:
         if traj.topology.n_chains > 1:
             chain_compound = mb.Compound()
@@ -661,7 +661,7 @@ def from_trajectory(
             chains_list_label.append("chain[$]")
         else:
             chain_compound = compound
-        
+
         res_list = []
         for res in chain.residues:
             if infer_hierarchy:
@@ -670,7 +670,7 @@ def from_trajectory(
                 res_list.append(res_compound)
             else:
                 parent_cmpd = chain_compound
-                
+
             atom_list = []
             atom_label_list = []
             for atom in res.atoms:
@@ -688,14 +688,14 @@ def from_trajectory(
                 atom_list.append(new_atom)
                 atom_label_list.append("{0}[$]".format(atom.name))
                 atom_mapping[atom] = new_atom
-            
+
             parent_cmpd.add(atom_list, label=atom_label_list)
-        
+
         if infer_hierarchy:
-             chain_compound.add(res_list)
+            chain_compound.add(res_list)
     if traj.topology.n_chains > 1:
         compound.add(chains_list, label=chains_list_label)
-        
+
     for mdtraj_atom1, mdtraj_atom2 in traj.topology.bonds:
         atom1 = atom_mapping[mdtraj_atom1]
         atom2 = atom_mapping[mdtraj_atom2]

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -650,19 +650,29 @@ def from_trajectory(
         compound = mb.Compound()
 
     atom_mapping = dict()
+    # temporary lists to speed up add to the compound
+    chains_list = []
+    chains_list_label = []
+    
     for chain in traj.topology.chains:
         if traj.topology.n_chains > 1:
             chain_compound = mb.Compound()
-            compound.add(chain_compound, "chain[$]")
+            chains_list.append(chain_compound)
+            chains_list_label.append("chain[$]")
         else:
             chain_compound = compound
+        
+        res_list = []
         for res in chain.residues:
             if infer_hierarchy:
                 res_compound = mb.Compound(name=res.name)
-                chain_compound.add(res_compound)
                 parent_cmpd = res_compound
+                res_list.append(res_compound)
             else:
                 parent_cmpd = chain_compound
+                
+            atom_list = []
+            atom_label_list = []
             for atom in res.atoms:
                 try:
                     element = element_from_atomic_number(
@@ -675,9 +685,17 @@ def from_trajectory(
                     pos=traj.xyz[frame, atom.index],
                     element=element,
                 )
-                parent_cmpd.add(new_atom, label="{0}[$]".format(atom.name))
+                atom_list.append(new_atom)
+                atom_label_list.append("{0}[$]".format(atom.name))
                 atom_mapping[atom] = new_atom
-
+            
+            parent_cmpd.add(atom_list, label=atom_label_list)
+        
+        if infer_hierarchy:
+             chain_compound.add(res_list)
+    if traj.topology.n_chains > 1:
+        compound.add(chains_list, label=chains_list_label)
+        
     for mdtraj_atom1, mdtraj_atom2 in traj.topology.bonds:
         atom1 = atom_mapping[mdtraj_atom1]
         atom2 = atom_mapping[mdtraj_atom2]

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -633,10 +633,7 @@ class TestCompound(BaseTest):
         three.name = "three"
         four = mb.clone(h2o)
         four.name = "four"
-        out = [
-            a.name
-            for a in h2o._flatten_list([one, two, [three, four]])
-        ]
+        out = [a.name for a in h2o._flatten_list([one, two, [three, four]])]
 
         assert out == ["one", "two", "three", "four"]
 

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -622,7 +622,9 @@ class TestCompound(BaseTest):
             ethane.add(mb.clone(h2o), label="water")
 
     def test_list_flatten(self, h2o):
-        out = [a for a in h2o._flatten_list(["one", "two", ["three", "four"]])]
+        from mbuild.compound import _flatten_list
+
+        out = [a for a in _flatten_list(["one", "two", ["three", "four"]])]
         assert out == ["one", "two", "three", "four"]
 
         one = mb.clone(h2o)
@@ -633,7 +635,7 @@ class TestCompound(BaseTest):
         three.name = "three"
         four = mb.clone(h2o)
         four.name = "four"
-        out = [a.name for a in h2o._flatten_list([one, two, [three, four]])]
+        out = [a.name for a in _flatten_list([one, two, [three, four]])]
 
         assert out == ["one", "two", "three", "four"]
 

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -622,21 +622,24 @@ class TestCompound(BaseTest):
             ethane.add(mb.clone(h2o), label="water")
 
     def test_list_flatten(self, h2o):
-        out = [a for a in h2o._flatten_list(['one', 'two',  ['three', 'four']])]
-        assert out == ['one', 'two', 'three', 'four']
-        
+        out = [a for a in h2o._flatten_list(["one", "two", ["three", "four"]])]
+        assert out == ["one", "two", "three", "four"]
+
         one = mb.clone(h2o)
-        one.name = 'one'
+        one.name = "one"
         two = mb.clone(h2o)
-        two.name = 'two'
+        two.name = "two"
         three = mb.clone(h2o)
-        three.name = 'three'
+        three.name = "three"
         four = mb.clone(h2o)
-        four.name = 'four'
-        out = [a.name for a in h2o._flatten_compound_list([one, two, [three, four]] )]
-        
-        assert out == ['one', 'two', 'three', 'four']
-    
+        four.name = "four"
+        out = [
+            a.name
+            for a in h2o._flatten_compound_list([one, two, [three, four]])
+        ]
+
+        assert out == ["one", "two", "three", "four"]
+
     def test_add_by_list(self, h2o):
         temp_comp = mb.Compound()
         comp_list = []

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -625,23 +625,29 @@ class TestCompound(BaseTest):
         temp_comp = mb.Compound()
         comp_list = []
         label_list = []
-        for j in range(0,5):
+        for j in range(0, 5):
             comp_list.append(mb.clone(h2o))
             label_list.append("water[$]")
         temp_comp.add(comp_list, label=label_list)
-        a = [k for k,v in temp_comp.labels.items()]
-        assert a == ['water', 'water[0]', 'water[1]', 'water[2]', 'water[3]', 'water[4]']
+        a = [k for k, v in temp_comp.labels.items()]
+        assert a == [
+            "water",
+            "water[0]",
+            "water[1]",
+            "water[2]",
+            "water[3]",
+            "water[4]",
+        ]
 
         temp_comp = mb.Compound()
         comp_list = []
-        label_list = ['water']
-        for j in range(0,5):
+        label_list = ["water"]
+        for j in range(0, 5):
             comp_list.append(mb.clone(h2o))
-            
+
         with pytest.raises(ValueError):
             temp_comp.add(comp_list, label=label_list)
-        
-            
+
     def test_set_pos(self, ethane):
         with pytest.raises(MBuildError):
             ethane.pos = [0, 0, 0]

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -621,6 +621,27 @@ class TestCompound(BaseTest):
         with pytest.raises(MBuildError):
             ethane.add(mb.clone(h2o), label="water")
 
+    def test_add_by_list(self, h2o):
+        temp_comp = mb.Compound()
+        comp_list = []
+        label_list = []
+        for j in range(0,5):
+            comp_list.append(mb.clone(h2o))
+            label_list.append("water[$]")
+        temp_comp.add(comp_list, label=label_list)
+        a = [k for k,v in temp_comp.labels.items()]
+        assert a == ['water', 'water[0]', 'water[1]', 'water[2]', 'water[3]', 'water[4]']
+
+        temp_comp = mb.Compound()
+        comp_list = []
+        label_list = ['water']
+        for j in range(0,5):
+            comp_list.append(mb.clone(h2o))
+            
+        with pytest.raises(ValueError):
+            temp_comp.add(comp_list, label=label_list)
+        
+            
     def test_set_pos(self, ethane):
         with pytest.raises(MBuildError):
             ethane.pos = [0, 0, 0]

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -621,6 +621,22 @@ class TestCompound(BaseTest):
         with pytest.raises(MBuildError):
             ethane.add(mb.clone(h2o), label="water")
 
+    def test_list_flatten(self, h2o):
+        out = [a for a in h2o._flatten_list(['one', 'two',  ['three', 'four']])]
+        assert out == ['one', 'two', 'three', 'four']
+        
+        one = mb.clone(h2o)
+        one.name = 'one'
+        two = mb.clone(h2o)
+        two.name = 'two'
+        three = mb.clone(h2o)
+        three.name = 'three'
+        four = mb.clone(h2o)
+        four.name = 'four'
+        out = [a.name for a in h2o._flatten_compound_list([one, two, [three, four]] )]
+        
+        assert out == ['one', 'two', 'three', 'four']
+    
     def test_add_by_list(self, h2o):
         temp_comp = mb.Compound()
         comp_list = []

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -635,7 +635,7 @@ class TestCompound(BaseTest):
         four.name = "four"
         out = [
             a.name
-            for a in h2o._flatten_compound_list([one, two, [three, four]])
+            for a in h2o._flatten_list([one, two, [three, four]])
         ]
 
         assert out == ["one", "two", "three", "four"]

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -945,10 +945,13 @@ class TestCompound(BaseTest):
         assert len(condensed.children) == 2
         assert condensed.n_bonds == 14
         assert condensed.n_particles == 16
-        
+
         assert condensed_hierarchy.depth() == 3
-        assert condensed_hierarchy.to_json(with_data=False) == '{"Compound, 16 particles, 14 bonds, 2 children": {"children": [{"[Ethane x 2], 8 particles, 7 bonds, 2 children": {"children": [{"[CH3 x 2], 4 particles, 3 bonds, 4 children": {"children": ["[C x 1], 1 particles, 4 bonds, 0 children", "[H x 3], 1 particles, 1 bonds, 0 children"]}}]}}]}}'
-        
+        assert (
+            condensed_hierarchy.to_json(with_data=False)
+            == '{"Compound, 16 particles, 14 bonds, 2 children": {"children": [{"[Ethane x 2], 8 particles, 7 bonds, 2 children": {"children": [{"[CH3 x 2], 4 particles, 3 bonds, 4 children": {"children": ["[C x 1], 1 particles, 4 bonds, 0 children", "[H x 3], 1 particles, 1 bonds, 0 children"]}}]}}]}}'
+        )
+
         # Condense the Compound in place
         system_copy = mb.clone(system)
         system_copy.condense(inplace=True)
@@ -958,11 +961,14 @@ class TestCompound(BaseTest):
         assert system_copy.n_bonds == 14
         assert system_copy.n_particles == 16
         assert condensed_hierarchy2.depth() == 3
-        assert condensed_hierarchy2.to_json(with_data=False) == '{"Compound, 16 particles, 14 bonds, 2 children": {"children": [{"[Ethane x 2], 8 particles, 7 bonds, 2 children": {"children": [{"[CH3 x 2], 4 particles, 3 bonds, 4 children": {"children": ["[C x 1], 1 particles, 4 bonds, 0 children", "[H x 3], 1 particles, 1 bonds, 0 children"]}}]}}]}}'
-        
+        assert (
+            condensed_hierarchy2.to_json(with_data=False)
+            == '{"Compound, 16 particles, 14 bonds, 2 children": {"children": [{"[Ethane x 2], 8 particles, 7 bonds, 2 children": {"children": [{"[CH3 x 2], 4 particles, 3 bonds, 4 children": {"children": ["[C x 1], 1 particles, 4 bonds, 0 children", "[H x 3], 1 particles, 1 bonds, 0 children"]}}]}}]}}'
+        )
+
         # add two particles that aren't bonded
-        system.add(mb.Compound(name='C'))
-        system.add(mb.Compound(name='C'))
+        system.add(mb.Compound(name="C"))
+        system.add(mb.Compound(name="C"))
         system_hierarchy = system.print_hierarchy(show_tree=False)
 
         assert len(system.children) == 3
@@ -970,7 +976,7 @@ class TestCompound(BaseTest):
         assert system.n_bonds == 14
         assert system.n_particles == 18
         assert system_hierarchy.depth() == 4
-        
+
         # condense the system
         condensed = system.condense(inplace=False)
         condensed_hierarchy = condensed.print_hierarchy(show_tree=False)
@@ -980,7 +986,10 @@ class TestCompound(BaseTest):
         assert condensed.n_particles == 18
 
         assert condensed_hierarchy.depth() == 3
-        assert condensed_hierarchy.to_json(with_data=False) == '{"Compound, 18 particles, 14 bonds, 4 children": {"children": ["[C x 2], 1 particles, 0 bonds, 0 children", {"[Ethane x 2], 8 particles, 7 bonds, 2 children": {"children": [{"[CH3 x 2], 4 particles, 3 bonds, 4 children": {"children": ["[C x 1], 1 particles, 4 bonds, 0 children", "[H x 3], 1 particles, 1 bonds, 0 children"]}}]}}]}}'
+        assert (
+            condensed_hierarchy.to_json(with_data=False)
+            == '{"Compound, 18 particles, 14 bonds, 4 children": {"children": ["[C x 2], 1 particles, 0 bonds, 0 children", {"[Ethane x 2], 8 particles, 7 bonds, 2 children": {"children": [{"[CH3 x 2], 4 particles, 3 bonds, 4 children": {"children": ["[C x 1], 1 particles, 4 bonds, 0 children", "[H x 3], 1 particles, 1 bonds, 0 children"]}}]}}]}}'
+        )
 
     def test_flatten_eth(self, ethane):
         # Before flattening


### PR DESCRIPTION
### PR Summary:
This refers to issue #1104 . This PR aims to improve the performance of the Compound.add function and loading routines that rely upon it. 

The basic gist, as outlined in the issue above, is that when constructing a compound using the add function, the performance can degrade as the compound grows in size, due to the repeated merging  (i.e., composing) of bond_graphs,  specifically, merging a small with a large bond graph over and over again.  This PR changes the underlying logic such that if a list of Compounds is passed to the add function, it will use the compose_all function to merge these bond_graphs together, before adding to the root Compound (and merging bond_graphs with the root compound).   The compose_all function effectively scales with the number of compounds being merged.  

This provides substantial speed improvements, as outlined in the issue. 

Other additions, Compound.add now accepts a list for the label argument if compounds are provided in a list. 

This is still a WIP, as tests need to be added for adding labels via a list, as well as adding in the updated load functions to stash compounds into lists (mdtraj conversion is basically complete and provides substantial speed up). 
  
### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
