### PR TITLE
Fix sidemax test in `test_packing.py` by using a more reasonable length

### DIFF
--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -575,9 +575,9 @@ class TestPacking(BaseTest):
 
         ch4 = Methane()
         # With default sidemax
-        box_of_methane = mb.fill_box(ch4, box=[1000, 1000, 1000], n_compounds=500)
+        box_of_methane = mb.fill_box(ch4, box=[500, 500, 500], n_compounds=500)
         sphere_of_methane = mb.fill_sphere(
-            ch4, sphere=[1000, 1000, 1000, 1000], n_compounds=500
+            ch4, sphere=[500, 500, 500, 500], n_compounds=500
         )
         assert all(
             np.asarray(box_of_methane.get_boundingbox().lengths) < [110, 110, 110]
@@ -588,21 +588,21 @@ class TestPacking(BaseTest):
 
         # With adjusted sidemax
         big_box_of_methane = mb.fill_box(
-            ch4, box=[1000, 1000, 1000], n_compounds=500, sidemax=1000.0
+            ch4, box=[100, 100, 100], n_compounds=500, sidemax=200.0
         )
         big_sphere_of_methane = mb.fill_sphere(
             ch4,
-            sphere=[1000, 1000, 1000, 1000],
+            sphere=[100, 100, 100, 100],
             n_compounds=500,
-            sidemax=2000.0,
+            sidemax=200.0,
         )
 
         assert all(
-            np.asarray(big_box_of_methane.get_boundingbox().lengths) > [900, 900, 900]
+            np.asarray(big_box_of_methane.get_boundingbox().lengths) > [90, 90, 90]
         )
         assert all(
             np.asarray(big_sphere_of_methane.get_boundingbox().lengths)
-            > [1800, 1800, 1800]
+            > [180, 180, 180]
         )
 
     def test_box_edge(self, h2o, methane):

--- a/mbuild/tests/test_packing.py
+++ b/mbuild/tests/test_packing.py
@@ -575,34 +575,33 @@ class TestPacking(BaseTest):
 
         ch4 = Methane()
         # With default sidemax
-        box_of_methane = mb.fill_box(ch4, box=[500, 500, 500], n_compounds=500)
+        box_of_methane = mb.fill_box(
+            ch4, box=[20, 20, 20], n_compounds=500, sidemax=10.0
+        )
         sphere_of_methane = mb.fill_sphere(
-            ch4, sphere=[500, 500, 500, 500], n_compounds=500
+            ch4, sphere=[20, 20, 20, 20], n_compounds=500, sidemax=10.0
         )
+        assert all(np.asarray(box_of_methane.get_boundingbox().lengths) < [11, 11, 11])
         assert all(
-            np.asarray(box_of_methane.get_boundingbox().lengths) < [110, 110, 110]
-        )
-        assert all(
-            np.asarray(sphere_of_methane.get_boundingbox().lengths) < [210, 210, 210]
+            np.asarray(sphere_of_methane.get_boundingbox().lengths) < [21, 21, 21]
         )
 
         # With adjusted sidemax
         big_box_of_methane = mb.fill_box(
-            ch4, box=[100, 100, 100], n_compounds=500, sidemax=200.0
+            ch4, box=[120, 120, 120], n_compounds=500, sidemax=20.0
         )
         big_sphere_of_methane = mb.fill_sphere(
             ch4,
-            sphere=[100, 100, 100, 100],
+            sphere=[120, 120, 120, 120],
             n_compounds=500,
-            sidemax=200.0,
+            sidemax=20.0,
         )
 
         assert all(
-            np.asarray(big_box_of_methane.get_boundingbox().lengths) > [90, 90, 90]
+            np.asarray(big_box_of_methane.get_boundingbox().lengths) > [10, 10, 10]
         )
         assert all(
-            np.asarray(big_sphere_of_methane.get_boundingbox().lengths)
-            > [180, 180, 180]
+            np.asarray(big_sphere_of_methane.get_boundingbox().lengths) > [14, 14, 14]
         )
 
     def test_box_edge(self, h2o, methane):


### PR DESCRIPTION
### PR Summary:

Packmol had a bug fix recently and a new release on conda-forge about a week ago. I think this was changing the behavior of the initial guess (using sidemax). The `test_sidemax` tests are failing as a result. From what I can tell, the issue stems from using too large of a box size combined with large sidemax values (2000 nanometers), which is causing the packing calls in the test to use a ton of memory. It was up to 28GB when running the same test in a notebook


### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
