### PR TITLE
Fix show ports

### DIFF
--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1038,7 +1038,7 @@ def save(
         output_sdf.write(pybel_molecule)
         output_sdf.close()
     else:  # ParmEd supported saver.
-        structure = compound.to_parmed()
+        structure = compound.to_parmed(include_ports=include_ports)
         structure.save(filename, overwrite=overwrite, **kwargs)
 
 

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -75,6 +75,20 @@ class TestCompound(BaseTest):
         test_converted2.from_parmed(test, coords_only=True)
         assert np.allclose(test_converted1.xyz, test_converted2.xyz)
 
+    def test_save_ports(self):
+        #ensure that setting include_ports=True works
+        mol = mb.Compound()
+
+        carbon = mb.Particle(pos=[0, 0, 0], name="C")
+        mol.add(carbon)
+        port1 = mb.Port(anchor=carbon, orientation=[1, 0, 0], separation=0.1)
+        mol.add(port1)
+
+        mol.save("test_ports.mol2", overwrite=True, include_ports=True)
+        mol_in = mb.load("test_ports.mol2")
+
+        assert mol_in.n_particles == 9
+
     def test_load_xyz(self):
         myethane = mb.load(get_fn("ethane.xyz"))
         assert myethane.n_particles == 8


### PR DESCRIPTION
### PR Summary:
Compound.visualize(show_ports=True) does not actually visualize the ports.  This can be traced to the  `save` function in conversion.py.  Here,  the `include_ports` variable is never passed to the `to_parmed` function. 

See issue #1232 

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
