### PR TITLE
Support GSD >= 2.9

### DIFF
--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -14,7 +14,7 @@ dependencies:
   - mdtraj
   - networkx
   - nglview>=2.7
-  - numpy
+  - numpy=1.24.2
   - openbabel>=3.0.0
   - packmol=1!18.013
   - parmed>=3.4.3

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -9,7 +9,7 @@ dependencies:
   - gmso>=0.9.0
   - foyer>=0.11.0
   - garnett>=0.7.1
-  - gsd>=1.2
+  - gsd>=2.9
   - intermol
   - mdtraj
   - networkx

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - foyer>=0.11.0
   - freud>=2.0.0
   - garnett>=0.7.1
-  - gsd>=2
+  - gsd>=2.9
   - hoomd>=3
   - intermol
   - mdtraj

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - mdtraj
   - networkx
   - nglview>=3
-  - numpy
+  - numpy=1.24.2
   - openbabel>=3
   - packmol>=20
   - parmed>=3.4.3

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ele
-  - numpy
+  - numpy=1.24.2
   - packmol>=18
   - gmso>=0.9.0
   - parmed>=3.4.3

--- a/mbuild/formats/gsdwriter.py
+++ b/mbuild/formats/gsdwriter.py
@@ -60,7 +60,7 @@ def write_gsd(
     if shift_coords:
         xyz = coord_shift(xyz, structure.box[:3])
 
-    gsd_snapshot = gsd.hoomd.Snapshot()
+    gsd_snapshot = gsd.hoomd.Frame()
 
     gsd_snapshot.configuration.step = 0
     gsd_snapshot.configuration.dimensions = 3
@@ -101,7 +101,7 @@ def write_gsd(
     if structure.rb_torsions:
         _write_dihedral_information(gsd_snapshot, structure)
 
-    with gsd.hoomd.open(filename, mode="wb") as gsd_file:
+    with gsd.hoomd.open(filename, mode="w") as gsd_file:
         gsd_file.append(gsd_snapshot)
 
 

--- a/mbuild/formats/hoomd_snapshot.py
+++ b/mbuild/formats/hoomd_snapshot.py
@@ -27,11 +27,11 @@ def _get_hoomd_version():
 def from_snapshot(snapshot, scale=1.0):
     """Convert a Snapshot to a Compound.
 
-    Snapshot can be a hoomd.Snapshot or a gsd.hoomd.Snapshot.
+    Snapshot can be a hoomd.Snapshot or a gsd.hoomd.Frame.
 
     Parameters
     ----------
-    snapshot : hoomd.Snapshot or gsd.hoomd.Snapshot
+    snapshot : hoomd.Snapshot or gsd.hoomd.Frame
         Snapshot from which to build the mbuild Compound.
     scale : float, optional, default 1.0
         Value by which to scale the length values

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -2360,15 +2360,6 @@ class TestCompound(BaseTest):
             np.diff(np.vstack(pos).reshape(len(pos), -1), axis=0) == 0
         ).all()
 
-    @pytest.mark.parametrize("bad_smiles", ["F[P-](F)(F)(F)(F)F"])
-    @pytest.mark.skipif(not has_rdkit, reason="RDKit is not installed")
-    def test_incorrect_rdkit_smiles(self, bad_smiles):
-        with pytest.raises(
-            MBuildError,
-            match=r"RDKit was unable to generate " r"3D coordinates",
-        ):
-            mb.load(bad_smiles, smiles=True, backend="rdkit", seed=29)
-
     @pytest.mark.skipif(not has_openbabel, reason="Pybel is not installed")
     def test_get_smiles(self):
         test_strings = ["CCO", "CCCCCCCC", "c1ccccc1", "CC(=O)Oc1ccccc1C(=O)O"]

--- a/mbuild/tests/test_gsd.py
+++ b/mbuild/tests/test_gsd.py
@@ -43,7 +43,7 @@ class TestGSD(BaseTest):
         from mbuild.utils.sorting import natural_sort
 
         ethane.save(filename="ethane.gsd", forcefield_name="oplsaa")
-        with gsd.hoomd.open("ethane.gsd", mode="rb") as f:
+        with gsd.hoomd.open("ethane.gsd", mode="r") as f:
             frame = f[0]
 
         assert frame.configuration.step == 0
@@ -88,7 +88,7 @@ class TestGSD(BaseTest):
         ethane.box = Box(lengths=[2.0, 3.0, 4.0])
 
         ethane.save(filename="ethane.gsd", forcefield_name="oplsaa")
-        with gsd.hoomd.open("ethane.gsd", mode="rb") as f:
+        with gsd.hoomd.open("ethane.gsd", mode="r") as f:
             frame = f[0]
 
         box_from_gsd = frame.configuration.box.astype(float)
@@ -101,7 +101,7 @@ class TestGSD(BaseTest):
 
         ethane.periodicity = (True, True, True)
         ethane.save(filename="ethane-periodicity.gsd", forcefield_name="oplsaa")
-        with gsd.hoomd.open("ethane-periodicity.gsd", mode="rb") as f:
+        with gsd.hoomd.open("ethane-periodicity.gsd", mode="r") as f:
             frame = f[0]
         box_from_gsd_periodic = frame.configuration.box.astype(float)
         assert np.array_equal(box_from_gsd, box_from_gsd_periodic)
@@ -111,7 +111,7 @@ class TestGSD(BaseTest):
         ethane.save(
             filename="triclinic-box.gsd", forcefield_name="oplsaa", box=box
         )
-        with gsd.hoomd.open("triclinic-box.gsd", mode="rb") as f:
+        with gsd.hoomd.open("triclinic-box.gsd", mode="r") as f:
             frame = f[0]
         lx, ly, lz, xy, xz, yz = frame.configuration.box
 
@@ -131,7 +131,7 @@ class TestGSD(BaseTest):
 
         benzene.label_rigid_bodies(rigid_particles="C")
         benzene.save(filename="benzene.gsd", forcefield_name="oplsaa")
-        with gsd.hoomd.open("benzene.gsd", mode="rb") as f:
+        with gsd.hoomd.open("benzene.gsd", mode="r") as f:
             frame = f[0]
 
         rigid_bodies = frame.particles.body
@@ -150,7 +150,7 @@ class TestGSD(BaseTest):
         from foyer import Forcefield
 
         ethane.save(filename="ethane.gsd", forcefield_name="oplsaa")
-        with gsd.hoomd.open("ethane.gsd", mode="rb") as f:
+        with gsd.hoomd.open("ethane.gsd", mode="r") as f:
             frame = f[0]
 
         structure = ethane.to_parmed()
@@ -244,7 +244,7 @@ class TestGSD(BaseTest):
         from foyer import Forcefield
 
         benzene.save(filename="benzene.gsd", forcefield_name="oplsaa")
-        with gsd.hoomd.open("benzene.gsd", mode="rb") as f:
+        with gsd.hoomd.open("benzene.gsd", mode="r") as f:
             frame = f[0]
 
         structure = benzene.to_parmed()
@@ -273,7 +273,7 @@ class TestGSD(BaseTest):
             ref_mass=ref_mass,
             box=box,
         )
-        with gsd.hoomd.open("ethane.gsd", mode="rb") as f:
+        with gsd.hoomd.open("ethane.gsd", mode="r") as f:
             frame = f[0]
 
         box_from_gsd = frame.configuration.box.astype(float)
@@ -312,7 +312,7 @@ class TestGSD(BaseTest):
             benzene, n_compounds=n_benzenes, box=[0, 0, 0, 4, 4, 4]
         )
         filled.save(filename="benzene.gsd")
-        with gsd.hoomd.open("benzene.gsd", mode="rb") as f:
+        with gsd.hoomd.open("benzene.gsd", mode="r") as f:
             frame = f[0]
         positions = frame.particles.position.astype(float)
         for coords in positions:

--- a/mbuild/tests/test_hoomd.py
+++ b/mbuild/tests/test_hoomd.py
@@ -74,7 +74,7 @@ class TestHoomdAny(BaseTest):
         snap, _ = to_hoomdsnapshot(filled)
 
         # copy attributes from the snapshot to a gsd snapshot
-        gsd_snap = gsd.hoomd.Snapshot()
+        gsd_snap = gsd.hoomd.Frame()
         gsd_snap.particles.N = snap.particles.N
         gsd_snap.particles.types = snap.particles.types
         gsd_snap.particles.typeid = snap.particles.typeid


### PR DESCRIPTION
### PR Summary:

Similar to https://github.com/mosdef-hub/gmso/pull/739 this PR updates the `gsd.hoomd` class names used from `Snapshot` to `Frame`. The write modes are also updated. 

Addresses #1130 if we decide to pin gsd to >= 2.9 which we talked about [Here](https://github.com/mosdef-hub/gmso/issues/738)

### PR Checklist
------------
 - [x ] Includes appropriate unit test(s)
 - [ x] Appropriate docstring(s) are added/updated
 - [ x] Code is (approximately) PEP8 compliant
 - [ x] Issue(s) raised/addressed?
