### PR TITLE
Fix Treelib test

### DIFF
--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -263,7 +263,7 @@ class TestCompound(BaseTest):
         temp_particle.print_hierarchy()
 
         captured = capsys.readouterr()
-        assert captured.out.strip() == "C, 1 particles, 0 bonds, 0 children"
+        assert "C, 1 particles, 0 bonds, 0 children" in captured.out.strip()
 
         temp_particle.print_hierarchy(show_tree=False)
         captured = capsys.readouterr()


### PR DESCRIPTION
### PR Summary:
Fix test that checked for the output of `show_hierarchy`.  Relate to #1141 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
