### PR TITLE
add namers.py with BeadNamer class

### DIFF
--- a/mbuild/path/__init__.py
+++ b/mbuild/path/__init__.py
@@ -10,3 +10,11 @@ from .build import (
     straight_line,
     zigzag,
 )
+from .namers import (
+    BeadNamer,
+    ConstantNamer,
+    CyclicNamer,
+    GradientNamer,
+    MarkovNamer,
+    RandomNamer,
+)

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -11,6 +11,7 @@ from scipy.interpolate import interp1d
 from mbuild import Compound
 from mbuild.exceptions import PathConvergenceError
 from mbuild.path.constraints import CuboidConstraint, CylinderConstraint
+from mbuild.path.namers import BeadNamer
 from mbuild.path.path_utils import (
     calculate_sq_distances,
     check_path,
@@ -22,7 +23,6 @@ from mbuild.path.points import (
     get_initial_point,
     get_second_point,
 )
-from mbuild.path.namers import BeadNamer
 from mbuild.path.termination import NumSites, Termination, Terminator
 
 logger = logging.getLogger(__name__)
@@ -397,8 +397,10 @@ def lamellar(
         The distance between two stacked layers. Required if `num_stacks` >= 2.
     left_to_right : boolean, default True
         If `True`, the first layer is built with increasing y-coordinates from the origin.
-    bead_name : str or np.ndarray (N, 1), optional default _A
-        The bead names in the path.
+    bead_name : str or BeadNamer, optional, default '_A'
+        Name(s) to assign to beads. A plain string assigns the same name to
+        every bead. Pass a ``BeadNamer`` instance (e.g. ``CyclicNamer``,
+        ``RandomNamer``, ``MarkovNamer``) for heterogeneous sequences.
     """
     if path is None:
         path = Path()
@@ -528,8 +530,10 @@ def straight_line(path, spacing, N, direction=(1, 0, 0), bead_name="_A"):
         The distance between sites along the path.
     direction : array-like (1,3), default = (1,0,0)
         The direction to align the straight path along.
-    bead_name : str or np.ndarray (N, 1), optional default _A
-        The bead names in the path.
+    bead_name : str or BeadNamer, optional, default '_A'
+        Name(s) to assign to beads. A plain string assigns the same name to
+        every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
+        See mbuild.path.namers.py
     """
     direction = np.asarray(direction)
     coordinates = np.array([np.zeros(3) + i * spacing * direction for i in range(N)])
@@ -559,8 +563,10 @@ def cyclic(path, spacing=None, N=None, radius=None, closed=True, bead_name="_A")
         The radius (nm) of the cyclic path.
     closed : bool, default True
         If `True` the cyclic path is closed by bonding the first and last sites together
-    bead_name : str or np.ndarray (N, 1), optional default _A
-        The bead names in the path.
+    bead_name : str or BeadNamer, optional, default '_A'
+        Name(s) to assign to beads. A plain string assigns the same name to
+        every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
+        See mbuild.path.namers.py
 
     Notes
     -----
@@ -614,8 +620,10 @@ def knot(path, spacing, N, m, closed=True, bead_name="_A"):
         3 gives the trefoil knot, 4 gives the figure 8 knot and 5 gives the cinquefoil knot.
     closed : bool, default True
         If `True` the cyclic path is closed by bonding the first and last sites together
-    bead_name : str or np.ndarray (N, 1), optional default _A
-        The bead names in the path.
+    bead_name : str or BeadNamer, optional, default '_A'
+        Name(s) to assign to beads. A plain string assigns the same name to
+        every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
+        See mbuild.path.namers.py
     """
     # Generate dense sites first, sample actual ones later from spacing
     t_dense = np.linspace(0, 2 * np.pi, 5000)
@@ -697,8 +705,10 @@ def helix(
         Set the handedness of the helical twist
     bottom_up : bool, default True
         If True, the twist is in the positive Z direction
-    bead_name : str or np.ndarray (N, 1), optional default _A
-        The bead names in the path.
+    bead_name : str or BeadNamer, optional, default '_A'
+        Name(s) to assign to beads. A plain string assigns the same name to
+        every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
+        See mbuild.path.namers.py
     """
     coordinates = np.zeros((N, 3))
     indices = reversed(range(N)) if not bottom_up else range(N)
@@ -738,8 +748,10 @@ def spiral_2D(path, N, a, b, spacing, bead_name="_A"):
         Determines how fast radius grows per angle increment (r = a + bθ)
     spacing : float, required
         Distance between adjacent sites (nm)
-    bead_name : str or np.ndarray (N, 1), optional default _A
-        The bead names in the path.
+    bead_name : str or BeadNamer, optional, default '_A'
+        Name(s) to assign to beads. A plain string assigns the same name to
+        every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
+        See mbuild.path.namers.py
     """
     coordinates = np.zeros((N, 3))
     theta = 0.0
@@ -791,8 +803,10 @@ def zigzag(
         The number of sites before rotating and beginning next segment.
     plane : str, default = "xy"
         The plane that the sites in the path occupy
-    bead_name : str or np.ndarray (N, 1), optional default _A
-        The bead names in the path.
+    bead_name : str or BeadNamer, optional, default '_A'
+        Name(s) to assign to beads. A plain string assigns the same name to
+        every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
+        See mbuild.path.namers.py
     """
     if N % sites_per_segment != 0:
         raise ValueError("N must be evenly divisible by sites_per_segment")
@@ -874,11 +888,10 @@ def hard_sphere_random_walk(
     -----------
     path : mbuild.path.Path, default None.
         The Path object to populate with coordinates. Creates a new path object if not passed.
-    bead_name : str or BeadNamer, default `'_A'`
-        Name(s) to assign to nodes added during this walk. A plain string is
-        wrapped in ``ConstantNamer`` automatically. Pass a ``BeadNamer``
-        instance (e.g. ``CyclicNamer``, ``RandomNamer``) for heterogeneous
-        sequences. ``next(namer)`` is called once per *accepted* bead.
+    bead_name : str or BeadNamer, optional, default '_A'
+        Name(s) to assign to beads. A plain string assigns the same name to
+        every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
+        See mbuild.path.namers.py
     bond_length : float, default 0.15 nm
         Fixed bond length between 2 coordinates.
     radius : float, default 0.1 nm

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -22,6 +22,7 @@ from mbuild.path.points import (
     get_initial_point,
     get_second_point,
 )
+from mbuild.path.namers import BeadNamer
 from mbuild.path.termination import NumSites, Termination, Terminator
 
 logger = logging.getLogger(__name__)
@@ -505,7 +506,9 @@ def lamellar(
     # Coordinates are set, update the Path object
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
-    path.append_coordinates(coordinates, bead_name)
+    namer = BeadNamer.coerce(bead_name)
+    names = np.array([next(namer) for _ in range(len(coordinates))], dtype="U10")
+    path.append_coordinates(coordinates, names)
     path._connect_edges(
         connectivity="linear", indices=np.arange(start_index, stop_index)
     )
@@ -532,7 +535,9 @@ def straight_line(path, spacing, N, direction=(1, 0, 0), bead_name="_A"):
     coordinates = np.array([np.zeros(3) + i * spacing * direction for i in range(N)])
     start_index = len(path.coordinates)
     stop_index = start_index + N
-    path.append_coordinates(coordinates, bead_name)
+    namer = BeadNamer.coerce(bead_name)
+    names = np.array([next(namer) for _ in range(len(coordinates))], dtype="U10")
+    path.append_coordinates(coordinates, names)
     path._connect_edges(
         connectivity="linear", indices=np.arange(start_index, stop_index)
     )
@@ -579,7 +584,9 @@ def cyclic(path, spacing=None, N=None, radius=None, closed=True, bead_name="_A")
     )
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
-    path.append_coordinates(coordinates, bead_name)
+    namer = BeadNamer.coerce(bead_name)
+    names = np.array([next(namer) for _ in range(len(coordinates))], dtype="U10")
+    path.append_coordinates(coordinates, names)
     if closed:
         path._connect_edges(
             connectivity="cycle", indices=np.arange(start_index, stop_index)
@@ -655,7 +662,9 @@ def knot(path, spacing, N, m, closed=True, bead_name="_A"):
 
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
-    path.append_coordinates(coordinates, bead_name)
+    namer = BeadNamer.coerce(bead_name)
+    names = np.array([next(namer) for _ in range(len(coordinates))], dtype="U10")
+    path.append_coordinates(coordinates, names)
     if closed:
         path._connect_edges(
             connectivity="cycle", indices=np.arange(start_index, stop_index)
@@ -705,7 +714,9 @@ def helix(
 
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
-    path.append_coordinates(coordinates, bead_name)
+    namer = BeadNamer.coerce(bead_name)
+    names = np.array([next(namer) for _ in range(len(coordinates))], dtype="U10")
+    path.append_coordinates(coordinates, names)
     path._connect_edges(
         connectivity="linear", indices=np.arange(start_index, stop_index)
     )
@@ -746,7 +757,9 @@ def spiral_2D(path, N, a, b, spacing, bead_name="_A"):
 
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
-    path.append_coordinates(coordinates, bead_name)
+    namer = BeadNamer.coerce(bead_name)
+    names = np.array([next(namer) for _ in range(len(coordinates))], dtype="U10")
+    path.append_coordinates(coordinates, names)
     path._connect_edges(
         connectivity="linear", indices=np.arange(start_index, stop_index)
     )
@@ -826,7 +839,9 @@ def zigzag(
 
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
-    path.append_coordinates(coordinates, bead_name)
+    namer = BeadNamer.coerce(bead_name)
+    names = np.array([next(namer) for _ in range(len(coordinates))], dtype="U10")
+    path.append_coordinates(coordinates, names)
     path._connect_edges(
         connectivity="linear", indices=np.arange(start_index, stop_index)
     )
@@ -859,8 +874,11 @@ def hard_sphere_random_walk(
     -----------
     path : mbuild.path.Path, default None.
         The Path object to populate with coordinates. Creates a new path object if not passed.
-    bead_name : str, default `'_A'`
-        Name to assign to nodes added during this walk.
+    bead_name : str or BeadNamer, default `'_A'`
+        Name(s) to assign to nodes added during this walk. A plain string is
+        wrapped in ``ConstantNamer`` automatically. Pass a ``BeadNamer``
+        instance (e.g. ``CyclicNamer``, ``RandomNamer``) for heterogeneous
+        sequences. ``next(namer)`` is called once per *accepted* bead.
     bond_length : float, default 0.15 nm
         Fixed bond length between 2 coordinates.
     radius : float, default 0.1 nm
@@ -938,6 +956,8 @@ def hard_sphere_random_walk(
     state.termination = termination
     state.termination._attach_path(path, state)
 
+    namer = BeadNamer.coerce(bead_name)
+
     # Create RNG state
     rng = np.random.default_rng(seed + len(path.coordinates))
     state.rng = rng
@@ -1013,8 +1033,7 @@ def hard_sphere_random_walk(
             next_step=next_step,
         )
         coordinates[state.count] = initial_xyz
-        # TODO: Use a NameGenerator() call here instead of a static bead name
-        beads[state.count] = bead_name
+        beads[state.count] = next(namer)
         state.count += 1
         if state.check_termination(path, coordinates, beads):
             return path
@@ -1029,8 +1048,7 @@ def hard_sphere_random_walk(
         )
         if second_xyz is not None:
             coordinates[state.count] = second_xyz
-            # TODO: Use a NameGenerator() call here instead of a static bead name
-            beads[state.count] = bead_name
+            beads[state.count] = next(namer)
             state.count += 1
             break
         else:
@@ -1123,8 +1141,7 @@ def hard_sphere_random_walk(
 
         if accept_xyz is not None:
             coordinates[state.count] = accept_xyz
-            # TODO: Use a NameGenerator() class here
-            beads[state.count] = bead_name
+            beads[state.count] = next(namer)
             state.count += 1
 
         state.attempts += 1

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -620,7 +620,7 @@ def knot(path, spacing, N, m, closed=True, bead_name="_A"):
         3 gives the trefoil knot, 4 gives the figure 8 knot and 5 gives the cinquefoil knot.
     closed : bool, default True
         If `True` the cyclic path is closed by bonding the first and last sites together
-    bead_name : str or BeadNamer, optional, default '_A'
+    bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -888,7 +888,7 @@ def hard_sphere_random_walk(
     -----------
     path : mbuild.path.Path, default None.
         The Path object to populate with coordinates. Creates a new path object if not passed.
-    bead_name : str or BeadNamer, optional, default '_A'
+    bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -530,7 +530,7 @@ def straight_line(path, spacing, N, direction=(1, 0, 0), bead_name="_A"):
         The distance between sites along the path.
     direction : array-like (1,3), default = (1,0,0)
         The direction to align the straight path along.
-    bead_name : str or BeadNamer, optional, default '_A'
+    bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -803,7 +803,7 @@ def zigzag(
         The number of sites before rotating and beginning next segment.
     plane : str, default = "xy"
         The plane that the sites in the path occupy
-    bead_name : str or BeadNamer, optional, default '_A'
+    bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -748,7 +748,7 @@ def spiral_2D(path, N, a, b, spacing, bead_name="_A"):
         Determines how fast radius grows per angle increment (r = a + bθ)
     spacing : float, required
         Distance between adjacent sites (nm)
-    bead_name : str or BeadNamer, optional, default '_A'
+    bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -563,7 +563,7 @@ def cyclic(path, spacing=None, N=None, radius=None, closed=True, bead_name="_A")
         The radius (nm) of the cyclic path.
     closed : bool, default True
         If `True` the cyclic path is closed by bonding the first and last sites together
-    bead_name : str or BeadNamer, optional, default '_A'
+    bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -705,7 +705,7 @@ def helix(
         Set the handedness of the helical twist
     bottom_up : bool, default True
         If True, the twist is in the positive Z direction
-    bead_name : str or BeadNamer, optional, default '_A'
+    bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py

--- a/mbuild/path/namers.py
+++ b/mbuild/path/namers.py
@@ -1,4 +1,4 @@
-"""Bead name generators for use with hard_sphere_random_walk."""
+"""Bead name generators for methods in mbuild.path.build.py."""
 
 import itertools
 from abc import ABC, abstractmethod
@@ -28,7 +28,7 @@ class BeadNamer(ABC):
 
     @classmethod
     def coerce(cls, value):
-        """Return value unchanged if it is a BeadNamer; wrap strings in ConstantNamer."""
+        """Return value unchanged if it is a BeadNamer or wrap strings in ConstantNamer."""
         if isinstance(value, BeadNamer):
             return value
         if isinstance(value, str):
@@ -110,18 +110,6 @@ class RandomNamer(BeadNamer):
         if self.strict:
             return f"RandomNamer({self.names!r}, strict=True)"
         return f"RandomNamer({self.names!r}, weights={self._weights})"
-
-
-def _flatten_sequence(sequence):
-    """Expand a mixed list of names / (name, count) tuples into a flat list."""
-    result = []
-    for item in sequence:
-        if isinstance(item, tuple):
-            name, count = item
-            result.extend([name] * int(count))
-        else:
-            result.append(item)
-    return result
 
 
 class MarkovNamer(BeadNamer):
@@ -267,3 +255,15 @@ class CyclicNamer(BeadNamer):
 
     def __repr__(self):
         return f"CyclicNamer({self._flat!r})"
+
+
+def _flatten_sequence(sequence):
+    """Expand a mixed list of names / (name, count) tuples into a flat list."""
+    result = []
+    for item in sequence:
+        if isinstance(item, tuple):
+            name, count = item
+            result.extend([name] * int(count))
+        else:
+            result.append(item)
+    return result

--- a/mbuild/path/namers.py
+++ b/mbuild/path/namers.py
@@ -1,0 +1,270 @@
+"""Bead name generators for use with hard_sphere_random_walk."""
+
+import itertools
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+
+class BeadNamer(ABC):
+    """Abstract base class for bead name generators.
+
+    Subclasses must implement ``__next__``. Instances are iterators —
+    ``next(namer)`` returns the name for the next accepted bead.
+
+    Pass a plain string anywhere a ``BeadNamer`` is expected and
+    ``BeadNamer.coerce()`` will wrap it in a ``ConstantNamer`` automatically.
+
+    To build a custom namer, subclass ``BeadNamer`` and implement ``__next__``.
+    """
+
+    @abstractmethod
+    def __next__(self) -> str: ...
+
+    def __iter__(self):
+        return self
+
+    @classmethod
+    def coerce(cls, value):
+        """Return value unchanged if it is a BeadNamer; wrap strings in ConstantNamer."""
+        if isinstance(value, BeadNamer):
+            return value
+        if isinstance(value, str):
+            return ConstantNamer(value)
+        raise TypeError(
+            f"bead_name must be a str or BeadNamer, got {type(value).__name__!r}"
+        )
+
+
+class ConstantNamer(BeadNamer):
+    """Always yields the same bead name."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __next__(self) -> str:
+        return self.name
+
+    def __repr__(self):
+        return f"ConstantNamer({self.name!r})"
+
+
+class RandomNamer(BeadNamer):
+    """Randomly draws bead names from a list, with optional weights.
+
+    Parameters
+    ----------
+    names : list of str
+        Pool of bead names to draw from.
+    weights : list of float or int, optional, default None
+        When ``strict=False``: sampling probabilities, normalized automatically.
+        When ``strict=True``: integer counts per period (e.g. ``[1, 3]`` gives
+        one ``_A`` and three ``_B`` per four-bead shuffle). Rounded to the
+        nearest integer. Defaults to 1 of each name if not provided.
+    strict : bool, default False
+        If False, samples with replacement — composition is approximate.
+        If True, samples without replacement from a shuffled pool that is
+        rebuilt each period — composition is exact over every period.
+    seed : int, optional, default None
+        Random seed for reproducibility.
+    """
+
+    def __init__(self, names, weights=None, strict=False, seed=None):
+        self.names = list(names)
+        self.strict = strict
+        self._rng = np.random.default_rng(seed)
+
+        if strict:
+            if weights is not None:
+                counts = np.round(np.asarray(weights, dtype=float)).astype(int)
+                if np.any(counts <= 0):
+                    raise ValueError(
+                        "All counts must be >= 1 when strict=True. "
+                        "Pass weights as integer counts, e.g. weights=[1, 3]."
+                    )
+            else:
+                counts = np.ones(len(self.names), dtype=int)
+            self._pool_template = []
+            for name, count in zip(self.names, counts):
+                self._pool_template.extend([name] * int(count))
+            self._pool = []
+        else:
+            if weights is not None:
+                w = np.asarray(weights, dtype=float)
+                self._weights = (w / w.sum()).tolist()
+            else:
+                self._weights = None
+
+    def __next__(self) -> str:
+        if self.strict:
+            if not self._pool:
+                self._pool = list(self._pool_template)
+                self._rng.shuffle(self._pool)
+            return self._pool.pop()
+        idx = int(self._rng.choice(len(self.names), p=self._weights))
+        return self.names[idx]
+
+    def __repr__(self):
+        if self.strict:
+            return f"RandomNamer({self.names!r}, strict=True)"
+        return f"RandomNamer({self.names!r}, weights={self._weights})"
+
+
+def _flatten_sequence(sequence):
+    """Expand a mixed list of names / (name, count) tuples into a flat list."""
+    result = []
+    for item in sequence:
+        if isinstance(item, tuple):
+            name, count = item
+            result.extend([name] * int(count))
+        else:
+            result.append(item)
+    return result
+
+
+class MarkovNamer(BeadNamer):
+    """Generates bead names from a first-order Markov chain.
+
+    Each bead name is drawn based on the transition probabilities from the
+    current state. This models real copolymer statistics — blocky, alternating,
+    and purely random sequences are all special cases of the transition matrix.
+
+    Parameters
+    ----------
+    names : list of str
+        Bead types (states in the chain).
+    transition_matrix : array-like, shape (N, N)
+        Entry ``[i][j]`` is the probability of transitioning from name ``i``
+        to name ``j``. Rows are normalized automatically, so raw reactivity
+        ratios can be passed directly.
+    start : str or int, optional, default None
+        Starting state, given as a name string or index. If None, a state is
+        chosen uniformly at random.
+    seed : int, optional, default None
+        Random seed for reproducibility.
+
+    Examples
+    --------
+    Perfect alternation (syndiotactic-like):
+
+    >>> namer = MarkovNamer(["_A", "_B"], [[0, 1], [1, 0]], start="_A", seed=0)
+    >>> [next(namer) for _ in range(6)]
+    ['_A', '_B', '_A', '_B', '_A', '_B']
+
+    Blocky character (high self-transition probability):
+
+    >>> namer = MarkovNamer(["_A", "_B"], [[0.9, 0.1], [0.1, 0.9]], start="_A", seed=0)
+    """
+
+    def __init__(self, names, transition_matrix, start=None, seed=None):
+        self.names = list(names)
+        matrix = np.asarray(transition_matrix, dtype=float)
+        if matrix.shape != (len(self.names), len(self.names)):
+            raise ValueError(
+                f"transition_matrix must be ({len(self.names)}, {len(self.names)}), "
+                f"got {matrix.shape}"
+            )
+        row_sums = matrix.sum(axis=1, keepdims=True)
+        self._matrix = matrix / row_sums
+        self._rng = np.random.default_rng(seed)
+
+        if start is None:
+            self._current = int(self._rng.integers(len(self.names)))
+        elif isinstance(start, str):
+            self._current = self.names.index(start)
+        else:
+            self._current = int(start)
+
+    def __next__(self) -> str:
+        name = self.names[self._current]
+        self._current = int(
+            self._rng.choice(len(self.names), p=self._matrix[self._current])
+        )
+        return name
+
+    def __repr__(self):
+        return f"MarkovNamer({self.names!r})"
+
+
+class GradientNamer(BeadNamer):
+    """Generates bead names with composition that shifts along the chain.
+
+    Linearly interpolates sampling weights from ``start_weights`` to
+    ``end_weights`` over ``n_steps``. After ``n_steps``, holds at
+    ``end_weights`` so the walk can run longer without raising.
+
+    Parameters
+    ----------
+    names : list of str
+        Bead types to draw from.
+    start_weights : list of float
+        Sampling weights at position 0. Normalized automatically.
+    end_weights : list of float
+        Sampling weights at position ``n_steps - 1``. Normalized automatically.
+    n_steps : int
+        Number of steps over which the gradient is applied.
+    seed : int, optional, default None
+        Random seed for reproducibility.
+
+    Examples
+    --------
+    Pure A at the start, pure B at the end:
+
+    >>> namer = GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=100, seed=0)
+    """
+
+    def __init__(self, names, start_weights, end_weights, n_steps, seed=None):
+        self.names = list(names)
+        start = np.asarray(start_weights, dtype=float)
+        end = np.asarray(end_weights, dtype=float)
+        self._start = start / start.sum()
+        self._end = end / end.sum()
+        self._n_steps = int(n_steps)
+        self._rng = np.random.default_rng(seed)
+        self._step = 0
+
+    def __next__(self) -> str:
+        t = min(self._step / max(self._n_steps - 1, 1), 1.0)
+        weights = (1 - t) * self._start + t * self._end
+        idx = int(self._rng.choice(len(self.names), p=weights))
+        self._step += 1
+        return self.names[idx]
+
+    def __repr__(self):
+        return f"GradientNamer({self.names!r}, n_steps={self._n_steps})"
+
+
+class CyclicNamer(BeadNamer):
+    """Cycles through a sequence of bead names indefinitely.
+
+    Accepts a flat list of names or a list of ``(name, count)`` tuples for
+    block patterns.
+
+    Parameters
+    ----------
+    sequence : list of str or list of (str, int) tuples
+        Names to cycle. Tuples expand to blocks, e.g.
+        ``[("_A", 5), ("_B", 5)]`` produces five ``_A`` then five ``_B``,
+        repeating forever.
+
+    Examples
+    --------
+    >>> list(itertools.islice(CyclicNamer(["_A", "_B"]), 6))
+    ['_A', '_B', '_A', '_B', '_A', '_B']
+    >>> list(itertools.islice(CyclicNamer([("_A", 2), ("_B", 3)]), 10))
+    ['_A', '_A', '_B', '_B', '_B', '_A', '_A', '_B', '_B', '_B']
+    """
+
+    def __init__(self, sequence):
+        self._flat = _flatten_sequence(sequence)
+        if not self._flat:
+            raise ValueError("CyclicNamer sequence must not be empty.")
+        self._cycle = itertools.cycle(self._flat)
+
+    def __next__(self) -> str:
+        return next(self._cycle)
+
+    def __repr__(self):
+        return f"CyclicNamer({self._flat!r})"
+
+

--- a/mbuild/path/namers.py
+++ b/mbuild/path/namers.py
@@ -9,7 +9,9 @@ import numpy as np
 class BeadNamer(ABC):
     """Abstract base class for bead name generators.
 
-    Subclasses must implement ``__next__``. Instances are iterators —
+    Subclasses must implement ``__next__``.
+
+    Instances are iterators:
     ``next(namer)`` returns the name for the next accepted bead.
 
     Pass a plain string anywhere a ``BeadNamer`` is expected and
@@ -126,8 +128,7 @@ class MarkovNamer(BeadNamer):
     """Generates bead names from a first-order Markov chain.
 
     Each bead name is drawn based on the transition probabilities from the
-    current state. This models real copolymer statistics — blocky, alternating,
-    and purely random sequences are all special cases of the transition matrix.
+    current state.
 
     Parameters
     ----------
@@ -145,7 +146,7 @@ class MarkovNamer(BeadNamer):
 
     Examples
     --------
-    Perfect alternation (syndiotactic-like):
+    Perfect alternation:
 
     >>> namer = MarkovNamer(["_A", "_B"], [[0, 1], [1, 0]], start="_A", seed=0)
     >>> [next(namer) for _ in range(6)]
@@ -266,5 +267,3 @@ class CyclicNamer(BeadNamer):
 
     def __repr__(self):
         return f"CyclicNamer({self._flat!r})"
-
-

--- a/mbuild/tests/test_namers.py
+++ b/mbuild/tests/test_namers.py
@@ -156,7 +156,7 @@ class TestRandomNamerStrict:
         namer = RandomNamer(["_A", "_B"], weights=[1, 1], strict=True, seed=0)
         period_a = [next(namer) for _ in range(2)]
         period_b = [next(namer) for _ in range(2)]
-        # Both periods have exact composition; order may differ
+        # Both periods have exact composition but order may differ
         assert sorted(period_a) == ["_A", "_B"]
         assert sorted(period_b) == ["_A", "_B"]
 
@@ -165,8 +165,14 @@ class TestRandomNamerStrict:
             RandomNamer(["_A", "_B"], weights=[0, 1], strict=True)
 
     def test_strict_seeded_reproducibility(self):
-        a = [next(RandomNamer(["_A", "_B"], weights=[1, 3], strict=True, seed=7)) for _ in range(20)]
-        b = [next(RandomNamer(["_A", "_B"], weights=[1, 3], strict=True, seed=7)) for _ in range(20)]
+        a = [
+            next(RandomNamer(["_A", "_B"], weights=[1, 3], strict=True, seed=7))
+            for _ in range(20)
+        ]
+        b = [
+            next(RandomNamer(["_A", "_B"], weights=[1, 3], strict=True, seed=7))
+            for _ in range(20)
+        ]
         assert a == b
 
     def test_strict_repr(self):
@@ -192,7 +198,7 @@ class TestMarkovNamer:
         assert all(r == "_B" for r in result[1:])
 
     def test_row_normalization(self):
-        # Unnormalized rows (e.g. raw counts) should be normalized automatically
+        # Unnormalized rows (raw counts) should be normalized automatically
         namer = MarkovNamer(["_A", "_B"], [[2, 2], [1, 3]], start="_A", seed=42)
         result = {next(namer) for _ in range(50)}
         assert result <= {"_A", "_B"}
@@ -217,7 +223,9 @@ class TestMarkovNamer:
         assert [next(namer) for _ in range(6)] == ["_A", "_B", "_C", "_A", "_B", "_C"]
 
     def test_repr(self):
-        assert "MarkovNamer" in repr(MarkovNamer(["_A", "_B"], [[0.5, 0.5], [0.5, 0.5]]))
+        assert "MarkovNamer" in repr(
+            MarkovNamer(["_A", "_B"], [[0.5, 0.5], [0.5, 0.5]])
+        )
 
 
 class TestGradientNamer:
@@ -257,10 +265,17 @@ class TestGradientNamer:
             assert next(namer) in {"_A", "_B"}
 
     def test_seeded_reproducibility(self):
-        a = [next(GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10, seed=5)) for _ in range(10)]
-        b = [next(GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10, seed=5)) for _ in range(10)]
+        a = [
+            next(GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10, seed=5))
+            for _ in range(10)
+        ]
+        b = [
+            next(GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10, seed=5))
+            for _ in range(10)
+        ]
         assert a == b
 
     def test_repr(self):
-        assert "GradientNamer" in repr(GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10))
-
+        assert "GradientNamer" in repr(
+            GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10)
+        )

--- a/mbuild/tests/test_namers.py
+++ b/mbuild/tests/test_namers.py
@@ -90,6 +90,31 @@ class TestRandomNamer:
         namer = RandomNamer(["_A"], seed=0)
         assert [next(namer) for _ in range(5)] == ["_A"] * 5
 
+    def test_weight_scaling_invariance(self):
+        # [0.5, 0.5], [1, 1], and [50, 50] all normalize to the same probabilities
+        r1 = [
+            next(RandomNamer(["_A", "_B"], weights=[0.5, 0.5], seed=7))
+            for _ in range(20)
+        ]
+        r2 = [
+            next(RandomNamer(["_A", "_B"], weights=[1, 1], seed=7)) for _ in range(20)
+        ]
+        r3 = [
+            next(RandomNamer(["_A", "_B"], weights=[50, 50], seed=7)) for _ in range(20)
+        ]
+        assert r1 == r2 == r3
+
+    def test_decimal_weights_unequal(self):
+        # [0.1, 1] normalizes to ~[0.09, 0.91] — same as [1, 10]
+        r1 = [
+            next(RandomNamer(["_A", "_B"], weights=[0.1, 1.0], seed=7))
+            for _ in range(20)
+        ]
+        r2 = [
+            next(RandomNamer(["_A", "_B"], weights=[1, 10], seed=7)) for _ in range(20)
+        ]
+        assert r1 == r2
+
 
 class TestCyclicNamer:
     def test_flat_sequence_alternating(self):
@@ -164,6 +189,18 @@ class TestRandomNamerStrict:
         with pytest.raises(ValueError, match="counts must be >= 1"):
             RandomNamer(["_A", "_B"], weights=[0, 1], strict=True)
 
+    def test_strict_decimal_weights_that_round_cleanly(self):
+        # [1.0, 3.0] rounds to [1, 3] — works fine
+        namer = RandomNamer(["_A", "_B"], weights=[1.0, 3.0], strict=True, seed=0)
+        result = [next(namer) for _ in range(40)]
+        assert result.count("_A") == 10
+        assert result.count("_B") == 30
+
+    def test_strict_small_decimal_raises(self):
+        # [0.5, 0.5] rounds to [0, 0] — strict mode needs integer counts >= 1
+        with pytest.raises(ValueError, match="counts must be >= 1"):
+            RandomNamer(["_A", "_B"], weights=[0.5, 0.5], strict=True)
+
     def test_strict_seeded_reproducibility(self):
         a = [
             next(RandomNamer(["_A", "_B"], weights=[1, 3], strict=True, seed=7))
@@ -202,6 +239,16 @@ class TestMarkovNamer:
         namer = MarkovNamer(["_A", "_B"], [[2, 2], [1, 3]], start="_A", seed=42)
         result = {next(namer) for _ in range(50)}
         assert result <= {"_A", "_B"}
+
+    def test_matrix_scaling_invariance(self):
+        # [[0.5, 0.5], ...], [[1, 1], ...], and [[50, 50], ...] all normalize identically
+        m1 = [[0.5, 0.5], [0.5, 0.5]]
+        m2 = [[1, 1], [1, 1]]
+        m3 = [[50, 50], [50, 50]]
+        r1 = [next(MarkovNamer(["_A", "_B"], m1, seed=7)) for _ in range(20)]
+        r2 = [next(MarkovNamer(["_A", "_B"], m2, seed=7)) for _ in range(20)]
+        r3 = [next(MarkovNamer(["_A", "_B"], m3, seed=7)) for _ in range(20)]
+        assert r1 == r2 == r3
 
     def test_start_by_name(self):
         namer = MarkovNamer(["_A", "_B"], [[0, 1], [1, 0]], start="_B", seed=0)

--- a/mbuild/tests/test_namers.py
+++ b/mbuild/tests/test_namers.py
@@ -1,0 +1,266 @@
+import itertools
+
+import pytest
+
+from mbuild.path.namers import (
+    BeadNamer,
+    ConstantNamer,
+    CyclicNamer,
+    GradientNamer,
+    MarkovNamer,
+    RandomNamer,
+)
+
+
+class TestBeadNamerCoerce:
+    def test_coerce_string_returns_constant_namer(self):
+        namer = BeadNamer.coerce("_A")
+        assert isinstance(namer, ConstantNamer)
+
+    def test_coerce_bead_namer_returns_same_object(self):
+        original = ConstantNamer("_A")
+        assert BeadNamer.coerce(original) is original
+
+    def test_coerce_bad_type_raises(self):
+        with pytest.raises(TypeError, match="bead_name must be a str or BeadNamer"):
+            BeadNamer.coerce(42)
+
+    def test_coerce_none_raises(self):
+        with pytest.raises(TypeError):
+            BeadNamer.coerce(None)
+
+    def test_namers_are_iterators(self):
+        for namer in [
+            ConstantNamer("_A"),
+            RandomNamer(["_A", "_B"], seed=0),
+            CyclicNamer(["_A", "_B"]),
+        ]:
+            assert iter(namer) is namer
+
+
+class TestConstantNamer:
+    def test_always_returns_same_name(self):
+        namer = ConstantNamer("_A")
+        assert [next(namer) for _ in range(5)] == ["_A"] * 5
+
+    def test_different_name(self):
+        namer = ConstantNamer("_B")
+        assert next(namer) == "_B"
+
+    def test_repr(self):
+        assert repr(ConstantNamer("_A")) == "ConstantNamer('_A')"
+
+    def test_coerce_string_behaves_like_constant(self):
+        namer = BeadNamer.coerce("_X")
+        assert [next(namer) for _ in range(3)] == ["_X"] * 3
+
+
+class TestRandomNamer:
+    def test_draws_from_pool(self):
+        namer = RandomNamer(["_A", "_B"], seed=0)
+        results = {next(namer) for _ in range(50)}
+        assert results <= {"_A", "_B"}
+
+    def test_uniform_weights_use_both_names(self):
+        namer = RandomNamer(["_A", "_B"], seed=42)
+        results = [next(namer) for _ in range(100)]
+        assert "_A" in results and "_B" in results
+
+    def test_weight_one_always_picks_that_name(self):
+        namer = RandomNamer(["_A", "_B"], weights=[1.0, 0.0], seed=0)
+        assert all(next(namer) == "_A" for _ in range(20))
+
+    def test_weights_are_normalized(self):
+        namer = RandomNamer(["_A", "_B"], weights=[2, 8], seed=0)
+        results = [next(namer) for _ in range(1000)]
+        ratio = results.count("_B") / len(results)
+        assert 0.75 < ratio < 0.85
+
+    def test_seeded_reproducibility(self):
+        seq_a = [next(RandomNamer(["_A", "_B"], seed=7)) for _ in range(20)]
+        seq_b = [next(RandomNamer(["_A", "_B"], seed=7)) for _ in range(20)]
+        assert seq_a == seq_b
+
+    def test_different_seeds_differ(self):
+        seq_a = [next(RandomNamer(["_A", "_B", "_C"], seed=1)) for _ in range(30)]
+        seq_b = [next(RandomNamer(["_A", "_B", "_C"], seed=2)) for _ in range(30)]
+        assert seq_a != seq_b
+
+    def test_single_name_pool(self):
+        namer = RandomNamer(["_A"], seed=0)
+        assert [next(namer) for _ in range(5)] == ["_A"] * 5
+
+
+class TestCyclicNamer:
+    def test_flat_sequence_alternating(self):
+        namer = CyclicNamer(["_A", "_B"])
+        assert [next(namer) for _ in range(6)] == ["_A", "_B", "_A", "_B", "_A", "_B"]
+
+    def test_flat_sequence_three(self):
+        namer = CyclicNamer(["_A", "_B", "_C"])
+        assert [next(namer) for _ in range(6)] == ["_A", "_B", "_C", "_A", "_B", "_C"]
+
+    def test_block_sequence(self):
+        namer = CyclicNamer([("_A", 3), ("_B", 2)])
+        expected = ["_A", "_A", "_A", "_B", "_B", "_A", "_A", "_A", "_B", "_B"]
+        assert [next(namer) for _ in range(10)] == expected
+
+    def test_block_sequence_equal_blocks(self):
+        namer = CyclicNamer([("_A", 5), ("_B", 5)])
+        result = [next(namer) for _ in range(20)]
+        assert result[:5] == ["_A"] * 5
+        assert result[5:10] == ["_B"] * 5
+        assert result[10:15] == ["_A"] * 5
+        assert result[15:20] == ["_B"] * 5
+
+    def test_mixed_flat_and_block(self):
+        namer = CyclicNamer(["_A", ("_B", 2)])
+        expected = ["_A", "_B", "_B", "_A", "_B", "_B"]
+        assert [next(namer) for _ in range(6)] == expected
+
+    def test_single_name_cycles_forever(self):
+        namer = CyclicNamer(["_A"])
+        assert [next(namer) for _ in range(5)] == ["_A"] * 5
+
+    def test_empty_sequence_raises(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            CyclicNamer([])
+
+    def test_never_exhausted(self):
+        namer = CyclicNamer(["_A", "_B"])
+        result = list(itertools.islice(namer, 10_000))
+        assert len(result) == 10_000
+
+    def test_repr(self):
+        assert "CyclicNamer" in repr(CyclicNamer(["_A", "_B"]))
+
+
+class TestRandomNamerStrict:
+    def test_exact_composition_one_period(self):
+        namer = RandomNamer(["_A", "_B"], weights=[1, 1], strict=True, seed=0)
+        result = [next(namer) for _ in range(2)]
+        assert sorted(result) == ["_A", "_B"]
+
+    def test_exact_composition_over_many_periods(self):
+        namer = RandomNamer(["_A", "_B"], weights=[1, 1], strict=True, seed=0)
+        result = [next(namer) for _ in range(100)]
+        assert result.count("_A") == result.count("_B") == 50
+
+    def test_weighted_counts_exact(self):
+        namer = RandomNamer(["_A", "_B"], weights=[1, 3], strict=True, seed=0)
+        result = [next(namer) for _ in range(40)]
+        assert result.count("_A") == 10
+        assert result.count("_B") == 30
+
+    def test_each_period_is_shuffled_independently(self):
+        namer = RandomNamer(["_A", "_B"], weights=[1, 1], strict=True, seed=0)
+        period_a = [next(namer) for _ in range(2)]
+        period_b = [next(namer) for _ in range(2)]
+        # Both periods have exact composition; order may differ
+        assert sorted(period_a) == ["_A", "_B"]
+        assert sorted(period_b) == ["_A", "_B"]
+
+    def test_zero_count_raises(self):
+        with pytest.raises(ValueError, match="counts must be >= 1"):
+            RandomNamer(["_A", "_B"], weights=[0, 1], strict=True)
+
+    def test_strict_seeded_reproducibility(self):
+        a = [next(RandomNamer(["_A", "_B"], weights=[1, 3], strict=True, seed=7)) for _ in range(20)]
+        b = [next(RandomNamer(["_A", "_B"], weights=[1, 3], strict=True, seed=7)) for _ in range(20)]
+        assert a == b
+
+    def test_strict_repr(self):
+        assert "strict=True" in repr(RandomNamer(["_A", "_B"], strict=True))
+
+
+class TestMarkovNamer:
+    def test_draws_from_names(self):
+        matrix = [[0.5, 0.5], [0.5, 0.5]]
+        namer = MarkovNamer(["_A", "_B"], matrix, seed=0)
+        result = {next(namer) for _ in range(50)}
+        assert result <= {"_A", "_B"}
+
+    def test_perfect_alternation(self):
+        namer = MarkovNamer(["_A", "_B"], [[0, 1], [1, 0]], start="_A", seed=0)
+        assert [next(namer) for _ in range(6)] == ["_A", "_B", "_A", "_B", "_A", "_B"]
+
+    def test_absorbing_state(self):
+        # Once in _B, stays in _B
+        namer = MarkovNamer(["_A", "_B"], [[0, 1], [0, 1]], start="_A", seed=0)
+        result = [next(namer) for _ in range(6)]
+        assert result[0] == "_A"
+        assert all(r == "_B" for r in result[1:])
+
+    def test_row_normalization(self):
+        # Unnormalized rows (e.g. raw counts) should be normalized automatically
+        namer = MarkovNamer(["_A", "_B"], [[2, 2], [1, 3]], start="_A", seed=42)
+        result = {next(namer) for _ in range(50)}
+        assert result <= {"_A", "_B"}
+
+    def test_start_by_name(self):
+        namer = MarkovNamer(["_A", "_B"], [[0, 1], [1, 0]], start="_B", seed=0)
+        assert next(namer) == "_B"
+
+    def test_seeded_reproducibility(self):
+        matrix = [[0.7, 0.3], [0.4, 0.6]]
+        a = [next(MarkovNamer(["_A", "_B"], matrix, seed=7)) for _ in range(20)]
+        b = [next(MarkovNamer(["_A", "_B"], matrix, seed=7)) for _ in range(20)]
+        assert a == b
+
+    def test_wrong_matrix_shape_raises(self):
+        with pytest.raises(ValueError, match="transition_matrix must be"):
+            MarkovNamer(["_A", "_B"], [[0.5, 0.3, 0.2], [0.5, 0.5, 0.0]])
+
+    def test_three_state(self):
+        matrix = [[0, 1, 0], [0, 0, 1], [1, 0, 0]]  # A→B→C→A→...
+        namer = MarkovNamer(["_A", "_B", "_C"], matrix, start="_A", seed=0)
+        assert [next(namer) for _ in range(6)] == ["_A", "_B", "_C", "_A", "_B", "_C"]
+
+    def test_repr(self):
+        assert "MarkovNamer" in repr(MarkovNamer(["_A", "_B"], [[0.5, 0.5], [0.5, 0.5]]))
+
+
+class TestGradientNamer:
+    def test_draws_from_names(self):
+        namer = GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10, seed=0)
+        result = {next(namer) for _ in range(10)}
+        assert result <= {"_A", "_B"}
+
+    def test_pure_start(self):
+        # weights=[1, 0] at step 0 → must be _A
+        namer = GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10, seed=0)
+        assert next(namer) == "_A"
+
+    def test_pure_end(self):
+        # weights=[0, 1] at step n_steps-1 → must be _B
+        namer = GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=5, seed=0)
+        result = [next(namer) for _ in range(5)]
+        assert result[-1] == "_B"
+
+    def test_composition_shifts(self):
+        # Over many independent runs: early beads mostly _A, late mostly _B
+        n_steps, n_trials = 100, 300
+        first, last = [], []
+        for i in range(n_trials):
+            namer = GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=n_steps, seed=i)
+            result = [next(namer) for _ in range(n_steps)]
+            first.append(result[0])
+            last.append(result[-1])
+        assert first.count("_A") > n_trials * 0.95
+        assert last.count("_B") > n_trials * 0.95
+
+    def test_continues_past_n_steps(self):
+        namer = GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=5, seed=0)
+        for _ in range(5):
+            next(namer)
+        for _ in range(10):
+            assert next(namer) in {"_A", "_B"}
+
+    def test_seeded_reproducibility(self):
+        a = [next(GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10, seed=5)) for _ in range(10)]
+        b = [next(GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10, seed=5)) for _ in range(10)]
+        assert a == b
+
+    def test_repr(self):
+        assert "GradientNamer" in repr(GradientNamer(["_A", "_B"], [1, 0], [0, 1], n_steps=10))
+

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -14,6 +14,7 @@ from mbuild.path.build import (
     straight_line,
     zigzag,
 )
+from mbuild.path.namers import CyclicNamer, RandomNamer
 from mbuild.path.constraints import (
     CuboidConstraint,
     CylinderConstraint,
@@ -198,6 +199,44 @@ class TestPaths(BaseTest):
         zigzag(path, N=20, spacing=1.0, angle_deg=120.0, sites_per_segment=5)
         assert len(path.coordinates) == 20
         assert path.bond_graph.number_of_edges() == 19
+
+    def test_straight_line_cyclic_namer_alternating(self):
+        path = Path()
+        straight_line(path, spacing=0.2, N=6, bead_name=CyclicNamer(["_A", "_B"]))
+        assert list(path.beads) == ["_A", "_B", "_A", "_B", "_A", "_B"]
+
+    def test_straight_line_cyclic_namer_blocks(self):
+        path = Path()
+        straight_line(
+            path, spacing=0.2, N=6, bead_name=CyclicNamer([("_A", 3), ("_B", 3)])
+        )
+        assert list(path.beads) == ["_A", "_A", "_A", "_B", "_B", "_B"]
+
+    def test_cyclic_path_cyclic_namer(self):
+        path = Path()
+        cyclic(path, spacing=1, N=6, bead_name=CyclicNamer(["_A", "_B"]))
+        assert list(path.beads) == ["_A", "_B", "_A", "_B", "_A", "_B"]
+
+    def test_helix_cyclic_namer(self):
+        path = Path()
+        helix(path, N=4, radius=1.0, rise=0.5, twist=90, bead_name=CyclicNamer(["_A", "_B"]))
+        assert list(path.beads) == ["_A", "_B", "_A", "_B"]
+
+    def test_zigzag_cyclic_namer(self):
+        path = Path()
+        zigzag(path, N=4, spacing=1.0, sites_per_segment=2, bead_name=CyclicNamer(["_A", "_B"]))
+        assert list(path.beads) == ["_A", "_B", "_A", "_B"]
+
+    def test_namer_beads_in_bond_graph(self):
+        path = Path()
+        straight_line(path, spacing=0.2, N=4, bead_name=CyclicNamer(["_A", "_B"]))
+        node_names = [d["name"] for _, d in path.bond_graph.nodes(data=True)]
+        assert node_names == ["_A", "_B", "_A", "_B"]
+
+    def test_string_bead_name_still_works(self):
+        path = Path()
+        straight_line(path, spacing=0.2, N=4, bead_name="_X")
+        assert list(path.beads) == ["_X", "_X", "_X", "_X"]
 
 
 class TestRandomWalk(BaseTest):
@@ -606,6 +645,48 @@ class TestRandomWalk(BaseTest):
         _, p_val = scipy.stats.kstest(angles, "uniform", args=uniform_loc_scale)
         assert p_val > 0.05
         assert np.isclose(np.mean(angles), np.pi * 5 / 12, atol=1e-1)
+
+    def test_rw_cyclic_namer_sequence(self):
+        path = hard_sphere_random_walk(
+            radius=0.1,
+            bond_length=0.15,
+            termination=6,
+            bead_name=CyclicNamer(["_A", "_B"]),
+            seed=42,
+        )
+        assert list(path.beads) == ["_A", "_B", "_A", "_B", "_A", "_B"]
+
+    def test_rw_cyclic_namer_blocks(self):
+        path = hard_sphere_random_walk(
+            radius=0.1,
+            bond_length=0.15,
+            termination=6,
+            bead_name=CyclicNamer([("_A", 3), ("_B", 3)]),
+            seed=42,
+        )
+        assert list(path.beads) == ["_A", "_A", "_A", "_B", "_B", "_B"]
+
+    def test_rw_random_namer_draws_from_pool(self):
+        path = hard_sphere_random_walk(
+            radius=0.1,
+            bond_length=0.15,
+            termination=20,
+            bead_name=RandomNamer(["_A", "_B"], seed=0),
+            seed=42,
+        )
+        assert set(path.beads) <= {"_A", "_B"}
+        assert len(path.beads) == 20
+
+    def test_rw_namer_beads_in_bond_graph(self):
+        path = hard_sphere_random_walk(
+            radius=0.1,
+            bond_length=0.15,
+            termination=4,
+            bead_name=CyclicNamer(["_A", "_B"]),
+            seed=42,
+        )
+        node_names = [d["name"] for _, d in path.bond_graph.nodes(data=True)]
+        assert node_names == ["_A", "_B", "_A", "_B"]
 
 
 class TestPathUtils(BaseTest):

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -14,12 +14,12 @@ from mbuild.path.build import (
     straight_line,
     zigzag,
 )
-from mbuild.path.namers import CyclicNamer, RandomNamer
 from mbuild.path.constraints import (
     CuboidConstraint,
     CylinderConstraint,
     SphereConstraint,
 )
+from mbuild.path.namers import CyclicNamer, RandomNamer
 from mbuild.path.path_utils import (
     local_density,
     target_density,
@@ -219,12 +219,25 @@ class TestPaths(BaseTest):
 
     def test_helix_cyclic_namer(self):
         path = Path()
-        helix(path, N=4, radius=1.0, rise=0.5, twist=90, bead_name=CyclicNamer(["_A", "_B"]))
+        helix(
+            path,
+            N=4,
+            radius=1.0,
+            rise=0.5,
+            twist=90,
+            bead_name=CyclicNamer(["_A", "_B"]),
+        )
         assert list(path.beads) == ["_A", "_B", "_A", "_B"]
 
     def test_zigzag_cyclic_namer(self):
         path = Path()
-        zigzag(path, N=4, spacing=1.0, sites_per_segment=2, bead_name=CyclicNamer(["_A", "_B"]))
+        zigzag(
+            path,
+            N=4,
+            spacing=1.0,
+            sites_per_segment=2,
+            bead_name=CyclicNamer(["_A", "_B"]),
+        )
         assert list(path.beads) == ["_A", "_B", "_A", "_B"]
 
     def test_namer_beads_in_bond_graph(self):


### PR DESCRIPTION
### PR Summary:

This provides a data structure for more fine-grained control over bead naming in the various path generation methods of `build.py`.  Similar to `Termination` and `Bias`, the `BeadNamer` class exists outside of the core path generation logic. This makes it easy to modify, and create custom instances of `BeadNamer` without having to change the underlying path code.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
