### PR TITLE
Fix get_initial_point to check overlaps for manually set points

### DIFF
--- a/mbuild/path/points.py
+++ b/mbuild/path/points.py
@@ -137,11 +137,22 @@ def get_initial_point(state, existing_points, beads, check_path, next_step):
     if state.include_compound:
         existing_points = np.concat((existing_points, state.include_compound.xyz))
 
-    # An initial point was manuallyl given in hard_sphere_random_walk, use that.
+    # An initial point was manually given in hard_sphere_random_walk, use that.
+    # Check if this point causes any overlaps, if so, raise error.
     if isinstance(state.initial_point, np.ndarray) and state.initial_point.shape == (
         3,
     ):
-        return state.initial_point
+        if check_path(
+            existing_points=existing_points,
+            new_point=state.initial_point,
+            radius=state.radius,
+            tolerance=state.tolerance,
+        ):
+            return state.initial_point
+        raise PathConvergenceError(
+            f"The provided initial_point {state.initial_point} overlaps with "
+            "existing particles. Try a different starting point."
+        )
 
     # Passing in an index to specify an initial point from already defined set of coordinates
     elif isinstance(state.initial_point, int):

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import mbuild as mb
+from mbuild.exceptions import PathConvergenceError
 from mbuild.path.build import (
     Path,
     crosslink,
@@ -25,6 +26,7 @@ from mbuild.path.path_utils import (
     target_density,
     target_sq_distances,
 )
+from mbuild.path.points import AnglesSampler
 from mbuild.path.termination import (
     NumAttempts,
     NumSites,
@@ -293,6 +295,54 @@ class TestRandomWalk(BaseTest):
         assert comp.n_bonds == 19
         # Test bounds of random initial point
         assert np.all(np.abs(path.coordinates[0])) < 20 * 0.22
+
+    def test_dense_random_walk(self):
+        rw_system = Path()
+        vol_constaint = CuboidConstraint(center=(0, 0, 0), Lx=8)
+        radius = 0.25
+        bond_L = radius + 0.001
+        num_chains = 200
+        chain_lengths = 40
+        tolerance = 0.01
+
+        for i in range(num_chains):
+            chain_passed = False
+            attempt = 0
+            while not chain_passed:
+                initial_point = vol_constaint.find_low_density_points(
+                    n_candidates=200 + attempt,
+                    points=rw_system.coordinates,
+                    buffer=radius,
+                )
+                term = Termination(
+                    [NumSites(chain_lengths), NumAttempts(chain_lengths)]
+                )
+                try:
+                    hard_sphere_random_walk(
+                        path=rw_system,
+                        bead_name="A",
+                        radius=radius,
+                        bond_length=bond_L,
+                        volume_constraint=vol_constaint,
+                        termination=term,
+                        seed=i,
+                        initial_point=initial_point[attempt],
+                        rw_angles=AnglesSampler(
+                            "normal", dict(loc=2.4, scale=1), seed=i
+                        ),
+                        tolerance=tolerance,
+                    )
+                    if term.success:
+                        attempt = 0
+                        chain_passed = True
+                    else:
+                        attempt += 1
+                except PathConvergenceError:
+                    attempt += 1  # try next initial_point candidate
+                except Exception:
+                    break  # only break on unexpected errors
+        comp = rw_system.to_compound()
+        assert len(comp.check_for_overlap(minimum_distance=radius - tolerance)) == 0
 
     def test_include_compound(self):
         L = 3


### PR DESCRIPTION
### PR Summary:

`get_initial_point` was not checking if a manually defined coordinate was causing overlaps. This is fixed now, and I added a test that performs a relatively dense multichain RW and makes sure there are no overlaps.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
