### PR TITLE
Drop `importlib.resources` backport

### DIFF
--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -5,7 +5,6 @@ channels:
 dependencies:
   - ele
   - numpy
-  - importlib_resources
   - python=3.11
   - ipython
   - boltons

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -40,7 +40,6 @@ dependencies:
   - symengine
   - python-symengine
   - hoomd>=4.0,<5.0
-  - importlib_resources
   - pip:
       - git+https://github.com/mosdef-hub/gmso.git@main
       - git+https://github.com/mosdef-hub/foyer.git@main

--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,3 @@ dependencies:
   - scipy
   - networkx
   - treelib
-  - importlib_resources

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -26,9 +26,8 @@ import os
 import sys
 import textwrap
 import warnings
+from importlib.resources import files
 from unittest import SkipTest
-
-import importlib_resources as resources
 
 
 class DelayImportError(ImportError, SkipTest):
@@ -362,8 +361,8 @@ def get_fn(name):
     name : str
         Name of the file to load (with respect to the reference/ folder).
     """
-    fn = resources.files("mbuild").joinpath("utils", "reference", name)
-    # fn = resource_filename("mbuild", os.path.join("utils", "reference", name))
+    fn = files("mbuild").joinpath("utils", "reference", name)
+
     if not os.path.exists(fn):
         raise IOError(f"Sorry! {fn} does not exists.")
     return str(fn)


### PR DESCRIPTION
### PR Summary:

This is in the standard library as of Python 3.10, so the third-party backport is not needed

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
