### PR TITLE
Clean up method parameters in `build.py` so default behavior is consistent.

### DIFF
--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -694,14 +694,7 @@ def knot(spacing, N, m, path=None, closed=True, bead_name="_A"):
 
 
 def helix(
-    N,
-    radius,
-    rise,
-    twist,
-    path=None,
-    right_handed=True,
-    bottom_up=True,
-    bead_name="_A"
+    N, radius, rise, twist, path=None, right_handed=True, bottom_up=True, bead_name="_A"
 ):
     """Generate helical path.
 
@@ -815,7 +808,7 @@ def zigzag(
     ----------
     N : int, required
         Number of sites in the path
-    spacing : float, required 
+    spacing : float, required
         The distance (nm) between consecutive sites along the path.
     path : mbuild.path.Path
         The Path object to populate with coordinates.

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -517,17 +517,18 @@ def lamellar(
     return path
 
 
-def straight_line(path, spacing, N, direction=(1, 0, 0), bead_name="_A"):
+def straight_line(spacing, N, path=None, direction=(1, 0, 0), bead_name="_A"):
     """Generates a set of coordinates in a straight line along a given axis.
 
     Parameters
     ----------
-    path : mbuild.path.Path, required
-        The Path object to populate with coordinates
     N : int, required
         The number of sites in the path.
     spacing : float, required
         The distance between sites along the path.
+    path : mbuild.path.Path
+        The Path object to populate with coordinates.
+        Defaults to creating a new, empty Path if no Path is given.
     direction : array-like (1,3), default = (1,0,0)
         The direction to align the straight path along.
     bead_name : str or path.BeadNamer, optional, default '_A'
@@ -535,6 +536,8 @@ def straight_line(path, spacing, N, direction=(1, 0, 0), bead_name="_A"):
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
     """
+    if path is None:
+        path = Path()
     direction = np.asarray(direction)
     coordinates = np.array([np.zeros(3) + i * spacing * direction for i in range(N)])
     start_index = len(path.coordinates)
@@ -548,17 +551,18 @@ def straight_line(path, spacing, N, direction=(1, 0, 0), bead_name="_A"):
     return path
 
 
-def cyclic(path, spacing=None, N=None, radius=None, closed=True, bead_name="_A"):
+def cyclic(spacing=None, N=None, path=None, radius=None, closed=True, bead_name="_A"):
     """Generates a set of coordinates evenly spaced along a circle.
 
     Parameters
     ----------
-    path : mbuild.path.Path, required
-        The Path object to populate with coordinates
     spacing : float, optional
         Distance between sites along the path.
     N : int, optional
         Number of sites in the cyclic path.
+    path : mbuild.path.Path
+        The Path object to populate with coordinates.
+        Defaults to creating a new, empty Path if no Path is given.
     radius : float, optional
         The radius (nm) of the cyclic path.
     closed : bool, default True
@@ -573,6 +577,8 @@ def cyclic(path, spacing=None, N=None, radius=None, closed=True, bead_name="_A")
     Only two of spacing, N and radius can be defined, as the third
     is determined by the other two.
     """
+    if path is None:
+        path = Path()
     n_params = sum(1 for i in (spacing, N, radius) if i is not None)
     if n_params != 2:
         raise ValueError("You must specify only 2 of spacing, N and radius.")
@@ -604,13 +610,11 @@ def cyclic(path, spacing=None, N=None, radius=None, closed=True, bead_name="_A")
     return path
 
 
-def knot(path, spacing, N, m, closed=True, bead_name="_A"):
+def knot(spacing, N, m, path=None, closed=True, bead_name="_A"):
     """Generate a knot path.
 
     Parameters
     ----------
-    path : mbuild.path.Path, required
-        The Path object to populate with coordinates
     spacing : float (nm)
         The spacing between sites along the path.
     N : int
@@ -618,6 +622,9 @@ def knot(path, spacing, N, m, closed=True, bead_name="_A"):
     m : int in [3, 4, 5]
         The number of crossings in the knot.
         3 gives the trefoil knot, 4 gives the figure 8 knot and 5 gives the cinquefoil knot.
