### PR TITLE
fixed freud bond issue

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1376,9 +1376,9 @@ class Compound(object):
         # they represent different actually particles.  Thus, toget the right behavior we
         # must not exclude particles with the same index, and thus exclude_ii = False.
         if name_a == name_b:
-            exclude_ii=True
+            exclude_ii = True
         else:
-            exclude_ii=False
+            exclude_ii = False
         aq = freud.locality.AABBQuery(freud_box, moved_positions[b_indices])
 
         nlist = aq.query(

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1373,7 +1373,7 @@ class Compound(object):
         # However, the way the code is structured, we don't actually pass
         # freud the indices, but rather a list of particle positions associated with each set of indices.
         # As such, the indices that freud sees will be (0, len(a_indices)) and (0, len(b_indices)), even though
-        # they represent different actually particles.  Thus, toget the right behavior we
+        # they represent different actually particles. Thus, to get the right behavior we
         # must not exclude particles with the same index, and thus exclude_ii = False.
         if name_a == name_b:
             exclude_ii = True

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -721,7 +721,7 @@ class TestCompound(BaseTest):
         ch3_clone.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3_clone.periodicity = (True, True, True)
         ch3_clone.freud_generate_bonds(
-            "H", "H", dmin=0.01, dmax=0.2, exclude_ii=True
+            "H", "H", dmin=0.01, dmax=0.2
         )
         assert ch3_clone.n_bonds == 3 + 3
 
@@ -729,7 +729,7 @@ class TestCompound(BaseTest):
         ch3_clone2.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3_clone2.periodicity = (True, True, False)
         ch3_clone2.freud_generate_bonds(
-            "H", "H", dmin=0.01, dmax=0.2, exclude_ii=True
+            "H", "H", dmin=0.01, dmax=0.2
         )
         assert ch3_clone2.n_bonds == 3 + 3
 
@@ -737,15 +737,34 @@ class TestCompound(BaseTest):
     def test_freud_generate_bonds(self, ch3):
         bounding_box = ch3.get_boundingbox()
         ch3.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
-        ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.2, exclude_ii=True)
+        ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.2)
         assert ch3.n_bonds == 3 + 3
 
     @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
     def test_freud_generate_bonds_expected(self, ch3):
         bounding_box = ch3.get_boundingbox()
         ch3.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
-        ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.1, exclude_ii=True)
+        ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.1)
         assert ch3.n_bonds == 3
+        
+    @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
+    def test_freud_generate_bonds_mixed(self):
+        carbon_atom = mb.Compound(name='C', element='C')
+
+        grid_pattern = mb.Grid3DPattern(2, 2, 2)
+
+        grid_pattern.scale([0.25, 0.25, 0.25])
+        carbon_list = grid_pattern.apply(carbon_atom)
+        co_system = mb.Compound(carbon_list)
+        co_system.box = mb.Box([1,1,1])
+        for i, child in enumerate(co_system.children):
+            if i%2 == 0:
+                child.name='O'
+                child.element='O'
+
+        co_system.freud_generate_bonds(name_a= "C", name_b="O",
+                                           dmin=0.0, dmax=0.16)
+        assert co_system.n_bonds == 4
 
     def test_remove_from_box(self, ethane):
         n_ethanes = 5

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -720,17 +720,13 @@ class TestCompound(BaseTest):
         ch3_clone = mb.clone(ch3)
         ch3_clone.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3_clone.periodicity = (True, True, True)
-        ch3_clone.freud_generate_bonds(
-            "H", "H", dmin=0.01, dmax=0.2
-        )
+        ch3_clone.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.2)
         assert ch3_clone.n_bonds == 3 + 3
 
         ch3_clone2 = mb.clone(ch3)
         ch3_clone2.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3_clone2.periodicity = (True, True, False)
-        ch3_clone2.freud_generate_bonds(
-            "H", "H", dmin=0.01, dmax=0.2
-        )
+        ch3_clone2.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.2)
         assert ch3_clone2.n_bonds == 3 + 3
 
     @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
@@ -746,24 +742,25 @@ class TestCompound(BaseTest):
         ch3.box = mb.Box(lengths=[max(bounding_box.lengths) + 1] * 3)
         ch3.freud_generate_bonds("H", "H", dmin=0.01, dmax=0.1)
         assert ch3.n_bonds == 3
-        
+
     @pytest.mark.skipif(not has_freud, reason="Freud not installed.")
     def test_freud_generate_bonds_mixed(self):
-        carbon_atom = mb.Compound(name='C', element='C')
+        carbon_atom = mb.Compound(name="C", element="C")
 
         grid_pattern = mb.Grid3DPattern(2, 2, 2)
 
         grid_pattern.scale([0.25, 0.25, 0.25])
         carbon_list = grid_pattern.apply(carbon_atom)
         co_system = mb.Compound(carbon_list)
-        co_system.box = mb.Box([1,1,1])
+        co_system.box = mb.Box([1, 1, 1])
         for i, child in enumerate(co_system.children):
-            if i%2 == 0:
-                child.name='O'
-                child.element='O'
+            if i % 2 == 0:
+                child.name = "O"
+                child.element = "O"
 
-        co_system.freud_generate_bonds(name_a= "C", name_b="O",
-                                           dmin=0.0, dmax=0.16)
+        co_system.freud_generate_bonds(
+            name_a="C", name_b="O", dmin=0.0, dmax=0.16
+        )
         assert co_system.n_bonds == 4
 
     def test_remove_from_box(self, ethane):


### PR DESCRIPTION
### PR Summary:
This addresses issue #1125 whereby the freud_generate_bonds routine was not finding all bonds when looking for bonds between two different species 

As detailed in the issue, this was caused by the way in which we pass the  particles to freud during the calculation of neighbors. Ultimately, the fix for this is relatively straight forward to implement.  If name_a == name_b, then  exclude_ii = True; If name_a != name_b, then exclude_ii = False.  This is now automatically toggled by the code, and users no longer have the option to change this. 
 
An additional test is included now that looks at a system where the two specifies are unique, as the original tests did not include this. 
### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
