### PR TITLE
Fix deprecation warnig in `packing.py` and replace `.format()` with f-strings where possible.

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -750,8 +750,8 @@ class Compound(object):
         if self.root.max_rigid_id is not None:
             rigid_id = self.root.max_rigid_id + 1
             warn(
-                "{} rigid bodies already exist.  Incrementing 'rigid_id'"
-                "starting from {}.".format(rigid_id, rigid_id)
+                f"{rigid_id} rigid bodies already exist.  Incrementing 'rigid_id'"
+                f"starting from {rigid_id}."
             )
         else:
             rigid_id = 0
@@ -935,9 +935,7 @@ class Compound(object):
         if containment:
             if new_child.parent is not None:
                 raise MBuildError(
-                    "Part {} already has a parent: {}".format(
-                        new_child, new_child.parent
-                    )
+                    f"Part {new_child} already has a parent: {new_child.parent}"
                 )
             self.children.append(new_child)
             new_child.parent = self
@@ -956,7 +954,7 @@ class Compound(object):
 
         # Add new_part to labels. Does not currently support batch add.
         if label is None:
-            label = "{0}[$]".format(new_child.name)
+            label = f"{new_child.name}[$]"
 
         if label.endswith("[$]"):
             label = label[:-3]
@@ -1121,7 +1119,7 @@ class Compound(object):
                         if "port" in label:
                             label = "port[$]"
                     else:
-                        label = "{0}[$]".format(child.name)
+                        label = f"{child.name}[$]"
 
                 if label.endswith("[$]"):
                     label = label[:-3]
@@ -1656,8 +1654,8 @@ class Compound(object):
         if not self.children:
             if not arrnx3.shape[0] == 1:
                 raise ValueError(
-                    "Trying to set position of {} with more than one"
-                    "coordinate: {}".format(self, arrnx3)
+                    f"Trying to set position of {self} with more than one"
+                    f"coordinate: {arrnx3}"
                 )
             self.pos = np.squeeze(arrnx3)
         else:
@@ -1678,8 +1676,8 @@ class Compound(object):
         if not self.children:
             if not arrnx3.shape[0] == 1:
                 raise ValueError(
-                    "Trying to set position of {} with more than one"
-                    "coordinate: {}".format(self, arrnx3)
+                    f"Trying to set position of {self} with more than one"
+                    f"coordinate: {arrnx3}"
                 )
             self.pos = np.squeeze(arrnx3)
         else:
@@ -2631,11 +2629,9 @@ class Compound(object):
 
             else:
                 warn(
-                    "OpenMM Force {} is "
+                    f"OpenMM Force {type(force).__name__} is "
                     "not currently supported in _energy_minimize_openmm. "
-                    "This Force will not be updated!".format(
-                        type(force).__name__
-                    )
+                    "This Force will not be updated!"
                 )
 
         simulation.context.setPositions(to_parmed.positions)
