### PR TITLE
Use list to store compound.children

### DIFF
--- a/mbuild/coarse_graining.py
+++ b/mbuild/coarse_graining.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 
 from mbuild.compound import Compound, clone
 from mbuild.exceptions import MBuildError
-from mbuild.utils.orderedset import OrderedSet
 
 __all__ = ["coarse_grain"]
 
@@ -95,7 +94,7 @@ class Proxy(Compound):
         if self.children is None:
             newone.children = None
         else:
-            newone.children = OrderedSet()
+            newone.children = list()
         # Parent should be None initially.
         newone.parent = None
         newone.labels = OrderedDict()
@@ -106,7 +105,7 @@ class Proxy(Compound):
         if self.children:
             for child in self.children:
                 newchild = child._clone(clone_of, root_container)
-                newone.children.add(newchild)
+                newone.children.append(newchild)
                 newchild.parent = newone
 
         # Copy labels, except bonds with atoms outside the hierarchy.

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -28,7 +28,6 @@ from mbuild.utils.decorators import experimental_feature
 from mbuild.utils.exceptions import RemovedFuncError
 from mbuild.utils.io import import_, run_from_ipython
 from mbuild.utils.jsutils import overwrite_nglview_default
-from mbuild.utils.orderedset import OrderedSet
 
 
 def clone(existing_compound, clone_of=None, root_container=None):
@@ -117,7 +116,7 @@ class Compound(object):
     ----------
     bond_graph : mb.BondGraph
         Graph-like object that stores bond information for this Compound
-    children : OrderedSet
+    children : list
         Contains all children (other Compounds).
     labels : OrderedDict
         Labels to Compound/Atom mappings. These do not necessarily need not be
@@ -174,7 +173,7 @@ class Compound(object):
             self._pos = np.zeros(3)
 
         self.parent = None
-        self.children = OrderedSet()
+        self.children = list()
         self.labels = OrderedDict()
         self.referrers = set()
 
@@ -920,7 +919,7 @@ class Compound(object):
 
         # Create children and labels on the first add operation
         if self.children is None:
-            self.children = OrderedSet()
+            self.children = list()
         if self.labels is None:
             self.labels = OrderedDict()
 
@@ -931,7 +930,7 @@ class Compound(object):
                         new_child, new_child.parent
                     )
                 )
-            self.children.add(new_child)
+            self.children.append(new_child)
             new_child.parent = self
 
             if new_child.bond_graph is not None and not isinstance(self, Port):
@@ -3500,7 +3499,7 @@ class Compound(object):
         if self.children is None:
             newone.children = None
         else:
-            newone.children = OrderedSet()
+            newone.children = list()
         # Parent should be None initially.
         newone.parent = None
         newone.labels = OrderedDict()
@@ -3511,7 +3510,7 @@ class Compound(object):
         if self.children:
             for child in self.children:
                 newchild = child._clone(clone_of, root_container)
-                newone.children.add(newchild)
+                newone.children.append(newchild)
                 newchild.parent = newone
 
         # Copy labels, except bonds with atoms outside the hierarchy.


### PR DESCRIPTION
### PR Summary:
After the discussion with @chrisiacovella, we have decided it would be faster to store `Compound.children` with `list` instead of the in house `OrderedSet`. The replacement will speed up both the `Compound.add` step by removing the comparing stage when adding new children to a set, and the indexing (getting element from a list/set by index). We realized the latter was the cause for https://github.com/mosdef-hub/mbuild/issues/1114, not directly the `Compound.add_bond` itself, but how the `particle` is retrieved from `Compound.children` to perform the addition. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
