### PR TITLE
Fix failing doc build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,6 @@ import mock
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 MOCK_MODULES = [
-    "ele",
-    "ele.element",
-    "ele.exceptions",
     "hoomd",
     "hoomd.data",
     "hoomd.md",
@@ -35,8 +32,6 @@ MOCK_MODULES = [
     "hoomd.md.charge",
     "hoomd.md.pair",
     "hoomd.md.special_pair",
-    "numpy",
-    "numpy.linalg",
     "mdtraj",
     "mdtraj.core.element",
     "networkx",

--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -3,6 +3,8 @@ channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 dependencies:
+  - ele
+  - numpy
   - importlib_resources
   - python=3.11
   - ipython

--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -79,5 +79,7 @@ Building the documentation
 
 mBuild uses `sphinx <https://www.sphinx-doc.org/en/master/index.html>`_ to build its documentation. To build the docs locally, run the following while in the ``docs`` directory::
 
-    $ pip install -r requirements.txt
+    $ cd docs
+    $ conda create -f docs-env.yml
+    $ conda activate mbuild-docs
     $ make html

--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -61,9 +61,9 @@ And (optional) all files can be checked by running::
 Supported Python Versions
 -------------------------
 
-Python 3.6, 3.7 and 3.8 are officially supported, including testing during
+Python 3.9, 3.10 and 3.11 are officially supported, including testing during
 development and packaging. Support for Python 2.7 has been dropped as of
-August 6, 2019. Other Python versions, such as 3.9 and 3.5 and older, may
+August 6, 2019. Other Python versions, such as 3.12 and 3.8 and older, may
 successfully build and function but no guarantee is made.
 
 Testing your installation

--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -80,6 +80,6 @@ Building the documentation
 mBuild uses `sphinx <https://www.sphinx-doc.org/en/master/index.html>`_ to build its documentation. To build the docs locally, run the following while in the ``docs`` directory::
 
     $ cd docs
-    $ conda create -f docs-env.yml
+    $ conda env create -f docs-env.yml
     $ conda activate mbuild-docs
     $ make html

--- a/docs/getting_started/writers/writers.rst
+++ b/docs/getting_started/writers/writers.rst
@@ -17,22 +17,21 @@ field XML files (used by the `Foyer package <https://github.com/mosdef-hub/foyer
 to the ``Compound.save`` function if Foyer is installed. If a force field is applied to a
 Compound, the mBuild internal writers will also write angle and dihedral information
 to the file in addition to labelling atoms by the atom types specified by the force
-field.  The CHARMM-style GOMC writers are the exception to this default rule since
+field.  The CHARMM-style GOMC writers (supported through the `MoSDeF-GOMC extension <https://github.com/GOMC-WSU/MoSDeF-GOMC>`_) are the exception to this default rule since
 they need a force field to build the files, as these files depend on the force field parameters (Example: charge and MW in the PSF files).
 
 The simulation engine writers that use mBuild or are currently contained in the mBuild library:
 
 
 * `Cassandra <https://cassandra.nd.edu/>`_
-* `GPU Optimized Monte Carlo (GOMC) <http://gomc.eng.wayne.edu/>`_
 * `GROMACS <https://www.gromacs.org/>`_
 * `HOOMD-blue <http://glotzerlab.engin.umich.edu/hoomd-blue//>`_
 * `Large-scale Atomic/Molecular Massively Parallel Simulator (LAMMPS) <https://lammps.sandia.gov/>`_
 
+Support for `GPU Optimized Monte Carlo (GOMC) <http://gomc.eng.wayne.edu/>`_  is also available through the `MoSDeF-GOMC library <https://github.com/GOMC-WSU/MoSDeF-GOMC>`_
 
 .. toctree::
 
 	cassandra_file_writers
-   	GOMC_file_writers
    	HOOMD_blue_file_writers
 	LAMMPS_file_writers


### PR DESCRIPTION
### PR Summary:
Turn out, even though the docs build on readthedocs pass, some of the pages still failed to be built (but didn't error out). This PR will try to fix the remaining issue with the docs and addressed the issue raised in #1174. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