@@ -2766,11 +2762,9 @@ class Compound(object):
                         particle._element = element_from_name(particle.name)
                     except ElementError:
                         raise MBuildError(
-                            "No element assigned to {}; element could not be"
-                            "inferred from particle name {}. Cannot perform"
-                            "an energy minimization.".format(
-                                particle, particle.name
-                            )
+                            f"No element assigned to {particle}; element could not be"
+                            f"inferred from particle name {particle.name}. Cannot perform"
+                            "an energy minimization."
                         )
         # Create a dict containing particle id and associated index to speed up looping
         particle_idx = {
@@ -2930,10 +2924,10 @@ class Compound(object):
         ff = openbabel.OBForceField.FindForceField(forcefield)
         if ff is None:
             raise MBuildError(
-                "Force field '{}' not supported for energy "
+                f"Force field '{forcefield}' not supported for energy "
                 "minimization. Valid force fields are 'MMFF94', "
                 "'MMFF94s', 'UFF', 'GAFF', and 'Ghemical'."
-                "".format(forcefield)
+                ""
             )
         warn(
             "Performing energy minimization using the Open Babel package. "
@@ -3594,19 +3588,17 @@ class Compound(object):
         descr.append(self.name + " ")
 
         if self.children:
-            descr.append("{:d} particles, ".format(self.n_particles))
-            descr.append("{:d} bonds, ".format(self.n_bonds))
+            descr.append(f"{self.n_particles} particles, ")
+            descr.append(f"{self.n_bonds} bonds, ")
             if self.box is not None:
-                descr.append("System box: {}, ".format(self.box))
+                descr.append(f"System box: {self.box}, ")
             else:
                 descr.append("non-periodic, ")
         else:
-            descr.append(
-                "pos=({}), ".format(np.array2string(self.pos, precision=4))
-            )
-            descr.append("{:d} bonds, ".format(self.n_direct_bonds))
+            descr.append(f"pos=({np.array2string(self.pos, precision=4)}), ")
+            descr.append(f"{self.n_direct_bonds} bonds, ")
 
-        descr.append("id: {}>".format(id(self)))
+        descr.append(f"id: {id(self)}>")
         return "".join(descr)
 
     def _clone(self, clone_of=None, root_container=None):

--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -411,8 +411,8 @@ def load_file(
                 tmp = read_xyz(filename)
                 if tmp.n_particles != compound.n_particles:
                     raise ValueError(
-                        "Number of atoms in {filename}"
-                        "does not match {compound}".format(**locals())
+                        f"Number of atoms in {filename}"
+                        f"does not match {compound}"
                     )
                 ref_and_compound = zip(
                     tmp._particles(include_ports=False),
@@ -583,7 +583,7 @@ def from_parmed(
                     name=str(atom.name), pos=pos, element=element
                 )
                 atom_list.append(new_atom)
-                atom_label_list.append("{0}[$]".format(atom.name))
+                atom_label_list.append(f"{atom.name}[$]")
                 atom_mapping[atom] = new_atom
             parent_compound.add(atom_list, label=atom_label_list)
         if infer_hierarchy:
@@ -697,7 +697,7 @@ def from_trajectory(
                     element=element,
                 )
                 atom_list.append(new_atom)
-                atom_label_list.append("{0}[$]".format(atom.name))
+                atom_label_list.append(f"{atom.name}[$]")
                 atom_mapping[atom] = new_atom
 
             parent_cmpd.add(atom_list, label=atom_label_list)
@@ -1093,7 +1093,7 @@ def save(
         saver = None
 
     if os.path.exists(filename) and not overwrite:
-        raise IOError("{0} exists; not overwriting".format(filename))
+        raise IOError(f"{filename} exists; not overwriting")
 
     if not parmed_kwargs:
         parmed_kwargs = {}

--- a/mbuild/coordinate_transform.py
+++ b/mbuild/coordinate_transform.py
@@ -321,8 +321,8 @@ def _create_equivalence_transform(equiv):
             isinstance(pair[0], Compound) and isinstance(pair[1], Compound)
         ):
             raise ValueError(
-                "Equivalence pair type mismatch: pair[0] is a {0} "
-                "and pair[1] is a {1}".format(type(pair[0]), type(pair[1]))
+                f"Equivalence pair type mismatch: pair[0] is a {pair[0]} "
+                f"and pair[1] is a {pair[1]}"
             )
 
         if not pair[0].children:
@@ -546,7 +546,7 @@ def x_axis_transform(
             "x_axis_transform, y_axis_transform, and z_axis_transform only "
             "accept mb.Compounds, list-like of size 3, or None for the "
             "point_on_x_axis parameter. User passed type: "
-            "{}.".format(type(point_on_x_axis))
+            f"{point_on_x_axis}."
         )
     if point_on_xy_plane is None:
         point_on_xy_plane = np.array([1.0, 1.0, 0.0])
@@ -559,7 +559,7 @@ def x_axis_transform(
             "x_axis_transform, y_axis_transform, and z_axis_transform only "
             "accept mb.Compounds, list-like of size 3, or None for the "
             "point_on_xy_plane parameter. User passed type: "
-            "{}.".format(type(point_on_xy_plane))
+            f"{point_on_xy_plane}."
         )
 
     atom_positions = compound.xyz_with_ports

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -273,25 +273,25 @@ class Lattice(object):
             lattice_spacing = lattice_spacing.reshape((3,))
             if np.shape(lattice_spacing) != (self.dimension,):
                 raise ValueError(
-                    "Lattice spacing should be a vector of size:({},). Please "
+                    f"Lattice spacing should be a vector of size:({self.dimension},). Please "
                     "include lattice spacing of size >= 0 depending on desired "
-                    "dimensionality.".format(self.dimension)
+                    "dimensionality."
                 )
         else:
             raise ValueError(
                 "No lattice_spacing provided. Please provide lattice spacing's "
-                "that are >= 0. with size ({},)".format((self.dimension))
+                f"that are >= 0. with size ({self.dimension},)"
             )
 
         if np.any(np.isnan(lattice_spacing)):
             raise ValueError(
                 "None type or NaN type values present in lattice_spacing: "
-                "{}.".format(lattice_spacing)
+                f"{lattice_spacing}."
             )
         elif np.any(lattice_spacing < 0.0):
             raise ValueError(
-                "Negative lattice spacing value. One of the spacing: {} is "
-                "negative.".format(lattice_spacing)
+                f"Negative lattice spacing value. One of the spacing: {lattice_spacing} is "
+                "negative."
             )
 
         self.lattice_spacing = lattice_spacing
@@ -320,20 +320,20 @@ class Lattice(object):
                     raise ValueError("Angles cannot be 180.0 or 0.0")
             else:
                 raise ValueError(
-                    "Angles sum: {} is either greater than 360.0 or less than "
-                    "-360.0".format(np.sum(tempAngles))
+                    f"Angles sum: {np.sum(tempAngles)} is either greater than 360.0 or less than "
+                    "-360.0"
                 )
 
             for subset in it.permutations(tempAngles, r=self.dimension):
                 if not subset[0] < np.sum(tempAngles) - subset[0]:
                     raise ValueError(
                         "Each angle provided must be less than the sum of the "
-                        "other angles. {} is greater.".format(subset[0])
+                        f"other angles. {subset[0]} is greater."
                     )
         else:
             raise ValueError(
                 "Incorrect array size. When converted to a Numpy array, the "
-                "shape is: {}, expected {}.".format(np.shape(tempAngles), (3,))
+                "shape is: {np.shape(tempAngles)}, expected {(3,)}."
             )
         self.angles = tempAngles
 
@@ -358,24 +358,21 @@ class Lattice(object):
 
             if (self.dimension, self.dimension) != np.shape(lattice_vectors):
                 raise ValueError(
-                    "Dimensionality of lattice_vectors is of shape {} not "
-                    "{}.".format(
-                        np.shape(lattice_vectors),
-                        (self.dimension, self.dimension),
-                    )
+                    f"Dimensionality of lattice_vectors is of shape {np.shape(lattice_vectors)} not "
+                    f"{(self.dimension, self.dimension)}."
                 )
 
             det = np.linalg.det(lattice_vectors)
             if abs(det) == 0.0:
                 raise ValueError(
-                    "Co-linear vectors: {} have a determinant of 0.0. Does not "
-                    "define a unit cell.".format(lattice_vectors)
+                    f"Co-linear vectors: {lattice_vectors} have a determinant of 0.0. Does not "
+                    "define a unit cell."
                 )
 
             if det <= 0.0:
                 raise ValueError(
-                    "Negative Determinant: the determinant of {} is negative, "
-                    "indicating a left-handed system.".format(det)
+                    f"Negative Determinant: the determinant of {det} is negative, "
+                    "indicating a left-handed system."
                 )
         self.lattice_vectors = lattice_vectors
 
@@ -398,8 +395,8 @@ class Lattice(object):
             pass
         else:
             raise TypeError(
-                "Incorrect type, lattice_points is of type {}, Expected "
-                "dict.".format(type(lattice_points))
+                f"Incorrect type, lattice_points is of type {type(lattice_points)}, Expected "
+                "dict."
             )
 
         for name, positions in lattice_points.items():
@@ -407,20 +404,20 @@ class Lattice(object):
                 if len(pos) != self.dimension:
                     raise ValueError(
                         "Incorrect lattice point position size. lattice point "
-                        "{} has location {}, which is inconsistent with the "
-                        "dimension {}.".format(name, pos, self.dimension)
+                        f"{name} has location {pos}, which is inconsistent with the "
+                        "dimension {self.dimension}."
                     )
                 if pos is None:
                     raise ValueError(
                         "NoneType passed, expected float. None was passed in "
-                        "as position for {}.".format(name)
+                        f"as position for {name}."
                     )
                 for coord in pos:
                     if (coord is None) or (0 > coord) or (coord >= 1):
                         raise ValueError(
                             "Incorrect lattice point fractional coordinates. "
                             "Coordinates cannot be None, greater than or equal "
-                            "to one, or negative. You passed {}.".format(coord)
+                            f"to one, or negative. You passed {coord}."
                         )
 
         self.lattice_points = self._check_for_overlap(lattice_points)
@@ -451,10 +448,8 @@ class Lattice(object):
             if len(val) > 1:
                 raise ValueError(
                     "Overlapping lattice points: Lattice points overlap when "
-                    "the unit cell is expanded to {}. This is an incorrect "
-                    "perfect lattice. The offending points are: {}".format(
-                        key, val
-                    )
+                    f"the unit cell is expanded to {key}. This is an incorrect "
+                    f"perfect lattice. The offending points are: {value}"
                 )
         return lattice_points
 
@@ -540,16 +535,14 @@ class Lattice(object):
             z = int(z)
         except (ValueError, TypeError):
             raise ValueError(
-                "Cannot convert replication amounts into integers. x= {}, "
-                "y= {}, z= {} needs to be an int.".format(x, y, z)
+                f"Cannot convert replication amounts into integers. x= {x}, "
+                f"y= {y}, z= {z} needs to be an int."
             )
 
         for replication_amount, index in zip([x, y, z], range(3)):
             if replication_amount < 1:
                 raise ValueError(
-                    "Incorrect populate value: {} : {} is < 1. ".format(
-                        error_dict[index], replication_amount
-                    )
+                    f"Incorrect populate value: {error_dict[index]} : {replication_amount} is < 1. "
                 )
 
         return x, y, z
@@ -592,9 +585,7 @@ class Lattice(object):
             pass
         else:
             raise TypeError(
-                "Compound dictionary is not a dict. {} was passed.".format(
-                    type(compound_dict)
-                )
+                "Compound dictionary is not a dict. {type(compound_dict)} was passed."
             )
 
         cell = defaultdict(list)
@@ -663,9 +654,7 @@ class Lattice(object):
                     err_type = type(compound_dict.get(key_id))
                     raise TypeError(
                         "Invalid type in provided Compound dictionary. For key "
-                        "{}, type: {} was provided, not Compound.".format(
-                            key_id, err_type
-                        )
+                        f"{key_id}, type: {err_type} was provided, not Compound."
                     )
         # Raise warnings about assumed elements
         for element in elementsSet:

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -585,7 +585,7 @@ class Lattice(object):
             pass
         else:
             raise TypeError(
-                "Compound dictionary is not a dict. {type(compound_dict)} was passed."
+                f"Compound dictionary is not a dict. {type(compound_dict)} was passed."
             )
 
         cell = defaultdict(list)

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -449,7 +449,7 @@ class Lattice(object):
                 raise ValueError(
                     "Overlapping lattice points: Lattice points overlap when "
                     f"the unit cell is expanded to {key}. This is an incorrect "
-                    f"perfect lattice. The offending points are: {value}"
+                    f"perfect lattice. The offending points are: {val}"
                 )
         return lattice_points
 

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -1179,8 +1179,7 @@ def _run_packmol(input_text, filled_xyz, temp_file):
         os.remove(packmol_inp.name)
 
     if temp_file is not None:
-        command = f"cp {filled_xyz.name} {os.path.join(temp_file)}"
-        os.system(command)
+        os.system("cp {0} {1}".format(filled_xyz.name, os.path.join(temp_file)))
 
 
 def _check_packmol(PACKMOL):  # pragma: no cover

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -4,10 +4,10 @@ http://leandro.iqm.unicamp.br/m3g/packmol/home.shtml
 """
 
 import os
+import shutil
 import sys
 import tempfile
 import warnings
-from distutils.spawn import find_executable
 from itertools import zip_longest
 from subprocess import PIPE, Popen
 
@@ -20,7 +20,7 @@ from mbuild.exceptions import MBuildError
 
 __all__ = ["fill_box", "fill_region", "fill_sphere", "solvate"]
 
-PACKMOL = find_executable("packmol")
+PACKMOL = shutil.which("packmol")
 PACKMOL_HEADER = """
 tolerance {0:.16f}
 filetype xyz

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -1179,7 +1179,8 @@ def _run_packmol(input_text, filled_xyz, temp_file):
         os.remove(packmol_inp.name)
 
     if temp_file is not None:
-        os.system(f"cp {filled_xyz.name} {os.path.join(temp_file)}")
+        command = f"cp {filled_xyz.name} {os.path.join(temp_file)}"
+        os.system(command)
 
 
 def _check_packmol(PACKMOL):  # pragma: no cover

--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -224,7 +224,7 @@ def fill_box(
     if arg_count != 2:
         raise ValueError(
             "Exactly 2 of `n_compounds`, `box`, and `density` must be "
-            "specified. {} were given.".format(arg_count)
+            f"specified. {arg_count} were given."
         )
 
     if box is not None:
@@ -703,7 +703,7 @@ def fill_sphere(
     if arg_count != 1:
         raise ValueError(
             "Exactly 1 of `n_compounds` and `density` must be specified. "
-            "{} were given.".format(arg_count)
+            f"{arg_count} were given."
         )
 
     if isinstance(sphere, (list, set, tuple)):
@@ -1156,7 +1156,7 @@ def _run_packmol(input_text, filled_xyz, temp_file):
     packmol_inp.close()
 
     proc = Popen(
-        "{} < {}".format(PACKMOL, packmol_inp.name),
+        f"{PACKMOL} < {packmol_inp.name}",
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE,
@@ -1170,7 +1170,7 @@ def _run_packmol(input_text, filled_xyz, temp_file):
             "Packmol finished with imperfect packing. Using the .xyz_FORCED "
             "file instead. This may not be a sufficient packing result."
         )
-        os.system("cp {0}_FORCED {0}".format(filled_xyz.name))
+        os.system(f"cp {filled_xyz.name}_FORCED {filled_xyz.name}")
 
     if "ERROR" in out or proc.returncode != 0:
         _packmol_error(out, err)
@@ -1179,7 +1179,7 @@ def _run_packmol(input_text, filled_xyz, temp_file):
         os.remove(packmol_inp.name)
 
     if temp_file is not None:
-        os.system("cp {0} {1}".format(filled_xyz.name, os.path.join(temp_file)))
+        os.system(f"cp {filled_xyz.name} {os.path.join(temp_file)}")
 
 
 def _check_packmol(PACKMOL):  # pragma: no cover

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -174,7 +174,7 @@ class Port(Compound):
                 for label in port_labels:
                     access_labels.add(f"['{label}']")
             for label in itertools.product(referrer_labels, port_labels):
-                access_labels.add(f"['{"']['".join(label)}']")
+                access_labels.add("['{}']".format("']['".join(label)))
 
         for key, val in self.root.labels.items():
             if self is val:

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -172,9 +172,9 @@ class Port(Compound):
             ]
             if referrer is self.root:
                 for label in port_labels:
-                    access_labels.add("['{}']".format(label))
+                    access_labels.add(f"['{label}']")
             for label in itertools.product(referrer_labels, port_labels):
-                access_labels.add("['{}']".format("']['".join(label)))
+                access_labels.add(f"['{"']['".join(label)}']")
 
         for key, val in self.root.labels.items():
             if self is val:
@@ -188,11 +188,11 @@ class Port(Compound):
         descr.append(self.name + ", ")
 
         if self.anchor:
-            descr.append("anchor: '{}', ".format(self.anchor.name))
+            descr.append(f"anchor: '{self.anchor.name}', ")
         else:
             descr.append("anchor: None, ")
 
-        descr.append("labels: {}, ".format(", ".join(self.access_labels)))
+        descr.append(f"labels: {", ".join(self.access_labels)}, ")
 
-        descr.append("id: {}>".format(id(self)))
+        descr.append(f"id: {id(self)}>")
         return "".join(descr)

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -192,7 +192,7 @@ class Port(Compound):
         else:
             descr.append("anchor: None, ")
 
-        descr.append(f"labels: {", ".join(self.access_labels)}, ")
+        descr.append("labels: {}, ".format(", ".join(self.access_labels)))
 
         descr.append(f"id: {id(self)}>")
         return "".join(descr)

--- a/mbuild/utils/decorators.py
+++ b/mbuild/utils/decorators.py
@@ -26,9 +26,7 @@ def deprecated(warning_string=""):  # pragma: no cover
 
     def old_function(fcn):
         def wrapper(*args, **kwargs):
-            printed_message = "{0} is deprecated. {1}".format(
-                fcn.__name__, warning_string
-            )
+            printed_message = f"{fcn.__name__} is deprecated. {warning_string}"
             warn(printed_message, DeprecationWarning)
             return fcn(*args, **kwargs)
 

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -400,7 +400,7 @@ def get_fn(name):
     fn = resources.files("mbuild").joinpath("utils", "reference", name)
     # fn = resource_filename("mbuild", os.path.join("utils", "reference", name))
     if not os.path.exists(fn):
-        raise IOError("Sorry! {} does not exists.".format(fn))
+        raise IOError(f"Sorry! {fn} does not exists.")
     return str(fn)
 
 

--- a/mbuild/utils/jsutils.py
+++ b/mbuild/utils/jsutils.py
@@ -30,7 +30,7 @@ def overwrite_nglview_default(widget):
     if not isinstance(widget, nglview.NGLWidget):
         raise TypeError(
             "The argument widget can only be of type nglview.NGLWidget not "
-            "{}".format(type(widget))
+            f"{type(widget)}."
         )
     tooltip_js = """
                     this.stage.mouseControls.add('hoverPick', (stage, pickingProxy) => {


### PR DESCRIPTION
### PR Summary:

This is a PR that does 2 things:

1) Fix a deprecation warning that is being raised about `find_executable` in `distutils`

```
>>> from distutils.spawn import find_executable
>>> find_executable("PACKMOL")
<stdin>:1: DeprecationWarning: Use shutil.which instead of find_executable
```

2) It also replaces `.format()` with f-strings in many places in an effort to clean things up a bit (I was bored at an airport)

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?