### PR TITLE
Fix bug in extending beads when including a compound

### DIFF
--- a/mbuild/path/points.py
+++ b/mbuild/path/points.py
@@ -51,9 +51,13 @@ def get_second_point(state, existing_points, beads, check_path, next_step):
     else:
         pos1 = None
         pos2 = existing_points[-1]
-    # Update existing points to include those in the compound.
+    # Update existing points and beads to include those in the compound.
     if state.include_compound:
-        existing_points = np.concat((existing_points, state.include_compound.xyz))
+        compound_xyz = state.include_compound.xyz
+        compound_names = np.array([p.name for p in state.include_compound.particles()])
+        existing_points = np.concat((existing_points, compound_xyz))
+        beads = np.concat((beads, compound_names))
+
     xyzs = next_step(
         pos1=pos1,
         pos2=pos2,
@@ -134,8 +138,14 @@ def get_initial_point(state, existing_points, beads, check_path, next_step):
         If no valid starting point can be found within the trial batch,
         regardless of which strategy is used.
     """
+    # Get len of existing points before adding coords from include compound
+    n_walk_points = len(existing_points)
+    # Include a Compound's coordinates and bead names
     if state.include_compound:
-        existing_points = np.concat((existing_points, state.include_compound.xyz))
+        compound_xyz = state.include_compound.xyz
+        compound_names = np.array([p.name for p in state.include_compound.particles()])
+        existing_points = np.concat((existing_points, compound_xyz))
+        beads = np.concat((beads, compound_names))
 
     # An initial point was manually given in hard_sphere_random_walk, use that.
     # Check if this point causes any overlaps, if so, raise error.
@@ -156,10 +166,10 @@ def get_initial_point(state, existing_points, beads, check_path, next_step):
 
     # Passing in an index to specify an initial point from already defined set of coordinates
     elif isinstance(state.initial_point, int):
-        if state.initial_point >= len(existing_points):
+        if state.initial_point >= n_walk_points:
             raise ValueError(
                 f"You passed a starting index of {state.initial_point} "
-                f"but there are only {len(existing_points)} existing points in the path."
+                f"but there are only {n_walk_points} existing points in the path."
             )
         # generate point off of current path coordinates
         starting_xyz = existing_points[state.initial_point]


### PR DESCRIPTION
### PR Summary:

`points.py` extends existing_coordinates when using include compound, but it needs to also extend the bead names. Not doing this was causing issues when including a Bias in the initial walks. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
