### PR TITLE
Use shutil.copyfile instead of os.system("cp") in packing (Windows portability)

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -1211,7 +1211,7 @@ def _run_packmol(input_text, filled_xyz, temp_file, packmol_file):
             "Packmol finished with imperfect packing. Using the .xyz_FORCED "
             "file instead. This may not be a sufficient packing result."
         )
-        os.system(f"cp {filled_xyz.name}_FORCED {filled_xyz.name}")
+        shutil.copyfile(f"{filled_xyz.name}_FORCED", filled_xyz.name)
 
     if "ERROR" in out or proc.returncode != 0:
         _packmol_error(out, err)
@@ -1220,7 +1220,7 @@ def _run_packmol(input_text, filled_xyz, temp_file, packmol_file):
         os.remove(packmol_inp.name)
 
     if temp_file is not None:
-        os.system("cp {0} {1}".format(filled_xyz.name, os.path.join(temp_file)))
+        shutil.copyfile(filled_xyz.name, temp_file)
 
 
 def _check_packmol(PACKMOL):  # pragma: no cover


### PR DESCRIPTION
In `_run_packmol` (`mbuild/packing.py`), two copies shell out to `cp` via `os.system`. `cp` is a Unix-only command, but mBuild is distributed on conda-forge for **win-64**, and `_check_packmol` right below already branches on `sys.platform.startswith("win")`. On Windows both calls fail, which breaks:

- the "imperfect packing" fallback that copies `<name>_FORCED` over the result, and
- the copy of the packed file to the user-provided `temp_file`.

They also invoke a shell with interpolated filenames unnecessarily (breaks on paths containing spaces).

### Change
Replace both `os.system("cp ...")` calls with `shutil.copyfile(...)` — portable, shell-free, and already used elsewhere in this module (`shutil` is imported at the top). Also drops a no-op single-argument `os.path.join(temp_file)`.

No behavior change on Unix; fixes the code path on Windows. Happy to add a regression test if desired.