### PR TITLE
Create criteria and termination data structure

### DIFF
--- a/mbuild/path/bias.py
+++ b/mbuild/path/bias.py
@@ -21,6 +21,10 @@ class Bias:
         # Inherit rng from the path for use in Bias classes
         self.rng = self.path.rng
 
+    def _clean(self):
+        self.path = None
+        self.rng = None
+
     def __call__(self, candidates):
         """Implemented in sub classes of Bias."""
         raise NotImplementedError

--- a/mbuild/path/bias.py
+++ b/mbuild/path/bias.py
@@ -64,7 +64,7 @@ class TargetType(Bias):
     def __init__(self, target_type, weight, r_cut):
         self.target_type = target_type
         self.r_cut = r_cut
-        super(TargetType, self).__init__(weight=weight)
+        super().__init__(weight=weight)
 
     def __call__(self, candidates):
         types = np.array(
@@ -91,7 +91,7 @@ class AvoidType(Bias):
     def __init__(self, avoid_type, weight, r_cut):
         self.avoid_type = avoid_type
         self.r_cut = r_cut
-        super(AvoidType, self).__init__(weight=weight)
+        super().__init__(weight=weight)
 
     def __call__(self, candidates):
         types = np.array(
@@ -121,7 +121,7 @@ class TargetDirection(Bias):
         if norm < 1e-8:
             raise ValueError("Direction vector must be non-zero.")
         self.direction = direction / norm
-        super(TargetDirection, self).__init__(weight=weight)
+        super().__init__(weight=weight)
 
     def __call__(self, candidates):
         last_step_pos = self.path.coordinates[self.path.count]
@@ -144,7 +144,7 @@ class AvoidDirection(Bias):
 
     def __init__(self, direction, weight):
         self.direction = direction
-        super(AvoidDirection, self).__init__(weight=weight)
+        super().__init__(weight=weight)
 
     def __call__(self, candidates):
         last_step_pos = self.path.coordinates[self.path.count]
@@ -166,7 +166,7 @@ class TargetEdge(Bias):
     """Bias next-moves so that ones moving towards a surface are more likely to be accepted."""
 
     def __init__(self, weight):
-        super(TargetEdge, self).__init__(weight=weight)
+        super().__init__(weight=weight)
 
     def __call__(self):
         raise NotImplementedError(
@@ -178,7 +178,7 @@ class AvoidEdge(Bias):
     """Bias next-moves so that ones away from a surface are more likely to be accepted."""
 
     def __init__(self, weight):
-        super(AvoidEdge, self).__init__(weight=weight)
+        super().__init__(weight=weight)
 
     def __call__(self):
         raise NotImplementedError(
@@ -191,7 +191,7 @@ class TargetPath(Bias):
 
     def __init__(self, target_path, weight):
         self.target_path = target_path
-        super(TargetPath, self).__init__(weight=weight)
+        super().__init__(weight=weight)
 
     def __call__(self):
         raise NotImplementedError(

--- a/mbuild/path/criteria.py
+++ b/mbuild/path/criteria.py
@@ -1,0 +1,140 @@
+import time
+
+import numpy as np
+
+
+class Termination:
+    def __init__(self, criteria):
+        self.criteria = list(criteria)
+        self.required = [c for c in self.criteria if c.required_to_end]
+        self.not_required = [c for c in self.criteria if not c.required_to_end]
+        # TODO, keep a list of triggered critera, add to logging when walk ends
+        self.triggered = []
+
+    def attach_path(self, path):
+        for c in self.criteria:
+            c._attach_path(path)
+
+    def is_met(self):
+        # Check required criteria first
+        if all([c.is_met() for c in self.required]):
+            return True
+        if any([c.is_met() for c in self.not_required]):
+            return True
+        return False
+
+
+class Criterion:
+    """"""
+
+    def __init__(self, required_to_end):
+        self.required_to_end = required_to_end
+
+    def _attach_path(self, path):
+        self.path = path
+        self.rng = getattr(path, "rng", None)
+
+    def is_met(self):
+        """Implemented in sub classes of Criterion."""
+        raise NotImplementedError
+
+
+class NumSites(Criterion):
+    def __init__(self, num_sites, required_to_end=True):
+        self.num_sites = num_sites
+        super().__init__(required_to_end)
+
+    def is_met(self):
+        return self.path.count - self.path.init_count >= self.num_sites
+
+
+class NumAttempts(Criterion):
+    def __init__(self, max_attempts, required_to_end=False):
+        self.max_attempts = int(max_attempts)
+        super().__init__(required_to_end)
+
+    def is_met(self):
+        return self.path.attempts >= self.max_attempts
+
+
+class WallTime(Criterion):
+    def __init__(self, max_time, required_to_end=False):
+        self.max_time = max_time
+        super().__init__(required_to_end)
+
+    def is_met(self):
+        current_time = time.time()
+        total_time = current_time - self.path.start_time
+        return total_time >= self.max_time
+
+
+class WithinCoordinate(Criterion):
+    def __init__(
+        self, final_coordinate, distance, tolerance=1e-3, required_to_end=True
+    ):
+        self.distance = float(distance)
+        self.final_coordinate = np.asarray(final_coordinate)
+        self.tolerance = tolerance
+        super().__init__(required_to_end)
+
+    def is_met(self):
+        last_site = self.path.coordinates[self.path.count]
+        current_distance = np.linalg.norm(self.final_coordinate - last_site)
+        return current_distance <= self.distance + self.tolerance
+
+
+class FinalCoordinate(Criterion):
+    def __init__(self, final_coordinate, tolerance=1e-3, required_to_end=True):
+        self.final_coordinate = np.asarray(final_coordinate)
+        self.tolerance = tolerance
+        super().__init__(required_to_end)
+
+    def is_met(self):
+        last_site = self.path.coordinates[self.path.count]
+        return np.linalg.norm(self.final_coordinate - last_site) <= self.tolerance
+
+
+class PairDistance(Criterion):
+    def __init__(self, distance, pair_type=None, required_to_end=True):
+        self.distance = float(distance)
+        self.pair_type = pair_type
+        super().__init__(required_to_end)
+
+    def is_met(self):
+        raise NotImplementedError
+
+
+class RadiusGyration(Criterion):
+    def __init__(self, radius_of_gyration, tolerance=1e-2, required_to_end=True):
+        self.radius_of_gyration = float(radius_of_gyration)
+        self.tolerance = tolerance
+        self.max_rg2 = (radius_of_gyration + tolerance) ** 2
+        super().__init__(required_to_end)
+
+    def is_met(self):
+        # Enforce at least 3 sites
+        n = self.path.count - self.path.init_count + 1
+        if n < 2:
+            return False
+
+        coords = self.path.coordinates[self.path.init_count : self.path.count + 1]
+        center = coords.mean(axis=0)
+        diffs = coords - center
+        rg2 = np.mean(np.sum(diffs * diffs, axis=1))
+        return rg2 >= self.max_rg2
+
+
+class EndtoEndDistance(Criterion):
+    def __init__(self, distance, tolerance=1e-2, required_to_end=True):
+        self.distance = float(distance)
+        self.tolerance = tolerance
+        super().__init__(required_to_end)
+
+    def is_met(self):
+        # Enforce at least 3 sites
+        n = self.path.count - self.path.init_count + 1
+        if n < 2:
+            return False
+        first_site = self.path.coordinates[self.path.init_count]
+        last_site = self.path.coordinates[self.path.count]
+        return np.linalg.norm(last_site - first_site) >= self.distance - self.tolerance

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -522,8 +522,8 @@ class HardSphereRandomWalk(Path):
         if self.termination.success:
             logger.info("Random walk successful.")
         else:
-            logger.info("Random walk not successful.")
-            logger.info(self.termination.summarize())
+            logger.warning("Random walk not successful.")
+            logger.warning(self.termination.summarize())
 
     def current_walk_coordinates(self):
         """Return the coordinates from the current random walk only.

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -1,5 +1,6 @@
 """Classes to generate intra-molecular paths and configurations."""
 
+import logging
 import math
 import time
 from abc import abstractmethod
@@ -12,6 +13,8 @@ from scipy.interpolate import interp1d
 from mbuild import Compound
 from mbuild.path.path_utils import check_path, random_coordinate
 from mbuild.utils.volumes import CuboidConstraint, CylinderConstraint
+
+logger = logging.getLogger(__name__)
 
 
 class Path:
@@ -516,6 +519,11 @@ class HardSphereRandomWalk(Path):
 
         # Trim the final coordinates, removing any used in last chunk
         self.coordinates = self.coordinates[: self.count + 1]
+        if self.termination.success:
+            logger.info("Random walk successful.")
+        else:
+            logger.info("Random walk not successful.")
+            logger.info(self.termination.summarize())
 
     def current_walk_coordinates(self):
         """Return the coordinates from the current random walk only.

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -519,8 +519,10 @@ class HardSphereRandomWalk(Path):
             logger.warning("Random walk not successful.")
             logger.warning(self.termination.summarize())
 
-        # Perform some object clean up that is not needed once a RW finishes
+        # Perform some object clean up once a RW finishes
         self.termination._clean()
+        if self.bias:
+            self.bias._clean()
         self.start_from_path = None
 
     def current_walk_coordinates(self):

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -324,7 +324,7 @@ class HardSphereRandomWalk(Path):
         if self.bias:
             self.bias._attach_path(self)
 
-        # Set up termination conditions 
+        # Set up termination conditions
         if termination is None:
             raise RuntimeError("No terminaiton conditions have been passed in.")
         self.termination = termination
@@ -454,7 +454,7 @@ class HardSphereRandomWalk(Path):
             self.attempts += 1
 
         #### Initial conditions set, now start RW ####
-        #while self.count < self.N - 1:
+        # while self.count < self.N - 1:
         walk_finished = False
         while not walk_finished:
             # Generate a batch of angles and vectors to create a set of candidate next coordinates
@@ -612,7 +612,7 @@ class HardSphereRandomWalk(Path):
                         return xyz
                 self.attempts += 1
                 if self.termination.is_met():
-                # if self.attempts == self.max_attempts and self.count < self.N:
+                    # if self.attempts == self.max_attempts and self.count < self.N:
                     raise RuntimeError(
                         "The maximum number attempts allowed have passed, and only ",
                         f"{self.count - self._init_count} sucsessful attempts were completed.",

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -161,8 +161,10 @@ class Path:
     def to_compound(self):
         """Convert a path and its bond graph to an mBuild Compound."""
         compound = Compound()
+        compounds = []
         for node_id, attrs in self.bond_graph.nodes(data=True):
-            compound.add(Compound(name=attrs["name"], pos=attrs["xyz"]))
+            compounds.append(Compound(name=attrs["name"], pos=attrs["xyz"]))
+        compound.add(compounds)
         compound.set_bond_graph(self.bond_graph)
         return compound
 
@@ -516,6 +518,10 @@ class HardSphereRandomWalk(Path):
         else:
             logger.warning("Random walk not successful.")
             logger.warning(self.termination.summarize())
+
+        # Perform some object clean up that is not needed once a RW finishes
+        self.termination._clean()
+        self.start_from_path = None
 
     def current_walk_coordinates(self):
         """Return the coordinates from the current random walk only.

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -213,7 +213,6 @@ class HardSphereRandomWalk(Path):
         attach_paths=False,
         initial_point=None,
         include_compound=None,
-        max_attempts=1e5,
         seed=42,
         trial_batch_size=20,
         tolerance=1e-5,
@@ -261,9 +260,6 @@ class HardSphereRandomWalk(Path):
             The number of trial moves to attempt in parallel for each step.
             Using larger values can improve success rates for more dense
             random walks.
-        max_attempts : int, default = 1e5
-            The maximum number of trial moves to attempt before quiting.
-            for the random walk.
         tolerance : float, default = 1e-4
             Tolerance used for rounding and checking for overlaps.
 
@@ -295,7 +291,6 @@ class HardSphereRandomWalk(Path):
         self.volume_constraint = volume_constraint
         self.tolerance = tolerance
         self.trial_batch_size = int(trial_batch_size)
-        self.max_attempts = int(max_attempts)
         self.attempts = 0
         self.start_from_path_index = start_from_path_index
         self.start_from_path = start_from_path
@@ -440,12 +435,9 @@ class HardSphereRandomWalk(Path):
                 # 2nd point failed, continue while loop
                 self.attempts += 1
                 # TODO Use termination here
-                if self.attempts == self.max_attempts and self.count < self.chunk_size:
-                    raise RuntimeError(
-                        "The maximum number attempts allowed have passed, and only ",
-                        f"{self.count - self._init_count} sucsessful attempts were completed.",
-                        "Try changing the parameters or seed and running again.",
-                    )
+                if self.termination.is_met() and not self.termination.sucsessful:
+                    logger.warning("Random walk not successful.")
+                    logger.warning(self.termination.summarize())
 
         # Starting random walk from a previous set of coordinates (another path)
         # First point was accepted in self._initial_point with these conditions

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -510,7 +510,7 @@ class HardSphereRandomWalk(Path):
             # candidates didn't produce a single valid next point
             self.attempts += 1
             # Check if we've filled up the current chunk size, if so, extend.
-            if (self.count - self._init_count - 1) % self.chunk_size == 0:
+            if (self.count - self._init_count + 1) % self.chunk_size == 0:
                 self._extend_coordinates(N=self.chunk_size)
             walk_finished = self.termination.is_met()
 

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -357,14 +357,14 @@ class HardSphereRandomWalk(Path):
         self.check_path = check_path
 
         # Needed for WallTime stop criterion
-        self.start_time = 0
+        self.start_time = None
 
         super(HardSphereRandomWalk, self).__init__(
             coordinates=coordinates, N=N, bond_graph=bond_graph, bead_name=bead_name
         )
 
     def generate(self):
-        self.start_time = np.round(time.time(), 1)
+        self.start_time = time.time()
         # Set the first coordinate using method _initial_points()
         initial_xyz = self._initial_points()
         self.coordinates[self.count] = initial_xyz

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -515,7 +515,7 @@ class HardSphereRandomWalk(Path):
             walk_finished = self.termination.is_met()
 
         # Trim the final coordinates, removing any used in last chunk
-        self.coordinates = self.coordinates[:self.count + 1]
+        self.coordinates = self.coordinates[: self.count + 1]
 
     def current_walk_coordinates(self):
         """Return the coordinates from the current random walk only.

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -366,7 +366,7 @@ class HardSphereRandomWalk(Path):
         self.next_step = random_coordinate
         self.check_path = check_path
 
-        # Needed for WallTime stop criterion
+        # Needed for mbuild.path.termination.WallTime stop terminator
         self.start_time = None
 
         super().__init__(
@@ -374,7 +374,7 @@ class HardSphereRandomWalk(Path):
         )
 
     def generate(self):
-        # start time is needed for path.termination.WallTime
+        # start time is needed for mbuild.path.termination.WallTime
         self.start_time = time.time()
         # Set the first coordinate using method _initial_points()
         initial_xyz = self._initial_points()
@@ -440,7 +440,6 @@ class HardSphereRandomWalk(Path):
                     next_point_found = True
                 # 2nd point failed, continue while loop
                 self.attempts += 1
-                # TODO Use termination here
                 if self.termination.is_met() and not self.termination.sucsessful:
                     logger.warning("Random walk not successful.")
                     logger.warning(self.termination.summarize())
@@ -508,7 +507,7 @@ class HardSphereRandomWalk(Path):
                     self.bond_graph.add_node(self.count, name=self.bead_name, xyz=xyz)
                     self.add_edge(u=self.count - 1, v=self.count)
                     break
-            # candidates didn't produce a single valid next point
+            # Candidates didn't produce a single valid next point
             self.attempts += 1
             # Check if we've filled up the current chunk size, if so, extend.
             if (self.count - self._init_count + 1) % self.chunk_size == 0:

--- a/mbuild/path/path.py
+++ b/mbuild/path/path.py
@@ -1,6 +1,7 @@
 """Classes to generate intra-molecular paths and configurations."""
 
 import math
+import time
 from abc import abstractmethod
 from copy import deepcopy
 
@@ -355,11 +356,15 @@ class HardSphereRandomWalk(Path):
         self.next_step = random_coordinate
         self.check_path = check_path
 
+        # Needed for WallTime stop criterion
+        self.start_time = 0
+
         super(HardSphereRandomWalk, self).__init__(
             coordinates=coordinates, N=N, bond_graph=bond_graph, bead_name=bead_name
         )
 
     def generate(self):
+        self.start_time = np.round(time.time(), 1)
         # Set the first coordinate using method _initial_points()
         initial_xyz = self._initial_points()
         self.coordinates[self.count] = initial_xyz

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -92,7 +92,7 @@ class WithinCoordinate(Terminator):
 
 
 class FinalCoordinate(Terminator):
-    def __init__(self, taget_coordinate, tolerance=1e-3, required_to_end=True):
+    def __init__(self, target_coordinate, tolerance=1e-3, required_to_end=True):
         self.target_coordinate = np.asarray(target_coordinate)
         self.tolerance = tolerance
         super().__init__(required_to_end)

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -1,20 +1,42 @@
+"""Modular and composable rules for termination an mbuild.path.HardSphereRandomWalk."""
+
 import time
 
 import numpy as np
 
 
 class Termination:
+    """A modular and composable container for individual Terminator instances.
+    This class should be passed to mbuild.path.HardSphereRandomWalk to provide
+    instructions on when to end a random walk.
+
+    Parameters
+    ----------
+    terminators : list, required
+        A list-like object of mbuild.path.Terminator subclasses.
+        Each are checked after each step of a random walk.
+
+    Methods
+    -------
+    is_met(): Called internally in HardSphereRandomWalk.
+        Returns `True` in two cases:
+
+        1) Every `Terminator` instance with `is_target=True` is met.
+        2) Any `Terminator` instance with `is_target=False` is met.
+
+    summarize(): Prints a summary of all `Terminator` instances and thier status
+
+    """
+
     def __init__(self, terminators):
         if isinstance(terminators, Terminator):
             self.terminators = [terminators]
         else:
             self.terminators = list(terminators)
         # These must all be True to trigger termination
-        self.required_to_end = [i for i in self.terminators if i.required_to_end]
+        self.is_target = [i for i in self.terminators if i.is_target]
         # Don't need to be True, but are used as safe-guards (WallTime, NumAttempts)
-        self.not_required_to_end = [
-            i for i in self.terminators if not i.required_to_end
-        ]
+        self.not_is_target = [i for i in self.terminators if not i.is_target]
         # TODO, keep a list of triggered critera, add to logging when walk ends
         self.triggered = []
         self.success = False
@@ -26,10 +48,10 @@ class Termination:
 
     def is_met(self):
         # Check required criteria first
-        if all([i.is_met() for i in self.required_to_end]):
+        if all([i.is_met() for i in self.is_target]):
             self.success = True
             return True
-        if any([i.is_met() for i in self.not_required_to_end]):
+        if any([i.is_met() for i in self.not_is_target]):
             return True
         return False
 
@@ -43,17 +65,36 @@ class Termination:
         for term in self.terminators:
             name = term.__class__.__name__
             met = term.is_met()
-            role = "required" if term.required_to_end else "safeguard"
+            role = "required" if term.is_target else "safeguard"
             flag = "✓" if met else "✗"
             lines.append(f"[{flag}] {name} ({role})")
         return "\n".join(lines)
 
 
 class Terminator:
-    """"""
+    """Defines a single condition that can trigger a termination of a HardSphereRandomWalk.
 
-    def __init__(self, required_to_end):
-        self.required_to_end = required_to_end
+    Parameters
+    ----------
+    is_target : bool, required
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    Notes
+    -----
+    Multiple instances of `Terminator` can be passed to `Termination`. Target
+    terminators define completion goals (e.g., placing a fixed number of sites),
+    while non-target terminators act as safety limits when convergence is
+    unlikely (e.g., maximum attempts or total wall time).
+
+    """
+
+    def __init__(self, is_target):
+        self.is_target = is_target
 
     def _attach_path(self, path):
         self.path = path
@@ -65,27 +106,75 @@ class Terminator:
 
 
 class NumSites(Terminator):
-    def __init__(self, num_sites, required_to_end=True):
+    """A terminator that triggers after a certain number of successful steps.
+
+    Parameters
+    ----------
+    num_sites : int, required
+        The number of successful sites before triggering.
+    is_target : bool, default True
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    """
+
+    def __init__(self, num_sites, is_target=True):
         self.num_sites = num_sites
-        super().__init__(required_to_end)
+        super().__init__(is_target)
 
     def is_met(self):
         return self.path.count - self.path._init_count >= self.num_sites - 1
 
 
 class NumAttempts(Terminator):
-    def __init__(self, max_attempts, required_to_end=False):
+    """A terminator that triggers after a certain number of total attempts.
+
+    Parameters
+    ----------
+    max_attempts : int, required
+        The number of attempts (successful or not) before triggering.
+    is_target : bool, default False
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    """
+
+    def __init__(self, max_attempts, is_target=False):
         self.max_attempts = int(max_attempts)
-        super().__init__(required_to_end)
+        super().__init__(is_target)
 
     def is_met(self):
         return self.path.attempts >= self.max_attempts
 
 
 class WallTime(Terminator):
-    def __init__(self, max_time, required_to_end=False):
+    """A terminator that triggers after a certain total time (seconds) as ellapsed.
+
+    Parameters
+    ----------
+    max_time : int, required
+        The total amount of time (seconds) allowed to ellapse before triggering.
+    is_target : bool, default False
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    """
+
+    def __init__(self, max_time, is_target=False):
         self.max_time = max_time
-        super().__init__(required_to_end)
+        super().__init__(is_target)
 
     def is_met(self):
         current_time = time.time()
@@ -94,13 +183,29 @@ class WallTime(Terminator):
 
 
 class WithinCoordinate(Terminator):
-    def __init__(
-        self, target_coordinate, distance, tolerance=1e-3, required_to_end=True
-    ):
+    """A terminator that triggers after a successful step is within a cutoff distance to a target coordinate.
+
+    Parameters
+    ----------
+    target_coordinate : array-like (n,3), required
+        The target coordinate in units of nm.
+    distance : float, required
+        A cutoff distance (nm) from the target coordinate.
+    is_target : bool, default True
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    """
+
+    def __init__(self, target_coordinate, distance, tolerance=1e-3, is_target=True):
         self.distance = float(distance)
         self.target_coordinate = np.asarray(target_coordinate)
         self.tolerance = tolerance
-        super().__init__(required_to_end)
+        super().__init__(is_target)
 
     def is_met(self):
         last_site = self.path.coordinates[self.path.count]
@@ -109,21 +214,57 @@ class WithinCoordinate(Terminator):
 
 
 class PairDistance(Terminator):
-    def __init__(self, distance, pair_type=None, required_to_end=True):
+    """A terminator that triggers after a successful step is within a cutoff distance to a certain site type.
+
+    Parameters
+    ----------
+    pair_type : str or list of str, required
+        The name of the site type(s) to consider in distance calculations
+    distance : float, required
+        A cutoff distance (nm) from the target sites.
+    is_target : bool, default True
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    """
+
+    def __init__(self, distance, pair_type=None, is_target=True):
         self.distance = float(distance)
         self.pair_type = pair_type
-        super().__init__(required_to_end)
+        super().__init__(is_target)
 
     def is_met(self):
         raise NotImplementedError
 
 
 class RadiusOfGyration(Terminator):
-    def __init__(self, radius_of_gyration, tolerance=0.01, required_to_end=True):
+    """A terminator that triggers after reaching a target radius of gyration.
+
+    Parameters
+    ----------
+    radius_of_gyration : float, required
+        The target radius of gyration in units of nm.
+    tolerance : float, default 0.01
+        The allowable tolerance relative to the target. In units of nm.
+    is_target : bool, default True
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    """
+
+    def __init__(self, radius_of_gyration, tolerance=0.01, is_target=True):
         self.radius_of_gyration = float(radius_of_gyration)
         self.tolerance = tolerance
         self.rg2 = (radius_of_gyration + tolerance) ** 2
-        super().__init__(required_to_end)
+        super().__init__(is_target)
 
     def is_met(self):
         # Enforce at least 3 sites
@@ -138,10 +279,28 @@ class RadiusOfGyration(Terminator):
 
 
 class EndToEndDistance(Terminator):
-    def __init__(self, distance, tolerance=0.01, required_to_end=True):
+    """A terminator that triggers after reaching a target end-to-end distance.
+
+    Parameters
+    ----------
+    distance : float, required
+        The target end-to-end distance in units of nm.
+    tolerance : float, default 0.01
+        The allowable tolerance relative to the target. In units of nm.
+    is_target : bool, default True
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    """
+
+    def __init__(self, distance, tolerance=0.01, is_target=True):
         self.distance = float(distance)
         self.tolerance = tolerance
-        super().__init__(required_to_end)
+        super().__init__(is_target)
 
     def is_met(self):
         # Enforce at least 3 sites

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -46,6 +46,11 @@ class Termination:
         for i in self.terminators:
             i._attach_path(path)
 
+    def _clean(self):
+        """This is automatically called within HardSphereRandomWalk."""
+        for i in self.terminators:
+            i.path = None
+
     def is_met(self):
         # Check required criteria first
         if all([i.is_met() for i in self.is_target]):

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -242,14 +242,14 @@ class PairDistance(Terminator):
 
 
 class RadiusOfGyration(Terminator):
-    """A terminator that triggers after reaching a target radius of gyration.
+    """A terminator that triggers after reaching a target square radius of gyration.
 
     Parameters
     ----------
     radius_of_gyration : float, required
-        The target radius of gyration in units of nm.
+        The target square radius of gyration (Rg^2) in units of nm^2.
     tolerance : float, default 0.01
-        The allowable tolerance relative to the target. In units of nm.
+        The allowable tolerance relative to the target. In units of nm^2.
     is_target : bool, default True
         If `True`, this terminator represents a target condition that the walk
         is attempting to reach. Triggering a target condition indicates
@@ -261,9 +261,8 @@ class RadiusOfGyration(Terminator):
     """
 
     def __init__(self, radius_of_gyration, tolerance=0.01, is_target=True):
-        self.radius_of_gyration = float(radius_of_gyration)
+        self.rg = float(radius_of_gyration)
         self.tolerance = tolerance
-        self.rg2 = (radius_of_gyration + tolerance) ** 2
         super().__init__(is_target)
 
     def is_met(self):
@@ -275,7 +274,7 @@ class RadiusOfGyration(Terminator):
         center = coords.mean(axis=0)
         diffs = coords - center
         rg2 = np.mean(np.sum(diffs * diffs, axis=1))
-        return self.rg2 - self.tolerance <= rg2 <= self.rg2 + self.tolerance
+        return self.rg - self.tolerance <= rg2 <= self.rg + self.tolerance
 
 
 class EndToEndDistance(Terminator):

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -9,7 +9,9 @@ class Termination:
         # These must all be True to trigger termination
         self.required_to_end = [i for i in self.terminators if i.required_to_end]
         # Don't need to be True, but are used as safe-guards (WallTime, NumAttempts)
-        self.not_required_to_end = [i for i in self.terminators if not i.required_to_end]
+        self.not_required_to_end = [
+            i for i in self.terminators if not i.required_to_end
+        ]
         # TODO, keep a list of triggered critera, add to logging when walk ends
         self.triggered = []
 

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -282,6 +282,40 @@ class RadiusOfGyration(Terminator):
         return self.rg - self.tolerance <= rg2 <= self.rg + self.tolerance
 
 
+class ContourLength(Terminator):
+    """A terminator that triggers after reaching a maximum contour length.
+
+    Parameters
+    ----------
+    length : float, required
+        The target contour length in units of nm.
+    tolerance : float, default 0.01
+        The allowable tolerance relative to the target. In units of nm.
+    is_target : bool, default True
+        If `True`, this terminator represents a target condition that the walk
+        is attempting to reach. Triggering a target condition indicates
+        successful completion of the walk. If `False`, the terminator represents
+        a safeguard that limits execution (e.g., maximum attempts or wall time);
+        triggering a safeguard causes the walk to stop without being considered
+        successful.
+
+    """
+
+    def __init__(self, length, tolerance=0.01, is_target=True):
+        self.length = float(length)
+        self.tolerance = tolerance
+        super().__init__(is_target)
+
+    def is_met(self):
+        # Enforce at least 3 sites
+        n = self.path.count - self.path._init_count + 1
+        return (
+            self.length - self.tolerance
+            <= n * self.path.bond_length
+            <= self.length + self.tolerance
+        )
+
+
 class EndToEndDistance(Terminator):
     """A terminator that triggers after reaching a target end-to-end distance.
 

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -91,17 +91,6 @@ class WithinCoordinate(Terminator):
         return current_distance <= self.distance + self.tolerance
 
 
-class FinalCoordinate(Terminator):
-    def __init__(self, target_coordinate, tolerance=1e-3, required_to_end=True):
-        self.target_coordinate = np.asarray(target_coordinate)
-        self.tolerance = tolerance
-        super().__init__(required_to_end)
-
-    def is_met(self):
-        last_site = self.path.coordinates[self.path.count]
-        return np.linalg.norm(self.target_coordinate - last_site) <= self.tolerance
-
-
 class PairDistance(Terminator):
     def __init__(self, distance, pair_type=None, required_to_end=True):
         self.distance = float(distance)

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -17,6 +17,7 @@ class Termination:
         ]
         # TODO, keep a list of triggered critera, add to logging when walk ends
         self.triggered = []
+        self.success = False
 
     def _attach_path(self, path):
         """This is automatically called within HardSphereRandomWalk."""
@@ -26,10 +27,26 @@ class Termination:
     def is_met(self):
         # Check required criteria first
         if all([i.is_met() for i in self.required_to_end]):
+            self.success = True
             return True
         if any([i.is_met() for i in self.not_required_to_end]):
             return True
         return False
+
+    def summarize(self):
+        """Print a quick summary of termination status."""
+        lines = []
+        status = "SUCCESS" if self.success else "ABORTED"
+        lines.append(f"Termination status: {status}")
+        lines.append("")
+
+        for term in self.terminators:
+            name = term.__class__.__name__
+            met = term.is_met()
+            role = "required" if term.required_to_end else "safeguard"
+            flag = "✓" if met else "✗"
+            lines.append(f"[{flag}] {name} ({role})")
+        return "\n".join(lines)
 
 
 class Terminator:

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -119,10 +119,10 @@ class PairDistance(Terminator):
 
 
 class RadiusOfGyration(Terminator):
-    def __init__(self, radius_of_gyration, tolerance=1e-2, required_to_end=True):
+    def __init__(self, radius_of_gyration, tolerance=0.01, required_to_end=True):
         self.radius_of_gyration = float(radius_of_gyration)
         self.tolerance = tolerance
-        self.max_rg2 = (radius_of_gyration + tolerance) ** 2
+        self.rg2 = (radius_of_gyration + tolerance) ** 2
         super().__init__(required_to_end)
 
     def is_met(self):
@@ -134,11 +134,11 @@ class RadiusOfGyration(Terminator):
         center = coords.mean(axis=0)
         diffs = coords - center
         rg2 = np.mean(np.sum(diffs * diffs, axis=1))
-        return rg2 >= self.max_rg2
+        return self.rg2 - self.tolerance <= rg2 <= self.rg2 + self.tolerance
 
 
 class EndToEndDistance(Terminator):
-    def __init__(self, distance, tolerance=1e-2, required_to_end=True):
+    def __init__(self, distance, tolerance=0.01, required_to_end=True):
         self.distance = float(distance)
         self.tolerance = tolerance
         super().__init__(required_to_end)
@@ -150,4 +150,8 @@ class EndToEndDistance(Terminator):
             return False
         first_site = self.path.coordinates[self.path._init_count]
         last_site = self.path.coordinates[self.path.count]
-        return np.linalg.norm(last_site - first_site) >= self.distance - self.tolerance
+        return (
+            self.distance - self.tolerance
+            <= np.linalg.norm(last_site - first_site)
+            <= self.distance + self.tolerance
+        )

--- a/mbuild/tests/base_test.py
+++ b/mbuild/tests/base_test.py
@@ -7,12 +7,12 @@ from mbuild.utils.io import get_fn
 
 
 def radius_of_gyration(coordinates):
-    """Calculate the radius of gyration for a set of coordinates using the geometric center."""
+    """Calculate the square radius of gyration for a set of coordinates using the geometric center."""
     coordinates = np.array(coordinates)
     geometric_center = np.mean(coordinates, axis=0)
     squared_distances = np.sum((coordinates - geometric_center) ** 2, axis=1)
-    rg = np.sqrt(np.mean(squared_distances))
-    return rg
+    rg2 = np.mean(squared_distances)
+    return rg2
 
 
 class BaseTest:

--- a/mbuild/tests/base_test.py
+++ b/mbuild/tests/base_test.py
@@ -6,6 +6,15 @@ from mbuild.utils.geometry import calc_dihedral
 from mbuild.utils.io import get_fn
 
 
+def radius_of_gyration(coordinates):
+    """Calculate the radius of gyration for a set of coordinates using the geometric center."""
+    coordinates = np.array(coordinates)
+    geometric_center = np.mean(coordinates, axis=0)
+    squared_distances = np.sum((coordinates - geometric_center) ** 2, axis=1)
+    rg = np.sqrt(np.mean(squared_distances))
+    return rg
+
+
 class BaseTest:
     @pytest.fixture(autouse=True)
     def initdir(self, tmpdir):

--- a/mbuild/tests/test_bias.py
+++ b/mbuild/tests/test_bias.py
@@ -34,7 +34,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         dist_to_target = np.linalg.norm(rw_path.coordinates[-1] - np.array([3, 3, 3]))
@@ -46,7 +45,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         dist_to_target_biased = np.linalg.norm(
@@ -63,7 +61,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         dist_to_target = np.linalg.norm(rw_path.coordinates[-1] - np.array([3, 3, 3]))
@@ -75,7 +72,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         dist_to_target_biased = np.linalg.norm(
@@ -96,7 +92,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         rw_path_avoid = HardSphereRandomWalk(
@@ -108,7 +103,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         assert radius_of_gyration(rw_path_target.coordinates) < radius_of_gyration(
@@ -125,7 +119,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         head_tail_vec = rw_path.coordinates[-1] - rw_path.coordinates[0]
@@ -138,7 +131,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         head_tail_vec_target = (
@@ -153,7 +145,6 @@ class TestBias(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         head_tail_vec_avoid = (

--- a/mbuild/tests/test_bias.py
+++ b/mbuild/tests/test_bias.py
@@ -11,16 +11,7 @@ from mbuild.path.bias import (
     TargetType,
 )
 from mbuild.path.termination import NumAttempts, NumSites, Termination
-from mbuild.tests.base_test import BaseTest
-
-
-def radius_of_gyration(coordinates):
-    """Calculate the radius of gyration for a set of coordinates using the geometric center."""
-    coordinates = np.array(coordinates)
-    geometric_center = np.mean(coordinates, axis=0)
-    squared_distances = np.sum((coordinates - geometric_center) ** 2, axis=1)
-    rg = np.sqrt(np.mean(squared_distances))
-    return rg
+from mbuild.tests.base_test import BaseTest, radius_of_gyration
 
 
 class TestBias(BaseTest):
@@ -37,7 +28,6 @@ class TestBias(BaseTest):
     def test_target_coordinate(self):
         bias = TargetCoordinate(target_coordinate=(3, 3, 3), weight=1.0)
         rw_path = HardSphereRandomWalk(
-            N=15,
             termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             initial_point=(0, 0, 0),
@@ -49,7 +39,6 @@ class TestBias(BaseTest):
         )
         dist_to_target = np.linalg.norm(rw_path.coordinates[-1] - np.array([3, 3, 3]))
         rw_path_biased = HardSphereRandomWalk(
-            N=15,
             termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=bias,
@@ -68,7 +57,6 @@ class TestBias(BaseTest):
     def test_avoid_coordinate(self):
         bias = AvoidCoordinate(avoid_coordinate=(3, 3, 3), weight=1.0)
         rw_path = HardSphereRandomWalk(
-            N=15,
             termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             initial_point=(0, 0, 0),
@@ -80,7 +68,6 @@ class TestBias(BaseTest):
         )
         dist_to_target = np.linalg.norm(rw_path.coordinates[-1] - np.array([3, 3, 3]))
         rw_path_biased = HardSphereRandomWalk(
-            N=15,
             termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=bias,
@@ -101,7 +88,6 @@ class TestBias(BaseTest):
         avoid_bias = AvoidType(avoid_type="A", weight=0.6, r_cut=2)
 
         rw_path_target = HardSphereRandomWalk(
-            N=50,
             termination=Termination([NumSites(50), NumAttempts(1e4)]),
             bias=target_bias,
             bond_length=0.25,
@@ -114,7 +100,6 @@ class TestBias(BaseTest):
             seed=14,
         )
         rw_path_avoid = HardSphereRandomWalk(
-            N=50,
             termination=Termination([NumSites(50), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=avoid_bias,
@@ -134,7 +119,6 @@ class TestBias(BaseTest):
         target_bias = TargetDirection(direction=(1, 0, 0), weight=0.7)
         avoid_bias = AvoidDirection(direction=(1, 0, 0), weight=0.7)
         rw_path = HardSphereRandomWalk(
-            N=15,
             termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             initial_point=(0, 0, 0),
@@ -147,7 +131,6 @@ class TestBias(BaseTest):
         head_tail_vec = rw_path.coordinates[-1] - rw_path.coordinates[0]
 
         rw_path_target = HardSphereRandomWalk(
-            N=15,
             termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=target_bias,
@@ -163,7 +146,6 @@ class TestBias(BaseTest):
         )
 
         rw_path_avoid = HardSphereRandomWalk(
-            N=15,
             termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=avoid_bias,

--- a/mbuild/tests/test_bias.py
+++ b/mbuild/tests/test_bias.py
@@ -10,6 +10,7 @@ from mbuild.path.bias import (
     TargetDirection,
     TargetType,
 )
+from mbuild.path.termination import NumAttempts, NumSites, Termination
 from mbuild.tests.base_test import BaseTest
 
 
@@ -37,6 +38,7 @@ class TestBias(BaseTest):
         bias = TargetCoordinate(target_coordinate=(3, 3, 3), weight=1.0)
         rw_path = HardSphereRandomWalk(
             N=15,
+            termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             initial_point=(0, 0, 0),
             radius=0.22,
@@ -48,6 +50,7 @@ class TestBias(BaseTest):
         dist_to_target = np.linalg.norm(rw_path.coordinates[-1] - np.array([3, 3, 3]))
         rw_path_biased = HardSphereRandomWalk(
             N=15,
+            termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=bias,
             initial_point=(0, 0, 0),
@@ -66,6 +69,7 @@ class TestBias(BaseTest):
         bias = AvoidCoordinate(avoid_coordinate=(3, 3, 3), weight=1.0)
         rw_path = HardSphereRandomWalk(
             N=15,
+            termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             initial_point=(0, 0, 0),
             radius=0.22,
@@ -77,6 +81,7 @@ class TestBias(BaseTest):
         dist_to_target = np.linalg.norm(rw_path.coordinates[-1] - np.array([3, 3, 3]))
         rw_path_biased = HardSphereRandomWalk(
             N=15,
+            termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=bias,
             initial_point=(0, 0, 0),
@@ -97,6 +102,7 @@ class TestBias(BaseTest):
 
         rw_path_target = HardSphereRandomWalk(
             N=50,
+            termination=Termination([NumSites(50), NumAttempts(1e4)]),
             bias=target_bias,
             bond_length=0.25,
             initial_point=(0, 0, 0),
@@ -109,6 +115,7 @@ class TestBias(BaseTest):
         )
         rw_path_avoid = HardSphereRandomWalk(
             N=50,
+            termination=Termination([NumSites(50), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=avoid_bias,
             initial_point=(0, 0, 0),
@@ -128,6 +135,7 @@ class TestBias(BaseTest):
         avoid_bias = AvoidDirection(direction=(1, 0, 0), weight=0.7)
         rw_path = HardSphereRandomWalk(
             N=15,
+            termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             initial_point=(0, 0, 0),
             radius=0.22,
@@ -140,6 +148,7 @@ class TestBias(BaseTest):
 
         rw_path_target = HardSphereRandomWalk(
             N=15,
+            termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=target_bias,
             initial_point=(0, 0, 0),
@@ -155,6 +164,7 @@ class TestBias(BaseTest):
 
         rw_path_avoid = HardSphereRandomWalk(
             N=15,
+            termination=Termination([NumSites(15), NumAttempts(1e4)]),
             bond_length=0.25,
             bias=avoid_bias,
             initial_point=(0, 0, 0),

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -17,7 +17,7 @@ from mbuild.path.path_utils import (
     target_density,
     target_sq_distances,
 )
-from mbuild.path.termination import Termination, NumSites
+from mbuild.path.termination import NumSites, Termination
 from mbuild.tests.base_test import BaseTest
 from mbuild.utils.geometry import bounding_box
 from mbuild.utils.volumes import (

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -20,9 +20,10 @@ from mbuild.path.path_utils import (
 from mbuild.path.termination import (
     NumAttempts,
     NumSites,
+    RadiusOfGyration,
     Termination,
 )
-from mbuild.tests.base_test import BaseTest
+from mbuild.tests.base_test import BaseTest, radius_of_gyration
 from mbuild.utils.geometry import bounding_box
 from mbuild.utils.volumes import (
     CuboidConstraint,
@@ -124,7 +125,6 @@ class TestRandomWalk(BaseTest):
     def test_no_termination(self):
         with pytest.raises(RuntimeError):
             HardSphereRandomWalk(
-                N=20,
                 termination=None,
                 bond_length=0.25,
                 radius=0.22,
@@ -134,11 +134,26 @@ class TestRandomWalk(BaseTest):
                 seed=14,
             )
 
+    def test_rg_termination(self):
+        num_sites = NumSites(20)
+        rg = RadiusOfGyration(3)
+        max_attempts = NumAttempts(1e4)
+        termination = Termination([num_sites, rg, max_attempts])
+        rw_path = HardSphereRandomWalk(
+            termination=termination,
+            bond_length=0.25,
+            radius=0.22,
+            min_angle=np.pi / 4,
+            max_angle=np.pi,
+            max_attempts=1e4,
+            seed=14,
+        )
+        assert np.allclose(radius_of_gyration(rw_path.coordinates), 3, atol=1e-1)
+
     def test_random_walk(self):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         rw_path = HardSphereRandomWalk(
-            N=20,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -160,7 +175,6 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         rw_path = HardSphereRandomWalk(
-            N=20,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -176,7 +190,6 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         rw_path_1 = HardSphereRandomWalk(
-            N=20,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -186,7 +199,6 @@ class TestRandomWalk(BaseTest):
             seed=14,
         )
         rw_path_2 = HardSphereRandomWalk(
-            N=20,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -201,7 +213,6 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         rw_path = HardSphereRandomWalk(
-            N=20,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -211,7 +222,6 @@ class TestRandomWalk(BaseTest):
             seed=14,
         )
         rw_path2 = HardSphereRandomWalk(
-            N=20,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -230,7 +240,6 @@ class TestRandomWalk(BaseTest):
     def test_walk_inside_cube(self):
         cube = CuboidConstraint(Lx=5, Ly=5, Lz=5)
         rw_path = HardSphereRandomWalk(
-            N=500,
             termination=Termination([NumSites(500), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
@@ -246,7 +255,6 @@ class TestRandomWalk(BaseTest):
     def test_walk_inside_cube_with_pbc(self):
         # First make sure this seed gives a path outside these bounds without PBC
         rw_path = HardSphereRandomWalk(
-            N=500,
             termination=Termination([NumSites(500), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
@@ -262,7 +270,6 @@ class TestRandomWalk(BaseTest):
 
         cube = CuboidConstraint(Lx=5, Ly=5, Lz=5, pbc=(True, True, True))
         rw_path = HardSphereRandomWalk(
-            N=500,
             termination=Termination([NumSites(500), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
@@ -279,7 +286,6 @@ class TestRandomWalk(BaseTest):
     def test_walk_inside_sphere(self):
         sphere = SphereConstraint(radius=4, center=(2, 2, 2))
         rw_path = HardSphereRandomWalk(
-            N=200,
             termination=Termination([NumSites(200), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
@@ -296,7 +302,6 @@ class TestRandomWalk(BaseTest):
     def test_walk_inside_cylinder(self):
         cylinder = CylinderConstraint(radius=3, height=6, center=(0, 0, 0))
         rw_path = HardSphereRandomWalk(
-            N=200,
             termination=Termination([NumSites(200), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -304,7 +304,7 @@ class TestRandomWalk(BaseTest):
         )
         assert len(rw_path.coordinates) == 20
         assert len(rw_path2.coordinates) == 40
-        for coord1, coord2 in zip(rw_path.coordinates[:10], rw_path2.coordinates[:10]):
+        for coord1, coord2 in zip(rw_path.coordinates[:20], rw_path2.coordinates[:20]):
             assert np.allclose(coord1, coord2, atol=1e-6)
 
     def test_walk_inside_cube(self):

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -119,6 +119,34 @@ class TestPaths(BaseTest):
         assert Lx == Lz  # stacking and layering directions
         assert Ly > Lx
 
+    def test_lamellar_direction(self):
+        path_left_to_right = Lamellar(
+            bond_length=0.25,
+            num_layers=3,
+            layer_separation=1.0,
+            layer_length=3.0,
+            num_stacks=3,
+            stack_separation=1.0,
+            initial_point=(0, 0, 0),
+        )
+
+        path_right_to_left = Lamellar(
+            bond_length=0.25,
+            num_layers=3,
+            layer_separation=1.0,
+            layer_length=3.0,
+            num_stacks=3,
+            stack_separation=1.0,
+            initial_point=(0, 0, 0),
+            left_to_right=False,
+        )
+
+        assert np.array_equal(
+            path_left_to_right.coordinates[0], path_right_to_left.coordinates[0]
+        )
+        assert path_right_to_left.coordinates[1][1] < 0
+        assert path_left_to_right.coordinates[1][1] > 0
+
     def test_lamellar_initial_point(self):
         path = Lamellar(
             bond_length=0.25,

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -12,21 +12,17 @@ from mbuild.path import (
     Spiral2D,
     StraightLine,
 )
-from mbuild.path.bias import TargetCoordinate
 from mbuild.path.path_utils import (
     local_density,
     target_density,
     target_sq_distances,
 )
 from mbuild.path.termination import (
-    EndToEndDistance,
     NumAttempts,
     NumSites,
-    RadiusOfGyration,
     Termination,
-    WithinCoordinate,
 )
-from mbuild.tests.base_test import BaseTest, radius_of_gyration
+from mbuild.tests.base_test import BaseTest
 from mbuild.utils.geometry import bounding_box
 from mbuild.utils.volumes import (
     CuboidConstraint,
@@ -125,93 +121,6 @@ class TestPaths(BaseTest):
 
 
 class TestRandomWalk(BaseTest):
-    def test_no_termination(self):
-        with pytest.raises(RuntimeError):
-            HardSphereRandomWalk(
-                termination=None,
-                bond_length=0.25,
-                radius=0.22,
-                min_angle=np.pi / 4,
-                max_angle=np.pi,
-                seed=14,
-            )
-
-    def test_rg_termination(self):
-        num_sites = NumSites(20)
-        rg = RadiusOfGyration(3)
-        max_attempts = NumAttempts(1e4)
-        termination = Termination([num_sites, rg, max_attempts])
-        rw_path = HardSphereRandomWalk(
-            termination=termination,
-            bond_length=0.25,
-            radius=0.22,
-            min_angle=np.pi / 4,
-            max_angle=np.pi,
-            seed=14,
-        )
-        assert np.allclose(radius_of_gyration(rw_path.coordinates), 3, atol=1e-1)
-
-    def test_re_termination(self):
-        num_sites = NumSites(20)
-        re = EndToEndDistance(2)
-        max_attempts = NumAttempts(1e4)
-        termination = Termination([num_sites, re, max_attempts])
-        rw_path = HardSphereRandomWalk(
-            termination=termination,
-            bond_length=0.25,
-            radius=0.22,
-            min_angle=np.pi / 4,
-            max_angle=np.pi,
-            seed=14,
-        )
-        dist = np.linalg.norm(rw_path.coordinates[-1] - rw_path.coordinates[0])
-        assert np.allclose(dist, 2, atol=1e-1)
-
-    def test_within_coord_termination(self):
-        bias = TargetCoordinate(target_coordinate=(2, 2, 2), weight=0.8)
-        termination = Termination(
-            [
-                WithinCoordinate(target_coordinate=(2, 2, 2), distance=0.22),
-                NumAttempts(1e3),
-            ]
-        )
-        rw_path = HardSphereRandomWalk(
-            termination=termination,
-            bias=bias,
-            initial_point=(0, 0, 0),
-            bond_length=0.25,
-            radius=0.22,
-            min_angle=np.pi / 4,
-            max_angle=np.pi,
-            trial_batch_size=100,
-            seed=14,
-        )
-        dist = np.linalg.norm(rw_path.coordinates[-1] - np.array([2, 2, 2]))
-        assert dist <= 0.22
-
-        termination = Termination(
-            [
-                WithinCoordinate(
-                    target_coordinate=(3, 3, 3), distance=0.0, tolerance=1e-1
-                ),
-                NumAttempts(100),
-            ]
-        )
-        bias = TargetCoordinate(target_coordinate=(3, 3, 3), weight=1.0)
-        rw_path = HardSphereRandomWalk(
-            termination=termination,
-            bias=bias,
-            initial_point=(0, 0, 0),
-            bond_length=0.25,
-            radius=0.22,
-            min_angle=np.pi / 4,
-            max_angle=np.pi,
-            trial_batch_size=200,
-            seed=14,
-        )
-        dist = np.linalg.norm(rw_path.coordinates[-1] - np.array([3, 3, 3]))
-        assert np.allclose(dist, 0, atol=1e-1)
-
     def test_extend_coordinates(self):
         num_sites = NumSites(80)
         max_attempts = NumAttempts(1e4)

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -17,6 +17,7 @@ from mbuild.path.path_utils import (
     target_density,
     target_sq_distances,
 )
+from mbuild.path.termination import Termination, NumSites
 from mbuild.tests.base_test import BaseTest
 from mbuild.utils.geometry import bounding_box
 from mbuild.utils.volumes import (
@@ -117,8 +118,10 @@ class TestPaths(BaseTest):
 
 class TestRandomWalk(BaseTest):
     def test_random_walk(self):
+        num_sites = NumSites(20)
         rw_path = HardSphereRandomWalk(
             N=20,
+            termination=Termination(num_sites),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -136,8 +139,10 @@ class TestRandomWalk(BaseTest):
         assert np.all(rw_path.coordinates[0]) < 20 * 0.22
 
     def test_set_initial_point(self):
+        num_sites = NumSites(20)
         rw_path = HardSphereRandomWalk(
             N=20,
+            termination=Termination(num_sites),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -149,8 +154,10 @@ class TestRandomWalk(BaseTest):
         assert np.array_equal(rw_path.coordinates[0], np.array([1, 2, 3]))
 
     def test_seeds(self):
+        num_sites = NumSites(20)
         rw_path_1 = HardSphereRandomWalk(
             N=20,
+            termination=Termination(num_sites),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -160,6 +167,7 @@ class TestRandomWalk(BaseTest):
         )
         rw_path_2 = HardSphereRandomWalk(
             N=20,
+            termination=Termination(num_sites),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -170,8 +178,10 @@ class TestRandomWalk(BaseTest):
         assert np.allclose(rw_path_1.coordinates, rw_path_2.coordinates, atol=1e-7)
 
     def test_from_path(self):
+        num_sites = NumSites(20)
         rw_path = HardSphereRandomWalk(
             N=20,
+            termination=Termination(num_sites),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -181,6 +191,7 @@ class TestRandomWalk(BaseTest):
         )
         rw_path2 = HardSphereRandomWalk(
             N=20,
+            termination=Termination(num_sites),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -199,6 +210,7 @@ class TestRandomWalk(BaseTest):
         cube = CuboidConstraint(Lx=5, Ly=5, Lz=5)
         rw_path = HardSphereRandomWalk(
             N=500,
+            termination=Termination(NumSites(500)),
             bond_length=0.25,
             radius=0.22,
             volume_constraint=cube,
@@ -214,6 +226,7 @@ class TestRandomWalk(BaseTest):
         # First make sure this seed gives a path outside these bounds without PBC
         rw_path = HardSphereRandomWalk(
             N=500,
+            termination=Termination(NumSites(500)),
             bond_length=0.25,
             radius=0.22,
             initial_point=(0, 0, 0),
@@ -229,6 +242,7 @@ class TestRandomWalk(BaseTest):
         cube = CuboidConstraint(Lx=5, Ly=5, Lz=5, pbc=(True, True, True))
         rw_path = HardSphereRandomWalk(
             N=500,
+            termination=Termination(NumSites(500)),
             bond_length=0.25,
             radius=0.22,
             initial_point=(0, 0, 0),
@@ -245,6 +259,7 @@ class TestRandomWalk(BaseTest):
         sphere = SphereConstraint(radius=4, center=(2, 2, 2))
         rw_path = HardSphereRandomWalk(
             N=200,
+            termination=Termination(NumSites(200)),
             bond_length=0.25,
             radius=0.22,
             volume_constraint=sphere,
@@ -261,6 +276,7 @@ class TestRandomWalk(BaseTest):
         cylinder = CylinderConstraint(radius=3, height=6, center=(0, 0, 0))
         rw_path = HardSphereRandomWalk(
             N=200,
+            termination=Termination(NumSites(200)),
             bond_length=0.25,
             radius=0.22,
             volume_constraint=cylinder,

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -17,7 +17,12 @@ from mbuild.path.path_utils import (
     target_density,
     target_sq_distances,
 )
-from mbuild.path.termination import NumSites, Termination
+from mbuild.path.termination import (
+    NumSites,
+    WallTime,
+    NumAttempts,
+    Termination,
+)
 from mbuild.tests.base_test import BaseTest
 from mbuild.utils.geometry import bounding_box
 from mbuild.utils.volumes import (
@@ -117,11 +122,25 @@ class TestPaths(BaseTest):
 
 
 class TestRandomWalk(BaseTest):
+    def test_no_termination(self):
+        with pytest.raises(RuntimeError):
+            HardSphereRandomWalk(
+                N=20,
+                termination=None,
+                bond_length=0.25,
+                radius=0.22,
+                min_angle=np.pi / 4,
+                max_angle=np.pi,
+                max_attempts=1e4,
+                seed=14,
+            )
+
     def test_random_walk(self):
         num_sites = NumSites(20)
+        max_attempts = NumAttempts(1e4)
         rw_path = HardSphereRandomWalk(
             N=20,
-            termination=Termination(num_sites),
+            termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -140,9 +159,10 @@ class TestRandomWalk(BaseTest):
 
     def test_set_initial_point(self):
         num_sites = NumSites(20)
+        max_attempts = NumAttempts(1e4)
         rw_path = HardSphereRandomWalk(
             N=20,
-            termination=Termination(num_sites),
+            termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -155,9 +175,10 @@ class TestRandomWalk(BaseTest):
 
     def test_seeds(self):
         num_sites = NumSites(20)
+        max_attempts = NumAttempts(1e4)
         rw_path_1 = HardSphereRandomWalk(
             N=20,
-            termination=Termination(num_sites),
+            termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -167,7 +188,7 @@ class TestRandomWalk(BaseTest):
         )
         rw_path_2 = HardSphereRandomWalk(
             N=20,
-            termination=Termination(num_sites),
+            termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -179,9 +200,10 @@ class TestRandomWalk(BaseTest):
 
     def test_from_path(self):
         num_sites = NumSites(20)
+        max_attempts = NumAttempts(1e4)
         rw_path = HardSphereRandomWalk(
             N=20,
-            termination=Termination(num_sites),
+            termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -191,7 +213,7 @@ class TestRandomWalk(BaseTest):
         )
         rw_path2 = HardSphereRandomWalk(
             N=20,
-            termination=Termination(num_sites),
+            termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 4,
@@ -210,7 +232,7 @@ class TestRandomWalk(BaseTest):
         cube = CuboidConstraint(Lx=5, Ly=5, Lz=5)
         rw_path = HardSphereRandomWalk(
             N=500,
-            termination=Termination(NumSites(500)),
+            termination=Termination([NumSites(500), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
             volume_constraint=cube,
@@ -226,7 +248,7 @@ class TestRandomWalk(BaseTest):
         # First make sure this seed gives a path outside these bounds without PBC
         rw_path = HardSphereRandomWalk(
             N=500,
-            termination=Termination(NumSites(500)),
+            termination=Termination([NumSites(500), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
             initial_point=(0, 0, 0),
@@ -242,7 +264,7 @@ class TestRandomWalk(BaseTest):
         cube = CuboidConstraint(Lx=5, Ly=5, Lz=5, pbc=(True, True, True))
         rw_path = HardSphereRandomWalk(
             N=500,
-            termination=Termination(NumSites(500)),
+            termination=Termination([NumSites(500), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
             initial_point=(0, 0, 0),
@@ -259,7 +281,7 @@ class TestRandomWalk(BaseTest):
         sphere = SphereConstraint(radius=4, center=(2, 2, 2))
         rw_path = HardSphereRandomWalk(
             N=200,
-            termination=Termination(NumSites(200)),
+            termination=Termination([NumSites(200), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
             volume_constraint=sphere,
@@ -276,7 +298,7 @@ class TestRandomWalk(BaseTest):
         cylinder = CylinderConstraint(radius=3, height=6, center=(0, 0, 0))
         rw_path = HardSphereRandomWalk(
             N=200,
-            termination=Termination(NumSites(200)),
+            termination=Termination([NumSites(200), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
             volume_constraint=cylinder,

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -133,7 +133,6 @@ class TestRandomWalk(BaseTest):
                 radius=0.22,
                 min_angle=np.pi / 4,
                 max_angle=np.pi,
-                max_attempts=1e4,
                 seed=14,
             )
 
@@ -148,7 +147,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         assert np.allclose(radius_of_gyration(rw_path.coordinates), 3, atol=1e-1)
@@ -164,7 +162,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         dist = np.linalg.norm(rw_path.coordinates[-1] - rw_path.coordinates[0])
@@ -186,7 +183,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             trial_batch_size=100,
             seed=14,
         )
@@ -210,7 +206,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=5e4,
             trial_batch_size=200,
             seed=14,
         )
@@ -226,7 +221,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
             chunk_size=50,
         )
@@ -241,7 +235,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         assert len(rw_path.coordinates) == 20
@@ -262,7 +255,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             initial_point=(1, 2, 3),
             seed=14,
         )
@@ -277,7 +269,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         rw_path_2 = HardSphereRandomWalk(
@@ -286,7 +277,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         assert np.allclose(rw_path_1.coordinates, rw_path_2.coordinates, atol=1e-7)
@@ -300,7 +290,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         rw_path2 = HardSphereRandomWalk(
@@ -309,7 +298,6 @@ class TestRandomWalk(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=24,
             start_from_path=rw_path,
             start_from_path_index=-1,
@@ -328,7 +316,6 @@ class TestRandomWalk(BaseTest):
             volume_constraint=cube,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         bounds = bounding_box(rw_path.coordinates)
@@ -344,7 +331,6 @@ class TestRandomWalk(BaseTest):
             volume_constraint=None,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         comp = rw_path.to_compound()
@@ -359,7 +345,6 @@ class TestRandomWalk(BaseTest):
             volume_constraint=cube,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         comp = rw_path.to_compound()
@@ -375,7 +360,6 @@ class TestRandomWalk(BaseTest):
             initial_point=(0, 0, 0),
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=90,
         )
         bounds = bounding_box(rw_path.coordinates)
@@ -390,7 +374,6 @@ class TestRandomWalk(BaseTest):
             volume_constraint=cylinder,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         bounds = bounding_box(rw_path.coordinates)

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -18,9 +18,8 @@ from mbuild.path.path_utils import (
     target_sq_distances,
 )
 from mbuild.path.termination import (
-    NumSites,
-    WallTime,
     NumAttempts,
+    NumSites,
     Termination,
 )
 from mbuild.tests.base_test import BaseTest

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -119,6 +119,19 @@ class TestPaths(BaseTest):
         assert Lx == Lz  # stacking and layering directions
         assert Ly > Lx
 
+    def test_lamellar_initial_point(self):
+        path = Lamellar(
+            bond_length=0.25,
+            num_layers=3,
+            layer_separation=1.0,
+            layer_length=3.0,
+            num_stacks=3,
+            stack_separation=1.0,
+            initial_point=(1, 1, 1),
+        )
+        assert np.array_equal(path.coordinates[0], np.array([1, 1, 1]))
+        assert path.coordinates[-1][2] == 3.0
+
 
 class TestRandomWalk(BaseTest):
     def test_extend_coordinates(self):

--- a/mbuild/tests/test_polymer.py
+++ b/mbuild/tests/test_polymer.py
@@ -14,7 +14,6 @@ from mbuild.tests.base_test import BaseTest
 class TestPolymer(BaseTest):
     def test_build_from_path(self):
         path = HardSphereRandomWalk(
-            N=20,
             termination=Termination([NumSites(20), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
@@ -34,7 +33,6 @@ class TestPolymer(BaseTest):
 
     def test_build_from_path_with_end_groups(self, ch2, ester):
         path = HardSphereRandomWalk(
-            N=20,
             termination=Termination([NumSites(20), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,

--- a/mbuild/tests/test_polymer.py
+++ b/mbuild/tests/test_polymer.py
@@ -7,6 +7,7 @@ import pytest
 import mbuild as mb
 from mbuild import Polymer
 from mbuild.path import HardSphereRandomWalk
+from mbuild.path.termination import NumAttempts, NumSites, Termination
 from mbuild.tests.base_test import BaseTest
 
 
@@ -14,6 +15,7 @@ class TestPolymer(BaseTest):
     def test_build_from_path(self):
         path = HardSphereRandomWalk(
             N=20,
+            termination=Termination([NumSites(20), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 2,
@@ -33,6 +35,7 @@ class TestPolymer(BaseTest):
     def test_build_from_path_with_end_groups(self, ch2, ester):
         path = HardSphereRandomWalk(
             N=20,
+            termination=Termination([NumSites(20), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
             min_angle=np.pi / 2,

--- a/mbuild/tests/test_polymer.py
+++ b/mbuild/tests/test_polymer.py
@@ -19,7 +19,6 @@ class TestPolymer(BaseTest):
             radius=0.22,
             min_angle=np.pi / 2,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         chain = Polymer()
@@ -38,7 +37,6 @@ class TestPolymer(BaseTest):
             radius=0.22,
             min_angle=np.pi / 2,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         ethane = mb.load("CC", smiles=True)

--- a/mbuild/tests/test_termination.py
+++ b/mbuild/tests/test_termination.py
@@ -13,6 +13,7 @@ from mbuild.path.termination import (
     NumSites,
     RadiusOfGyration,
     Termination,
+    Terminator,
     WallTime,
     WithinCoordinate,
 )
@@ -33,6 +34,17 @@ class TestTermination(BaseTest):
                 max_angle=np.pi,
                 seed=14,
             )
+
+    def test_terminator_base_class(self):
+        with pytest.raises(NotImplementedError):
+            termination = Termination(Terminator(is_target=True))
+            termination.is_met()
+
+    def test_single_terminator(self):
+        num_sites = NumSites(5000)
+        termination = Termination(num_sites)
+        assert isinstance(termination.terminators, list)
+        assert termination.terminators[0] is num_sites
 
     def test_wall_time_termination(self):
         cube = CuboidConstraint(Lx=1, Ly=1, Lz=1)

--- a/mbuild/tests/test_termination.py
+++ b/mbuild/tests/test_termination.py
@@ -52,6 +52,20 @@ class TestTermination(BaseTest):
         assert time.time() - start <= 6
         assert len(rw_path.coordinates) < 5000
 
+    def test_num_attempts_termination(self):
+        rw_path = HardSphereRandomWalk(
+            termination=Termination([NumSites(500), NumAttempts(100)]),
+            bond_length=0.25,
+            radius=0.22,
+            min_angle=np.pi / 4,
+            max_angle=np.pi,
+            max_attempts=1e4,
+            seed=14,
+        )
+        # First 2 steps in unconstrianed RWs are always accepted
+        # Counting doesn't start until afterwards
+        assert len(rw_path.coordinates) == 102
+
     def test_rg_termination(self):
         num_sites = NumSites(20)
         rg = RadiusOfGyration(3)

--- a/mbuild/tests/test_termination.py
+++ b/mbuild/tests/test_termination.py
@@ -8,6 +8,7 @@ from mbuild.path import (
 )
 from mbuild.path.bias import TargetCoordinate
 from mbuild.path.termination import (
+    ContourLength,
     EndToEndDistance,
     NumAttempts,
     NumSites,
@@ -45,6 +46,17 @@ class TestTermination(BaseTest):
         termination = Termination(num_sites)
         assert isinstance(termination.terminators, list)
         assert termination.terminators[0] is num_sites
+
+    def test_contour_length_termination(self):
+        rw = HardSphereRandomWalk(
+            radius=0.20,
+            bond_length=0.22,
+            min_angle=1.5,
+            max_angle=3.14,
+            termination=Termination([ContourLength(22), NumAttempts(1e4)]),
+            initial_point=(0, 0, 0),
+        )
+        assert len(rw.coordinates) == 100
 
     def test_wall_time_termination(self):
         cube = CuboidConstraint(Lx=1, Ly=1, Lz=1)

--- a/mbuild/tests/test_termination.py
+++ b/mbuild/tests/test_termination.py
@@ -31,7 +31,6 @@ class TestTermination(BaseTest):
                 radius=0.22,
                 min_angle=np.pi / 4,
                 max_angle=np.pi,
-                max_attempts=1e4,
                 seed=14,
             )
 
@@ -45,7 +44,6 @@ class TestTermination(BaseTest):
             volume_constraint=cube,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         # Allow some buffer
@@ -59,7 +57,6 @@ class TestTermination(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         # First 2 steps in unconstrianed RWs are always accepted
@@ -77,7 +74,6 @@ class TestTermination(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         assert np.allclose(radius_of_gyration(rw_path.coordinates), 3, atol=1e-1)
@@ -93,7 +89,6 @@ class TestTermination(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             seed=14,
         )
         dist = np.linalg.norm(rw_path.coordinates[-1] - rw_path.coordinates[0])
@@ -115,7 +110,6 @@ class TestTermination(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=1e4,
             trial_batch_size=100,
             seed=14,
         )
@@ -139,7 +133,6 @@ class TestTermination(BaseTest):
             radius=0.22,
             min_angle=np.pi / 4,
             max_angle=np.pi,
-            max_attempts=5e4,
             trial_batch_size=200,
             seed=14,
         )

--- a/mbuild/tests/test_termination.py
+++ b/mbuild/tests/test_termination.py
@@ -65,22 +65,24 @@ class TestTermination(BaseTest):
 
     def test_rg_termination(self):
         num_sites = NumSites(20)
-        rg = RadiusOfGyration(3)
-        max_attempts = NumAttempts(1e4)
+        rg = RadiusOfGyration(2)
+        max_attempts = NumAttempts(2e4)
         termination = Termination([num_sites, rg, max_attempts])
         rw_path = HardSphereRandomWalk(
             termination=termination,
-            bond_length=0.25,
+            initial_point=(0, 0, 0),
+            bond_length=0.24,
             radius=0.22,
-            min_angle=np.pi / 4,
+            min_angle=np.pi / 2,
             max_angle=np.pi,
-            seed=14,
+            seed=10,
         )
-        assert np.allclose(radius_of_gyration(rw_path.coordinates), 3, atol=1e-1)
+        assert len(rw_path.coordinates) >= 20
+        assert np.allclose(radius_of_gyration(rw_path.coordinates), 2, atol=1e-1)
 
     def test_re_termination(self):
         num_sites = NumSites(20)
-        re = EndToEndDistance(2)
+        re = EndToEndDistance(2, tolerance=0.1)
         max_attempts = NumAttempts(1e4)
         termination = Termination([num_sites, re, max_attempts])
         rw_path = HardSphereRandomWalk(
@@ -92,7 +94,7 @@ class TestTermination(BaseTest):
             seed=14,
         )
         dist = np.linalg.norm(rw_path.coordinates[-1] - rw_path.coordinates[0])
-        assert np.allclose(dist, 2, atol=1e-1)
+        assert np.allclose(dist, 2, atol=0.1)
 
     def test_within_coord_termination(self):
         bias = TargetCoordinate(target_coordinate=(2, 2, 2), weight=0.8)

--- a/mbuild/tests/test_termination.py
+++ b/mbuild/tests/test_termination.py
@@ -65,7 +65,7 @@ class TestTermination(BaseTest):
 
     def test_rg_termination(self):
         num_sites = NumSites(20)
-        rg = RadiusOfGyration(2)
+        rg = RadiusOfGyration(4)
         max_attempts = NumAttempts(2e4)
         termination = Termination([num_sites, rg, max_attempts])
         rw_path = HardSphereRandomWalk(
@@ -78,7 +78,7 @@ class TestTermination(BaseTest):
             seed=10,
         )
         assert len(rw_path.coordinates) >= 20
-        assert np.allclose(radius_of_gyration(rw_path.coordinates), 2, atol=1e-1)
+        assert np.allclose(radius_of_gyration(rw_path.coordinates), 4, atol=1e-1)
 
     def test_re_termination(self):
         num_sites = NumSites(20)

--- a/mbuild/tests/test_termination.py
+++ b/mbuild/tests/test_termination.py
@@ -1,0 +1,133 @@
+import time
+
+import numpy as np
+import pytest
+
+from mbuild.path import (
+    HardSphereRandomWalk,
+)
+from mbuild.path.bias import TargetCoordinate
+from mbuild.path.termination import (
+    EndToEndDistance,
+    NumAttempts,
+    NumSites,
+    RadiusOfGyration,
+    Termination,
+    WallTime,
+    WithinCoordinate,
+)
+from mbuild.tests.base_test import BaseTest, radius_of_gyration
+from mbuild.utils.volumes import (
+    CuboidConstraint,
+)
+
+
+class TestTermination(BaseTest):
+    def test_no_termination(self):
+        with pytest.raises(RuntimeError):
+            HardSphereRandomWalk(
+                termination=None,
+                bond_length=0.25,
+                radius=0.22,
+                min_angle=np.pi / 4,
+                max_angle=np.pi,
+                max_attempts=1e4,
+                seed=14,
+            )
+
+    def test_wall_time_termination(self):
+        cube = CuboidConstraint(Lx=1, Ly=1, Lz=1)
+        start = time.time()
+        rw_path = HardSphereRandomWalk(
+            termination=Termination([NumSites(5000), WallTime(5)]),
+            bond_length=0.25,
+            radius=0.22,
+            volume_constraint=cube,
+            min_angle=np.pi / 4,
+            max_angle=np.pi,
+            max_attempts=1e4,
+            seed=14,
+        )
+        # Allow some buffer
+        assert time.time() - start <= 6
+        assert len(rw_path.coordinates) < 5000
+
+    def test_rg_termination(self):
+        num_sites = NumSites(20)
+        rg = RadiusOfGyration(3)
+        max_attempts = NumAttempts(1e4)
+        termination = Termination([num_sites, rg, max_attempts])
+        rw_path = HardSphereRandomWalk(
+            termination=termination,
+            bond_length=0.25,
+            radius=0.22,
+            min_angle=np.pi / 4,
+            max_angle=np.pi,
+            max_attempts=1e4,
+            seed=14,
+        )
+        assert np.allclose(radius_of_gyration(rw_path.coordinates), 3, atol=1e-1)
+
+    def test_re_termination(self):
+        num_sites = NumSites(20)
+        re = EndToEndDistance(2)
+        max_attempts = NumAttempts(1e4)
+        termination = Termination([num_sites, re, max_attempts])
+        rw_path = HardSphereRandomWalk(
+            termination=termination,
+            bond_length=0.25,
+            radius=0.22,
+            min_angle=np.pi / 4,
+            max_angle=np.pi,
+            max_attempts=1e4,
+            seed=14,
+        )
+        dist = np.linalg.norm(rw_path.coordinates[-1] - rw_path.coordinates[0])
+        assert np.allclose(dist, 2, atol=1e-1)
+
+    def test_within_coord_termination(self):
+        bias = TargetCoordinate(target_coordinate=(2, 2, 2), weight=0.8)
+        termination = Termination(
+            [
+                WithinCoordinate(target_coordinate=(2, 2, 2), distance=0.22),
+                NumAttempts(1e3),
+            ]
+        )
+        rw_path = HardSphereRandomWalk(
+            termination=termination,
+            bias=bias,
+            initial_point=(0, 0, 0),
+            bond_length=0.25,
+            radius=0.22,
+            min_angle=np.pi / 4,
+            max_angle=np.pi,
+            max_attempts=1e4,
+            trial_batch_size=100,
+            seed=14,
+        )
+        dist = np.linalg.norm(rw_path.coordinates[-1] - np.array([2, 2, 2]))
+        assert dist <= 0.22
+
+        termination = Termination(
+            [
+                WithinCoordinate(
+                    target_coordinate=(3, 3, 3), distance=0.0, tolerance=1e-1
+                ),
+                NumAttempts(100),
+            ]
+        )
+        bias = TargetCoordinate(target_coordinate=(3, 3, 3), weight=1.0)
+        rw_path = HardSphereRandomWalk(
+            termination=termination,
+            bias=bias,
+            initial_point=(0, 0, 0),
+            bond_length=0.25,
+            radius=0.22,
+            min_angle=np.pi / 4,
+            max_angle=np.pi,
+            max_attempts=5e4,
+            trial_batch_size=200,
+            seed=14,
+        )
+        dist = np.linalg.norm(rw_path.coordinates[-1] - np.array([3, 3, 3]))
+        assert np.allclose(dist, 0, atol=1e-1)

--- a/mbuild/tests/test_termination.py
+++ b/mbuild/tests/test_termination.py
@@ -57,6 +57,7 @@ class TestTermination(BaseTest):
             initial_point=(0, 0, 0),
         )
         assert len(rw.coordinates) == 100
+        rw.termination.summarize()
 
     def test_wall_time_termination(self):
         cube = CuboidConstraint(Lx=1, Ly=1, Lz=1)


### PR DESCRIPTION
### PR Summary:
This PR adds a modular termination system for random walks, designed to complement the Bias class (https://github.com/mosdef-hub/mbuild/pull/1292) and provide flexibility in designing specific paths, such as semi-crystalline lamellae or cross-links. Termination criteria are not hard-coded into the random walk class, allowing users to define new criteria as needed or handle edge cases specific to their system.

The main ideas and features are:
 
- Flexible criteria: A walk can terminate based on conditions other than number of steps—for example, reaching a target coordinate, achieving a specific radius of gyration, or satisfying multiple criteria simultaneously. 
- Required vs optional criteria: Some criteria must be met before the walk can end (e.g., minimum number of steps), while others act as safeguards (e.g., maximum attempts or wall time) and can terminate the walk early if triggered.
- Composable criteria: Multiple criteria can be combined in the Termination class, allowing complex stopping conditions without modifying the core random walk.

Example use case: A walk could be required to come within 0.1 nm of a target coordinate, while also enforcing a minimum walk length. Meanwhile, safety criteria like maximum attempts or wall time can be included as well to ensure the walk does not run indefinitely.

Next steps: Replace the existing while loop with calls to the Termination instance provided when the random walk is initiated. Once this is done, we can see if there is a significant performance hit. I don't think there will be, especially since most of these criteria are not doing large iterations through the complete set of coordinates.

@CalCraven I'm open to any design and/or implementation feedback or ideas you might have.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
