### PR TITLE
Turn off the infer_residues in compound.py

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -3234,7 +3234,7 @@ class Compound(object):
         title="",
         residues=None,
         show_ports=False,
-        infer_residues=True,
+        infer_residues=False,
         infer_residues_kwargs={},
     ):
         """Create a ParmEd Structure from a Compound.

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1459,7 +1459,7 @@ class TestCompound(BaseTest):
 
         # test multiple cg molecules
         system = mb.Compound([mb.clone(cg), mb.clone(cg)])
-        struct = system.to_parmed()
+        struct = system.to_parmed(infer_residues=True)
         assert len(struct.residues) == 2
 
         # test hierarchical cg molecules to depth 1
@@ -1543,7 +1543,6 @@ class TestCompound(BaseTest):
                 "include_base_level": True,
             },
         )
-        print(struct.residues)
         # two_bonded beads should generate 8 residues (gets down to particle level) (16 total)
         # benzene gets down to particle levels (24 total)
         # hexane is goes from polymer down to monomer level. Made from two propyl groups which gives two monomers (4 total)

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1373,6 +1373,7 @@ class TestCompound(BaseTest):
         system = Compound([h2o, mb.clone(h2o), ethane])
         struct = system.to_parmed(
             residues=["Ethane", "H2O"],
+            infer_residues=True,
         )
         assert len(struct.residues) == 3
         assert struct.residues[0].name == "H2O"
@@ -1382,7 +1383,7 @@ class TestCompound(BaseTest):
             struct.atoms
         )
 
-        struct = system.to_parmed(residues="Ethane")
+        struct = system.to_parmed(residues="Ethane", infer_residues=True)
         assert len(struct.residues) == 2
         assert struct.residues[0].name == "RES"
         assert struct.residues[1].name == "Ethane"


### PR DESCRIPTION
### PR Summary:
This is a follow up PR to #1134. Turn out, my initial instinct was correct, in that the slow down was cause by the `infer_residues` in parmed conversion. The reason the last PR doesn't show any improvement is because I forgot to also the `infer_residues` in the `to_parmed` existing in `compound.py` (I only turned off in `conversion.py`). 


### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
