### PR TITLE
Pass residue information to parmed during save

### DIFF
--- a/mbuild/conversion.py
+++ b/mbuild/conversion.py
@@ -1042,7 +1042,7 @@ def save(
         output_sdf.write(pybel_molecule)
         output_sdf.close()
     else:  # ParmEd supported saver.
-        structure = compound.to_parmed(include_ports=include_ports)
+        structure = compound.to_parmed(residues=residues, include_ports=include_ports)
         structure.save(filename, overwrite=overwrite, **kwargs)
 
 

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -2265,6 +2265,9 @@ class TestCompound(BaseTest):
         struc = pmd.load_file(get_fn("spc.pdb"))
         comp.from_parmed(struc)
         assert comp.children[0].name == "SPC"
+        comp.save("test.pdb", residues=["SPC"])
+        struc2 = pmd.load_file("test.pdb")
+        assert struc2.residues[0].name == struc.residues[0].name
 
     @pytest.mark.skipif(not has_mdtraj, reason="MDTraj not installed")
     def test_complex_from_trajectory(self):


### PR DESCRIPTION
### PR Summary:
Fix bug pointed out in https://github.com/mosdef-hub/mbuild/issues/1279 saving using parmed savers when not passing residue information, which affects the .pdb file outputs.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
