### PR TITLE
Fix failing tests with latest version of packmol

### DIFF
--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -634,7 +634,9 @@ class TestCompound(BaseTest):
 
         assert np.allclose(h2o.mass, 18.015, atol=1e-5)
 
-        system = mb.fill_box(compound=h2o, n_compounds=5, box=[0.5, 0.5, 0.5])
+        system = mb.fill_box(
+            compound=h2o, n_compounds=5, box=[0.5, 0.5, 0.5], overlap=0.01
+        )
         assert np.allclose(system.mass, 5 * h2o.mass, atol=1e-5)
 
     def test_mass_setter(self, ethane):
@@ -1471,7 +1473,7 @@ class TestCompound(BaseTest):
         box = Box.from_mins_maxs_angles(
             mins=(2, 2, 2), maxs=(3, 3, 3), angles=(90.0, 90.0, 90.0)
         )
-        bead_box = mb.fill_box(bead, 100, box=[2, 2, 2, 3, 3, 3])
+        bead_box = mb.fill_box(bead, 100, box=[2, 2, 2, 3, 3, 3], overlap=0.01)
         bead_box_in_pmd = bead_box.to_parmed(box=box)
 
         assert isinstance(bead_box_in_pmd, pmd.Structure)

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -302,7 +302,7 @@ class TestPacking(BaseTest):
             mb.fill_box(h2o, n_compounds=10, box=[0, 0, 0])
 
     def test_packmol_warning(self, h2o):
-        with pytest.warns(UserWarning):
+        with pytest.raises(RuntimeError):
             mb.fill_box(h2o, n_compounds=10, box=[1, 1, 1], overlap=10)
 
     def test_rotate(self, h2o):

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -302,8 +302,16 @@ class TestPacking(BaseTest):
             mb.fill_box(h2o, n_compounds=10, box=[0, 0, 0])
 
     def test_packmol_warning(self, h2o):
-        with pytest.raises(RuntimeError):
-            mb.fill_box(h2o, n_compounds=10, box=[1, 1, 1], overlap=10)
+        import sys
+
+        if (
+            "win" in sys.platform and not sys.platform == "darwin"
+        ):  # windows uses old 20.0.4 of packmol, which raises a warning
+            with pytest.warns(UserWarning):
+                mb.fill_box(h2o, n_compounds=10, box=[1, 1, 1], overlap=10)
+        else:
+            with pytest.raises(RuntimeError):
+                mb.fill_box(h2o, n_compounds=10, box=[1, 1, 1], overlap=10)
 
     def test_rotate(self, h2o):
         filled = mb.fill_box(h2o, 2, box=[1, 1, 1], fix_orientation=True)


### PR DESCRIPTION
Update packmol arguments to raise Errors on overlapping molecules on overpacked boxes, and reduce overlaps argument for test cases.

### PR Summary:

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
