### PR TITLE
Use numpy 2 in CI testing. Drop python 3.9, add python 3.13 to testing, remove openbabel from `enviroment-dev.yml`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
         name: Checkout Branch / Pull Request
 
-      - uses: Vampire/setup-wsl@v4
+      - uses: Vampire/setup-wsl@v5
         with:
           distribution: Ubuntu-24.04
           wsl-shell-user: runner

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,7 +40,7 @@ jobs:
         run: python -m pip install -e .
 
       - name: Conditionally install OpenBabel
-        if: ${{ matrix.python-version != "3.13" }}
+        if: ${{ matrix.python-version != '3.13' }}
         run: micromamba install -y openbabel
 
       - name: Test (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     defaults:
       run:
@@ -38,6 +38,10 @@ jobs:
 
       - name: Install Package
         run: python -m pip install -e .
+
+      - name: Conditionally install OpenBabel
+        if: ${{ matrix.python-version != '3.13' }}
+        run: micromamba install -y openbabel
 
       - name: Test (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
         run: python -m pytest -v --cov=mbuild --cov-report=xml --cov-append --cov-config=setup.cfg --color yes --pyargs mbuild

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     defaults:
       run:
@@ -40,7 +40,7 @@ jobs:
         run: python -m pip install -e .
 
       - name: Conditionally install OpenBabel
-        if: ${{ matrix.python-version != '3.13' }}
+        if: ${{ matrix.python-version != "3.13" }}
         run: micromamba install -y openbabel
 
       - name: Test (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, macOS-13, ubuntu-latest]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
 
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ conda activate mbuild-dev
 pip install .
 ```
 
+NOTE: [openbabel](https://github.com/openbabel/openbabel) is required for some energy minimization methods in `mbuild.compound.Compound()`. It can be installed into your mBuild environment from conda-forge with `conda install -c conda-forge openbabel`; however, openbabel does not yet support python 3.13.
+
 #### Install an editable version from source
 
 Once all dependencies have been installed and the ``conda`` environment has been created, the ``mBuild`` itself can be installed.

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: mbuild-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9,<=3.12
+  - python>=3.10,<=3.13
   - boltons
   - numpy>=2.0,<2.3
   - sympy
@@ -10,7 +10,6 @@ dependencies:
   - boltons
   - lark>=1.2
   - lxml
-  - freud>=3.0
   - intermol
   - mdtraj
   - pydantic>=2
@@ -21,11 +20,12 @@ dependencies:
   - openff-toolkit-base>0.16.7
   - openmm
   - gsd>=2.9
+  - freud>=3.2
   - parmed>=3.4.3
   - packmol>=20.15
   - pytest-cov
   - pycifrw
-  - rdkit>=2021,<2025.3.3
+  - rdkit>=2021
   - requests
   - requests-mock
   - scipy
@@ -38,8 +38,8 @@ dependencies:
   - pandas
   - symengine
   - python-symengine
-  - hoomd>=4.0,<5.0
   - py3Dmol
+  - hoomd>=4.0
   - pip:
       - git+https://github.com/mosdef-hub/gmso.git@main
       - git+https://github.com/mosdef-hub/foyer.git@main

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.9,<=3.12
   - boltons
-  - numpy=1.26.4
+  - numpy>=2.2,<2.3
   - sympy
   - unyt>=2.9.5
   - boltons

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.9,<=3.12
   - boltons
-  - numpy>=2.2,<2.3
+  - numpy>=2.0,<2.3
   - sympy
   - unyt>=2.9.5
   - boltons

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -18,8 +18,7 @@ dependencies:
   - nglview>=3
   - pytest
   - garnett>=0.7.1
-  - openbabel>=3.0.0
-  - openff-toolkit-base >=0.11,<0.16.7
+  - openff-toolkit-base>0.16.7
   - openmm
   - gsd>=2.9
   - parmed>=3.4.3

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -26,7 +26,7 @@ dependencies:
   - packmol>=20.15
   - pytest-cov
   - pycifrw
-  - rdkit>=2021
+  - rdkit>=2021,<2025.3.3
   - requests
   - requests-mock
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,11 @@ dependencies:
   - ele
   - numpy>=2.0,<2.3
   - packmol>=20.15
-  - gmso>=0.9.0
+  - gmso>=0.12.0
   - garnett
   - parmed>=3.4.3
   - pycifrw
-  - python>=3.8
+  - python>=3.10,<=3.13
   - rdkit>=2021
   - scipy
   - networkx

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ele
-  - numpy>=2.2,<2.3
+  - numpy>=2.0,<2.3
   - packmol>=20.15
   - gmso>=0.9.0
   - garnett

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ele
-  - numpy=1.26.4
+  - numpy>=2.2,<2.3
   - packmol>=20.15
   - gmso>=0.9.0
   - garnett

--- a/mbuild/tests/test_lattice.py
+++ b/mbuild/tests/test_lattice.py
@@ -172,7 +172,7 @@ class TestLattice(BaseTest):
             (-1, 1, 1),
             (1, -1, 1),
             (1, 1, -1),
-            (1, 1, np.NaN),
+            (1, 1, np.nan),
         ],
     )
     def test_incorrect_populate_inputs(self, x, y, z):

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -116,7 +116,7 @@ class TestPacking(BaseTest):
         assert filled.n_bonds == 50 * 2
 
         center = np.array([3.0, 3.0, 3.0])
-        assert np.alltrue(np.linalg.norm(filled.xyz - center, axis=1) < 1.5)
+        assert np.all(np.linalg.norm(filled.xyz - center, axis=1) < 1.5)
 
     def test_fill_sphere_density(self, h2o):
         filled = mb.fill_sphere(h2o, sphere=[3, 3, 3, 1.5], density=1000)

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -88,6 +88,9 @@ openbabel can be installed with conda using:
 
 # conda install -c conda-forge openbabel
 
+NOTE: openbabel is only available for python<3.13.
+If you need it in your environment, make sure your python is 3.10, 3.11 or 3.12.
+
 or from source following instructions at:
 
 # http://openbabel.org/docs/current/UseTheLibrary/PythonInstall.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers=[
     "Operating System :: MacOS",
 ]
 urls = {Homepage = "https://github.com/mosdef-hub/mbuild"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 
 [tool.setuptools]


### PR DESCRIPTION
### PR Summary:

This pins the numpy version used in the environment.yml files to >=2.0 and <2.3.
There are breaking changes in some upstream packages in 2.3 (https://github.com/ParmEd/ParmEd/issues/1406)

There were a couple syntax changes needed in some unit tests. Tests with numpy 2 are passing in gmso as well, so I'll start a PR there. I'll check in foyer and ffutils next.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
