### PR TITLE
Fix bond order in Visualizaiton

### DIFF
--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -1762,6 +1762,9 @@ class Compound(object):
         py3Dmol = import_("py3Dmol")
 
         cloned = clone(self)
+        for edge in cloned.bond_graph.edges(data=True):
+            if edge[2]["bond_order"] == 0.0:
+                edge[2]["bond_order"] = 1.0
 
         modified_color_scheme = {}
         for name, color in color_scheme.items():


### PR DESCRIPTION
### PR Summary:
Because of https://github.com/mosdef-hub/mbuild/pull/1274, the bond order is now drawn accurately by py3Dmol, which causes bond orders of 0.0 or None to not be drawn. This PR changes all bonder orders of 0 to 1, but it operates only on the cloned compound created in `visualize`, so it won't change the bond orders set in the main compound.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
