### PR TITLE
Fix PBC checks, make pbc and box length info accessible to RandomWalkState

### DIFF
--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -999,12 +999,15 @@ def hard_sphere_random_walk(
     namer = BeadNamer.coerce(bead_name)
     namer._attach_rng(np.random.default_rng(name_seed_sequence))
 
-    # Set up PBC info from volume constraints
+    # Set up PBC info from volume constraints cast to numba-safe arrays
+    # TODO: We can probably out-source pbc, box_lengths return to the Constraint classes
     if isinstance(volume_constraint, CuboidConstraint):
-        pbc = volume_constraint.pbc
+        pbc = np.asarray(volume_constraint.pbc, dtype=np.bool_)
         box_lengths = volume_constraint.box_lengths.astype(np.float32)
     elif isinstance(volume_constraint, CylinderConstraint):
-        pbc = (False, False, volume_constraint.periodic_height)
+        pbc = np.array(
+            [False, False, volume_constraint.periodic_height], dtype=np.bool_
+        )
         box_lengths = np.array(
             [
                 volume_constraint.radius * 2,
@@ -1013,8 +1016,10 @@ def hard_sphere_random_walk(
             ]
         ).astype(np.float32)
     else:
-        pbc = (None, None, None)
-        box_lengths = (None, None, None)
+        pbc = np.array([False, False, False], dtype=np.bool_)
+        box_lengths = np.array([np.inf, np.inf, np.inf], dtype=np.float32)
+    state.pbc = pbc
+    state.box_lengths = box_lengths
 
     # Set up bias conditions
     if bias:
@@ -1141,11 +1146,12 @@ def hard_sphere_random_walk(
                 coordinates=coordinates[: state.count],
                 names=beads[: state.count],
             )
-        # Handle postion for PBCs
+        # Handle postion for PBCs. Cast back to float32
         if any(pbc):
-            candidates = volume_constraint.mins + np.mod(
-                candidates - volume_constraint.mins, box_lengths
-            )
+            candidates = (
+                volume_constraint.mins
+                + np.mod(candidates - volume_constraint.mins, box_lengths)
+            ).astype(np.float32)
         # Check candidate sites
         accept_xyz = None
         if state.run_on_gpu and len(candidates) > 0:
@@ -1157,6 +1163,8 @@ def hard_sphere_random_walk(
                 candidates,
                 radius,
                 tolerance,
+                pbc=pbc,
+                box_lengths=box_lengths,
             )
             valid_candidates = candidates[valid_mask]
             if len(valid_candidates) > 0:
@@ -1172,6 +1180,8 @@ def hard_sphere_random_walk(
                     new_point=xyz,
                     radius=radius,
                     tolerance=tolerance,
+                    pbc=pbc,
+                    box_lengths=box_lengths,
                 ):
                     accept_xyz = xyz
                     break
@@ -1180,7 +1190,6 @@ def hard_sphere_random_walk(
             coordinates[state.count] = accept_xyz
             beads[state.count] = next(namer)
             state.count += 1
-
         state.attempts += 1
 
         # Extend coordinates array if we're running out of space
@@ -1202,10 +1211,8 @@ def hard_sphere_random_walk(
 class RandomWalkState:
     """Tracks state and configuration for a hard_sphere_random_walk.
 
-
     This class encapsulates all the bookkeeping information needed during
     a random walk, keeping the Path object clean of implementation details.
-
 
     Attributes
     ----------
@@ -1342,6 +1349,10 @@ class RandomWalkState:
         self.attempts = 0
         self.start_time = None
         self.gpu_static_points = None
+        # PBC info for overlap checks; populated in hard_sphere_random_walk.
+        # Defaults reproduce non-periodic behavior.
+        self.pbc = np.array([False, False, False], dtype=np.bool_)
+        self.box_lengths = np.array([np.inf, np.inf, np.inf], dtype=np.float32)
 
     def check_termination(self, path, coordinates, beads):
         """Examine and process termination if we have reached.

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -999,7 +999,7 @@ def hard_sphere_random_walk(
     namer = BeadNamer.coerce(bead_name)
     namer._attach_rng(np.random.default_rng(name_seed_sequence))
 
-    # Set up PBC info from volume constraints cast to numba-safe arrays
+    # Set up PBC info from volume constraints
     # TODO: We can probably out-source pbc, box_lengths return to the Constraint classes
     if isinstance(volume_constraint, CuboidConstraint):
         pbc = np.asarray(volume_constraint.pbc, dtype=np.bool_)
@@ -1146,7 +1146,7 @@ def hard_sphere_random_walk(
                 coordinates=coordinates[: state.count],
                 names=beads[: state.count],
             )
-        # Handle postion for PBCs. Cast back to float32
+        # Handle postion for PBCs.
         if any(pbc):
             candidates = (
                 volume_constraint.mins

--- a/mbuild/path/path_utils.py
+++ b/mbuild/path/path_utils.py
@@ -56,7 +56,14 @@ def random_coordinate(
 
 
 @njit(cache=True, fastmath=True)
-def check_path(existing_points, new_point, radius, tolerance):
+def check_path(
+    existing_points,
+    new_point,
+    radius,
+    tolerance,
+    pbc=np.array([False, False, False], dtype=bool),
+    box_lengths=np.array([np.inf, np.inf, np.inf], dtype=np.float32),
+):
     """Default check path method for HardSphereRandomWalk.
 
     Parameters
@@ -71,6 +78,14 @@ def check_path(existing_points, new_point, radius, tolerance):
         The radius used for hard-sphere overlap checks.
     tolerance : float, required
         Tolerance in center-to-center distances, allowing for rounding errors.
+    pbc : np.ndarray (3,) of bool, optional
+        Periodic boundary flags per axis. When an axis is periodic, the
+        center-to-center distance along that axis uses the minimum-image
+        convention so overlaps across a periodic face are detected. The
+        default of all ``False`` reproduces the non-periodic behavior.
+    box_lengths : np.ndarray (3,) of float, optional
+        Box length along each axis, used for the minimum-image wrap on
+        periodic axes. Only consulted where ``pbc`` is ``True``.
     """
     if existing_points is None or existing_points.size == 0:
         return True
@@ -79,6 +94,9 @@ def check_path(existing_points, new_point, radius, tolerance):
         dist_sq = 0.0
         for j in range(existing_points.shape[1]):
             diff = existing_points[i, j] - new_point[j]
+            # Apply minimum-image convention on periodic axes
+            if pbc[j]:
+                diff -= np.round(diff / box_lengths[j]) * box_lengths[j]
             dist_sq += diff * diff
         if dist_sq < min_sq_dist:
             return False

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -22,6 +22,7 @@ from mbuild.path.constraints import (
 )
 from mbuild.path.namers import CyclicNamer, RandomNamer
 from mbuild.path.path_utils import (
+    check_path,
     local_density,
     target_density,
     target_sq_distances,
@@ -932,6 +933,32 @@ class TestPathUtils(BaseTest):
             _, p_value = scipy.stats.normaltest(points)
 
         assert p_value > 0.05
+
+    @pytest.mark.parametrize("axis", [0, 1, 2])
+    def test_check_path_pbc_overlap_across_face(self, axis):
+        # Two beads sit just inside opposite faces of a 10 x 10 x 10 box.
+        # minimum-image separation is 0.2
+        box_lengths = np.full(3, 10.0, dtype=np.float32)
+        radius = 1.0
+        tolerance = 1e-5
+        existing = np.full((1, 3), 5.0, dtype=np.float32)
+        existing[0, axis] = 0.1
+        candidate = np.full(3, 5.0, dtype=np.float32)
+        candidate[axis] = 9.9
+        # No PBCs should be accepted.
+        assert check_path(existing, candidate, radius, tolerance)
+
+        # Periodic on each axis, should be rejected.
+        pbc = np.array([False, False, False])
+        pbc[axis] = True
+        assert not check_path(
+            existing,
+            candidate,
+            radius,
+            tolerance,
+            pbc=pbc,
+            box_lengths=box_lengths,
+        )
 
 
 class TestCrossLinks(BaseTest):


### PR DESCRIPTION
### PR Summary:
This fixes an issue with checking for overlaps along PBCs, adds a test that should have caught it. This also makes pbc information and box lengths accessible to RandomWalkState

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
