### PR TITLE
Add `check_box_size` option for `add` method in `Compound.add()`

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -815,6 +815,7 @@ class Compound(object):
         inherit_periodicity=None,
         inherit_box=False,
         reset_rigid_ids=True,
+        verbose=True,
     ):
         """Add a part to the Compound.
 
@@ -843,6 +844,8 @@ class Compound(object):
             rigid_ids such that values remain distinct from rigid_ids
             already present in `self`. Can be set to False if attempting
             to add Compounds to an existing rigid body.
+        verbose : bool, optional, default=True
+            Warns if compound box is smaller than its bounding box after adding new_child.
         """
         # Support batch add via lists, tuples and sets.
         # If iterable, we will first compose all the bondgraphs of individual
@@ -891,9 +894,12 @@ class Compound(object):
                         child,
                         label=label_list[i],
                         reset_rigid_ids=reset_rigid_ids,
+                        verbose=False,
                     )
                 else:
-                    self.add(child, reset_rigid_ids=reset_rigid_ids)
+                    self.add(
+                        child, reset_rigid_ids=reset_rigid_ids, verbose=False
+                    )
 
             return
 
@@ -995,7 +1001,7 @@ class Compound(object):
                     )
 
         # Check that bounding box is within box after adding compound
-        if self.box:
+        if self.box and verbose:
             if (
                 np.array(self.box.lengths)
                 < np.array(self.get_boundingbox().lengths)

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -815,7 +815,7 @@ class Compound(object):
         inherit_periodicity=None,
         inherit_box=False,
         reset_rigid_ids=True,
-        verbose=True,
+        check_box_size=True,
     ):
         """Add a part to the Compound.
 
@@ -844,8 +844,8 @@ class Compound(object):
             rigid_ids such that values remain distinct from rigid_ids
             already present in `self`. Can be set to False if attempting
             to add Compounds to an existing rigid body.
-        verbose : bool, optional, default=True
-            Warns if compound box is smaller than its bounding box after adding new_child.
+        check_box_size : bool, optional, default=True
+            Checks and warns if compound box is smaller than its bounding box after adding new_child.
         """
         # Support batch add via lists, tuples and sets.
         # If iterable, we will first compose all the bondgraphs of individual
@@ -898,7 +898,9 @@ class Compound(object):
                     )
                 else:
                     self.add(
-                        child, reset_rigid_ids=reset_rigid_ids, verbose=False
+                        child,
+                        reset_rigid_ids=reset_rigid_ids,
+                        check_box_size=False,
                     )
 
             return

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -894,7 +894,7 @@ class Compound(object):
                         child,
                         label=label_list[i],
                         reset_rigid_ids=reset_rigid_ids,
-                        verbose=False,
+                        check_box_size=False,
                     )
                 else:
                     self.add(
@@ -1003,7 +1003,7 @@ class Compound(object):
                     )
 
         # Check that bounding box is within box after adding compound
-        if self.box and verbose:
+        if self.box and check_box_size:
             if (
                 np.array(self.box.lengths)
                 < np.array(self.get_boundingbox().lengths)


### PR DESCRIPTION
### PR Summary:
Add `verbose` option for `add` method in `Compound.add()`. When provided a list of compound to `Compound`, the method would recursively calling itself to add each compound. During this process, there is a final step to check if the new compound bounding box is bigger than the `Compound.Box`. The time for `Compound.get_boundingbox()`, however, would really add up in this process (scale up really badly if you get to the >10,000 range). Hence, I am adding an `verbose` option for this method to be able to turn it off when adding individual particle if a list/iterable is provided. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
