### PR TITLE
Quick fix to visualization method in Path

### DIFF
--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -368,7 +368,7 @@ def lamellar(
     num_layers=1,
     layer_separation=None,
     layer_length=None,
-    bond_length=None,
+    spacing=None,
     initial_point=(0, 0, 0),
     num_stacks=1,
     stack_separation=None,
@@ -387,7 +387,7 @@ def lamellar(
         The distance between any two layers.
     layer_length : float (nm), required
         The distance of a lamellar layer before curving to the next.
-    bond_length : float (nm), required
+    spacing : float (nm), required
         The distance between two adjacent sites in the path.
     initial_point : nd.array (1,3), default (0,0,0)
         The coordinate of the first site of the lamellar path.
@@ -407,7 +407,7 @@ def lamellar(
     initial_point = np.asarray(initial_point)
 
     # Coordinates in the y-direction (layer-length) of the lamellar layer
-    layer_spacing = np.arange(0, layer_length, bond_length)
+    layer_spacing = np.arange(0, layer_length, spacing)
     if not left_to_right:
         layer_spacing *= -1
     layer_spacing += initial_point[1]
@@ -415,7 +415,7 @@ def lamellar(
     # Info needed for generating coords of the arc curves between layers
     r = layer_separation / 2
     arc_length = r * np.pi
-    arc_num_points = math.floor(arc_length / bond_length)
+    arc_num_points = math.floor(arc_length / spacing)
     arc_angle = np.pi / (arc_num_points + 1)
     arc_angles = np.linspace(arc_angle, np.pi, arc_num_points, endpoint=False)
 
@@ -461,7 +461,7 @@ def lamellar(
         first_stack_coordinates = np.copy(np.array(coordinates))
         r = stack_separation / 2
         arc_length = r * np.pi
-        arc_num_points = math.floor(arc_length / bond_length)
+        arc_num_points = math.floor(arc_length / spacing)
         arc_angle = np.pi / (arc_num_points + 1)
         arc_angles = np.linspace(arc_angle, np.pi, arc_num_points, endpoint=False)
 

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -176,7 +176,7 @@ class TestPaths(BaseTest):
         path = Path()
         lamellar(
             path=path,
-            bond_length=0.25,
+            spacing=0.25,
             num_layers=3,
             layer_separation=1.0,
             layer_length=3.0,

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -125,7 +125,7 @@ class TestPaths(BaseTest):
         path = Path()
         lamellar(
             path=path,
-            bond_length=0.25,
+            spacing=0.25,
             num_layers=3,
             layer_separation=1.0,
             layer_length=3.0,
@@ -144,7 +144,7 @@ class TestPaths(BaseTest):
         path_left_to_right = Path()
         lamellar(
             path=path_left_to_right,
-            bond_length=0.25,
+            spacing=0.25,
             num_layers=3,
             layer_separation=1.0,
             layer_length=3.0,
@@ -156,7 +156,7 @@ class TestPaths(BaseTest):
         path_right_to_left = Path()
         lamellar(
             path=path_right_to_left,
-            bond_length=0.25,
+            spacing=0.25,
             num_layers=3,
             layer_separation=1.0,
             layer_length=3.0,

--- a/mbuild/utils/visualize.py
+++ b/mbuild/utils/visualize.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import numpy as np
 
+from mbuild.path.formats import to_mol3000
 from mbuild.utils.io import import_
 
 
@@ -61,7 +62,7 @@ def visualize_path(path, radius=0.1, hide_periodic_bonds=False):
         "#000000",
     ]
 
-    data = path.to_mol3000(G)
+    data = to_mol3000(path=path, G=G)
     view = py3Dmol.view(data=data)
     for i, name in enumerate(unique_names):
         color = colors[i % len(colors)]


### PR DESCRIPTION
### PR Summary:

calling `.visualize()` on a Path object wasn't working for me in the latest `develop` branch.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
