### PR TITLE
revised load_xyz function

### DIFF
--- a/mbuild/formats/xyz.py
+++ b/mbuild/formats/xyz.py
@@ -86,7 +86,7 @@ def read_xyz(filename, compound=None):
                 "were expected, but at least one more was found."
             )
             raise MBuildError(msg.format(n_atoms))
-    
+
     compound.add(compound_list)
 
     return compound

--- a/mbuild/formats/xyz.py
+++ b/mbuild/formats/xyz.py
@@ -44,6 +44,7 @@ def read_xyz(filename, compound=None):
 
     guessed_elements = set()
 
+    compound_list = []
     with open(filename, "r") as xyz_file:
         n_atoms = int(xyz_file.readline())
         xyz_file.readline()
@@ -74,7 +75,7 @@ def read_xyz(filename, compound=None):
                 element = None
 
             particle = mb.Compound(pos=coords[row], name=name, element=element)
-            compound.add(particle)
+            compound_list.append(particle)
 
         # Verify we have read the last line by ensuring the next line in blank
         line = xyz_file.readline().split()
@@ -85,6 +86,8 @@ def read_xyz(filename, compound=None):
                 "were expected, but at least one more was found."
             )
             raise MBuildError(msg.format(n_atoms))
+    
+    compound.add(compound_list)
 
     return compound
 

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -55,6 +55,7 @@ constrain_rotation y 0. 0.
 constrain_rotation z 0. 0.
 """
 
+
 def fill_box(
     compound,
     n_compounds=None,
@@ -869,6 +870,7 @@ def _new_xyz_file():
     """
     return tempfile.NamedTemporaryFile(suffix=".xyz", delete=False)
 
+
 def _create_topology(container, comp_to_add, n_compounds):
     """Return updated mBuild compound with new coordinates.
 
@@ -890,7 +892,7 @@ def _create_topology(container, comp_to_add, n_compounds):
     for comp, m_compound in zip(comp_to_add, n_compounds):
         for _ in range(m_compound):
             container_list.append(clone(comp))
-            
+
     container.add(container_list)
     return container
 

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -55,7 +55,6 @@ constrain_rotation y 0. 0.
 constrain_rotation z 0. 0.
 """
 
-
 def fill_box(
     compound,
     n_compounds=None,
@@ -870,7 +869,6 @@ def _new_xyz_file():
     """
     return tempfile.NamedTemporaryFile(suffix=".xyz", delete=False)
 
-
 def _create_topology(container, comp_to_add, n_compounds):
     """Return updated mBuild compound with new coordinates.
 
@@ -888,9 +886,12 @@ def _create_topology(container, comp_to_add, n_compounds):
     container : mb.Compound
         Compound with added compounds from PACKMOL.
     """
+    container_list = []
     for comp, m_compound in zip(comp_to_add, n_compounds):
         for _ in range(m_compound):
-            container.add(clone(comp))
+            container_list.append(clone(comp))
+            
+    container.add(container_list)
     return container
 
 


### PR DESCRIPTION
### PR Summary:
This address issue #1139 .  Loading of xyz files did not see the prior changes to adding multiple compounds as a single list, rather than one at a time. 


### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
