### PR TITLE
Add py3Dmol to dev env file

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -41,6 +41,7 @@ dependencies:
   - python-symengine
   - hoomd>=4.0,<5.0
   - importlib_resources
+  - py3Dmol
   - pip:
       - git+https://github.com/mosdef-hub/gmso.git@main
       - git+https://github.com/mosdef-hub/foyer.git@main


### PR DESCRIPTION
### PR Summary:

I think the dev environment should include py3Dmol. We could have a separate discussion if it should be included in the conda-forge package dependencies as well.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
