### PR TITLE
fixed the tree print issue

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -362,7 +362,7 @@ class Compound(object):
                     f"{h['parent_id']}",
                 )
         if show_tree:
-            tree.show()
+            print(tree)
         return tree
 
     def _get_hierarchy(self, level=0):


### PR DESCRIPTION
### PR Summary:
fixed the issue not being able to print the hireachy. 
related to the issue (https://github.com/mosdef-hub/mbuild/issues/1143)

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