+    path : mbuild.path.Path
+        The Path object to populate with coordinates.
+        Defaults to creating a new, empty Path if no Path is given.
     closed : bool, default True
         If `True` the cyclic path is closed by bonding the first and last sites together
     bead_name : str or path.BeadNamer, optional, default '_A'
@@ -625,6 +632,8 @@ def knot(path, spacing, N, m, closed=True, bead_name="_A"):
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
     """
+    if path is None:
+        path = Path()
     # Generate dense sites first, sample actual ones later from spacing
     t_dense = np.linspace(0, 2 * np.pi, 5000)
 
@@ -685,14 +694,19 @@ def knot(path, spacing, N, m, closed=True, bead_name="_A"):
 
 
 def helix(
-    path, N, radius, rise, twist, right_handed=True, bottom_up=True, bead_name="_A"
+    N,
+    radius,
+    rise,
+    twist,
+    path=None,
+    right_handed=True,
+    bottom_up=True,
+    bead_name="_A"
 ):
     """Generate helical path.
 
     Parameters:
     -----------
-    path : mbuild.path.Path, required
-        The Path object to populate with coordinates
     N : int, required
         Number of sites in the path
     radius : float, required
@@ -701,6 +715,9 @@ def helix(
         Rise per site on path (nm)
     twist : float, required
         Twist per site in path (degrees)
+    path : mbuild.path.Path
+        The Path object to populate with coordinates.
+        Defaults to creating a new, empty Path if no Path is given.
     right_handed : bool, default True
         Set the handedness of the helical twist
     bottom_up : bool, default True
@@ -710,6 +727,8 @@ def helix(
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
     """
+    if path is None:
+        path = Path()
     coordinates = np.zeros((N, 3))
     indices = reversed(range(N)) if not bottom_up else range(N)
 
@@ -733,13 +752,11 @@ def helix(
     return path
 
 
-def spiral_2D(path, N, a, b, spacing, bead_name="_A"):
+def spiral_2D(N, a, b, spacing, path=None, bead_name="_A"):
     """Generate a 2D spiral path in the XY plane.
 
     Parameters
     ----------
-    path : mbuild.path.Path, required
-        The Path object to populate with coordinates
     N : int, required
         Number of sites in the path
     a : float, required
@@ -748,11 +765,16 @@ def spiral_2D(path, N, a, b, spacing, bead_name="_A"):
         Determines how fast radius grows per angle increment (r = a + bθ)
     spacing : float, required
         Distance between adjacent sites (nm)
+    path : mbuild.path.Path
+        The Path object to populate with coordinates.
+        Defaults to creating a new, empty Path if no Path is given.
     bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
     """
+    if path is None:
+        path = Path()
     coordinates = np.zeros((N, 3))
     theta = 0.0
 
@@ -779,9 +801,9 @@ def spiral_2D(path, N, a, b, spacing, bead_name="_A"):
 
 
 def zigzag(
-    path,
     N,
-    spacing=1.0,
+    spacing,
+    path=None,
     angle_deg=120.0,
     sites_per_segment=4,
     plane="xy",
@@ -791,12 +813,13 @@ def zigzag(
 
     Parameters
     ----------
-    path : mbuild.path.Path, required
-        The Path object to populate with coordinates
     N : int, required
         Number of sites in the path
-    spacing : float, default = 1.0 nm
+    spacing : float, required 
         The distance (nm) between consecutive sites along the path.
+    path : mbuild.path.Path
+        The Path object to populate with coordinates.
+        Defaults to creating a new, empty Path if no Path is given.
     angle_deg : float, default = 120.
         The rotation (degrees) applied between segments
     sites_per_segment : int, default = 4
@@ -811,6 +834,8 @@ def zigzag(
     if N % sites_per_segment != 0:
         raise ValueError("N must be evenly divisible by sites_per_segment")
 
+    if path is None:
+        path = Path()
     angle_rad = np.deg2rad(angle_deg)
     direction = np.array([1.0, 0.0])
     position = np.zeros(2)
@@ -886,8 +911,9 @@ def hard_sphere_random_walk(
 
     Parameters:
     -----------
-    path : mbuild.path.Path, default None.
-        The Path object to populate with coordinates. Creates a new path object if not passed.
+    path : mbuild.path.Path
+        The Path object to populate with coordinates.
+        Defaults to creating a new, empty Path if no Path is given.
     bead_name : str or path.BeadNamer, optional, default '_A'
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -204,7 +204,7 @@ class TestPaths(BaseTest):
 
     def test_straight_line_cyclic_namer_alternating(self):
         path = Path()
-        straight_line(path, spacing=0.2, N=6, bead_name=CyclicNamer(["_A", "_B"]))
+        straight_line(path=path, spacing=0.2, N=6, bead_name=CyclicNamer(["_A", "_B"]))
         assert list(path.beads) == ["_A", "_B", "_A", "_B", "_A", "_B"]
 
     def test_straight_line_cyclic_namer_blocks(self):
@@ -901,14 +901,14 @@ class TestCrossLinks(BaseTest):
             assert (i + 10, i + 20) in path.bond_graph.edges
 
     def test_deterministic_rw(self):
-        path1 = hard_sphere_random_walk(  # TODO: hsrw cuts off some chains early
+        path1 = hard_sphere_random_walk(
             radius=1,
             bond_length=2,
             termination=20,
             rw_angles=(np.pi / 2, np.pi),
             seed=1,
         )
-        path2 = hard_sphere_random_walk(  # TODO: hsrw cuts off some chains early
+        path2 = hard_sphere_random_walk(
             radius=1,
             bond_length=2,
             termination=20,

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -66,7 +66,7 @@ class TestPaths(BaseTest):
 
     def test_straight_line(self):
         path = Path()  # works with empty path
-        straight_line(path, spacing=0.20, N=5, direction=(1, 0, 0))
+        straight_line(path=path, spacing=0.20, N=5, direction=(1, 0, 0))
         assert len(path.coordinates) == 5
         assert path.bond_graph.number_of_edges() == 4
         # 5 sites = 4 bonds at 0.20 each
@@ -78,7 +78,7 @@ class TestPaths(BaseTest):
 
     def test_cyclic_parameters(self):
         path = Path()
-        cyclic(path, spacing=1, N=20)
+        cyclic(path=path, spacing=1, N=20)
         # C = 2*pi*r
         radius = 20 * 1 / (2 * np.pi)
         # Check that computed radius matches expected
@@ -86,25 +86,25 @@ class TestPaths(BaseTest):
         assert np.allclose(actual_radius, radius, atol=1e-2)
 
         path2 = Path()
-        cyclic(path2, spacing=1, radius=10 / np.pi, N=None)
+        cyclic(path=path2, spacing=1, radius=10 / np.pi, N=None)
         assert len(path2.coordinates) == 20
 
         path3 = Path()
-        cyclic(path3, N=20, radius=10 / np.pi, spacing=None)
+        cyclic(path=path3, N=20, radius=10 / np.pi, spacing=None)
         # Check spacing
         dist = np.linalg.norm(path3.coordinates[1] - path3.coordinates[0])
         assert np.allclose(dist, 1.0, atol=1e-2)
 
     def test_cyclic_bonding(self):
         path = Path()
-        cyclic(path, spacing=1, N=20)
+        cyclic(path=path, spacing=1, N=20)
         assert path.bond_graph.number_of_edges() == 20
         comp = path.to_compound()
         assert comp.n_bonds == comp.n_particles
 
     def test_knot(self):
         path = Path()
-        knot(path, spacing=0.25, N=50, m=3)
+        knot(path=path, spacing=0.25, N=50, m=3)
         assert path.bond_graph.number_of_edges() == 50
         comp = path.to_compound()
         assert comp.n_bonds == comp.n_particles
@@ -112,11 +112,11 @@ class TestPaths(BaseTest):
     def test_knot_bad_arg(self):
         path = Path()
         with pytest.raises(ValueError):
-            knot(path, spacing=0.25, N=50, m=2)
+            knot(path=path, spacing=0.25, N=50, m=2)
 
     def test_spiral(self):
         path = Path()
-        spiral_2D(path, N=50, a=0.5, b=2, spacing=0.25)
+        spiral_2D(path=path, N=50, a=0.5, b=2, spacing=0.25)
         assert path.bond_graph.number_of_edges() == 49
         comp = path.to_compound()
         assert comp.n_bonds == comp.n_particles - 1
@@ -124,7 +124,7 @@ class TestPaths(BaseTest):
     def test_lamellar(self):
         path = Path()
         lamellar(
-            path,
+            path=path,
             bond_length=0.25,
             num_layers=3,
             layer_separation=1.0,
@@ -143,7 +143,7 @@ class TestPaths(BaseTest):
     def test_lamellar_direction(self):
         path_left_to_right = Path()
         lamellar(
-            path_left_to_right,
+            path=path_left_to_right,
             bond_length=0.25,
             num_layers=3,
             layer_separation=1.0,
@@ -155,7 +155,7 @@ class TestPaths(BaseTest):
 
         path_right_to_left = Path()
         lamellar(
-            path_right_to_left,
+            path=path_right_to_left,
             bond_length=0.25,
             num_layers=3,
             layer_separation=1.0,
@@ -175,7 +175,7 @@ class TestPaths(BaseTest):
     def test_lamellar_initial_point(self):
         path = Path()
         lamellar(
-            path,
+            path=path,
             bond_length=0.25,
             num_layers=3,
             layer_separation=1.0,
@@ -189,7 +189,7 @@ class TestPaths(BaseTest):
 
     def test_helix(self):
         path = Path()
-        helix(path, N=50, radius=2.0, rise=0.5, twist=30)
+        helix(path=path, N=50, radius=2.0, rise=0.5, twist=30)
         assert len(path.coordinates) == 50
         assert path.bond_graph.number_of_edges() == 49
         # Check that all points are roughly at radius distance from z-axis
@@ -198,7 +198,7 @@ class TestPaths(BaseTest):
 
     def test_zigzag(self):
         path = Path()
-        zigzag(path, N=20, spacing=1.0, angle_deg=120.0, sites_per_segment=5)
+        zigzag(path=path, N=20, spacing=1.0, angle_deg=120.0, sites_per_segment=5)
         assert len(path.coordinates) == 20
         assert path.bond_graph.number_of_edges() == 19
 
@@ -210,19 +210,19 @@ class TestPaths(BaseTest):
     def test_straight_line_cyclic_namer_blocks(self):
         path = Path()
         straight_line(
-            path, spacing=0.2, N=6, bead_name=CyclicNamer([("_A", 3), ("_B", 3)])
+            path=path, spacing=0.2, N=6, bead_name=CyclicNamer([("_A", 3), ("_B", 3)])
         )
         assert list(path.beads) == ["_A", "_A", "_A", "_B", "_B", "_B"]
 
     def test_cyclic_path_cyclic_namer(self):
         path = Path()
-        cyclic(path, spacing=1, N=6, bead_name=CyclicNamer(["_A", "_B"]))
+        cyclic(path=path, spacing=1, N=6, bead_name=CyclicNamer(["_A", "_B"]))
         assert list(path.beads) == ["_A", "_B", "_A", "_B", "_A", "_B"]
 
     def test_helix_cyclic_namer(self):
         path = Path()
         helix(
-            path,
+            path=path,
             N=4,
             radius=1.0,
             rise=0.5,
@@ -234,7 +234,7 @@ class TestPaths(BaseTest):
     def test_zigzag_cyclic_namer(self):
         path = Path()
         zigzag(
-            path,
+            path=path,
             N=4,
             spacing=1.0,
             sites_per_segment=2,
@@ -244,13 +244,13 @@ class TestPaths(BaseTest):
 
     def test_namer_beads_in_bond_graph(self):
         path = Path()
-        straight_line(path, spacing=0.2, N=4, bead_name=CyclicNamer(["_A", "_B"]))
+        straight_line(path=path, spacing=0.2, N=4, bead_name=CyclicNamer(["_A", "_B"]))
         node_names = [d["name"] for _, d in path.bond_graph.nodes(data=True)]
         assert node_names == ["_A", "_B", "_A", "_B"]
 
     def test_string_bead_name_still_works(self):
         path = Path()
-        straight_line(path, spacing=0.2, N=4, bead_name="_X")
+        straight_line(path=path, spacing=0.2, N=4, bead_name="_X")
         assert list(path.beads) == ["_X", "_X", "_X", "_X"]
 
 
@@ -260,7 +260,7 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(80)
         max_attempts = NumAttempts(1e4)
         hard_sphere_random_walk(
-            path,
+            path=path,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -280,7 +280,7 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         hard_sphere_random_walk(
-            path,
+            path=path,
             termination=[num_sites, max_attempts],
             bond_length=0.25,
             radius=0.22,
@@ -355,7 +355,7 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         chain = hard_sphere_random_walk(
-            path,
+            path=path,
             termination=[num_sites, max_attempts],
             bond_length=0.25,
             volume_constraint=vol_constraint,
@@ -375,7 +375,7 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         hard_sphere_random_walk(
-            path,
+            path=path,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -389,7 +389,7 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         hard_sphere_random_walk(
-            path1,
+            path=path1,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -397,7 +397,7 @@ class TestRandomWalk(BaseTest):
         )
         path2 = Path()
         hard_sphere_random_walk(
-            path2,
+            path=path2,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -410,7 +410,7 @@ class TestRandomWalk(BaseTest):
         num_sites = NumSites(20)
         max_attempts = NumAttempts(1e4)
         hard_sphere_random_walk(
-            path1,
+            path=path1,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -418,7 +418,7 @@ class TestRandomWalk(BaseTest):
         )
         path2 = Path()
         hard_sphere_random_walk(
-            path2,
+            path=path2,
             termination=Termination([num_sites, max_attempts]),
             bond_length=0.25,
             radius=0.22,
@@ -433,7 +433,7 @@ class TestRandomWalk(BaseTest):
         cube = CuboidConstraint(Lx=5, Ly=5, Lz=5)
         for i in range(100):
             hard_sphere_random_walk(
-                path,
+                path=path,
                 termination=Termination([NumSites(5), NumAttempts(100)]),
                 bond_length=0.25,
                 radius=0.22,
@@ -447,7 +447,7 @@ class TestRandomWalk(BaseTest):
         # First make sure this seed gives a path outside these bounds without PBC
         path1 = Path()
         hard_sphere_random_walk(
-            path1,
+            path=path1,
             termination=Termination([NumSites(500), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
@@ -461,7 +461,7 @@ class TestRandomWalk(BaseTest):
         path2 = Path()
         cube = CuboidConstraint(Lx=5, Ly=5, Lz=5, pbc=(True, True, True))
         hard_sphere_random_walk(
-            path2,
+            path=path2,
             termination=Termination([NumSites(500), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
@@ -476,7 +476,7 @@ class TestRandomWalk(BaseTest):
         path = Path()
         sphere = SphereConstraint(radius=4, center=(2, 2, 2))
         hard_sphere_random_walk(
-            path,
+            path=path,
             termination=Termination([NumSites(200), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,
@@ -491,7 +491,7 @@ class TestRandomWalk(BaseTest):
         path = Path()
         cylinder = CylinderConstraint(radius=3, height=6, center=(0, 0, 0))
         hard_sphere_random_walk(
-            path,
+            path=path,
             termination=Termination([NumSites(200), NumAttempts(1e4)]),
             bond_length=0.25,
             radius=0.22,


### PR DESCRIPTION
### PR Summary:

Some build methods had a way to handle `path=None` while others left `path` as a required parameter. This changes it so all methods in `build.py` defualt to `path=None` and create a new Path instances. 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
