### PR TITLE
Added extensions to savers doc string

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2892,7 +2892,7 @@ class Compound(object):
             prefix will be parsed and control the format. Supported extensions:
             'hoomdxml', 'gsd', 'gro', 'top', 'lammps', 'lmp', 'mcf', 'pdb', 'xyz',
             'json', 'mol2', 'sdf', 'psf'. See parmed/structure.py for more
-            information savers.
+            information on savers.
         show_ports : bool, optional, default=False
             Save ports contained within the compound.
         forcefield_files : str, optional, default=None

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2890,7 +2890,9 @@ class Compound(object):
         filename : str
             Filesystem path in which to save the trajectory. The extension or
             prefix will be parsed and control the format. Supported extensions:
-            'hoomdxml', 'gsd', 'gro', 'top', 'lammps', 'lmp', 'mcf'
+            'hoomdxml', 'gsd', 'gro', 'top', 'lammps', 'lmp', 'mcf', 'pdb', 'xyz',
+            'json', 'mol2', 'sdf', 'psf'. See parmed/structure.py for more
+            information savers.
         show_ports : bool, optional, default=False
             Save ports contained within the compound.
         forcefield_files : str, optional, default=None

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -978,7 +978,9 @@ def save(
     filename : str
         Filesystem path in which to save the trajectory. The extension or prefix
         will be parsed and control the format. Supported extensions are:
-        'hoomdxml', 'gsd', 'gro', 'top', 'lammps', 'lmp', 'mcf'.
+        'hoomdxml', 'gsd', 'gro', 'top', 'lammps', 'lmp', 'mcf', 'xyz', 'pdb',
+        'sdf', 'mol2', 'psf'. See parmed/structure.py for more information on
+        savers.
     show_ports : bool, optional, default=False
         Save ports contained within the compound.
     forcefield_files : str, optional, default=None


### PR DESCRIPTION
### PR Summary:
Add more doc strings to be explicit about saving out compounds into various formats.

### PR Checklist
------------
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
