### PR TITLE
Drop python 3.10 and add python 3.14 to testing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,18 +19,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Checkout Branch / Pull Request
 
       - name: Install Mamba (Linux)
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           micromamba-version: 'latest'
           cache-environment: false
@@ -43,14 +43,14 @@ jobs:
         run: python -m pip install -e .
 
       - name: Conditionally install OpenBabel
-        if: ${{ matrix.python-version != '3.13' }}
+        if: ${{ matrix.python-version < '3.13' }}
         run: micromamba install -y openbabel
 
       - name: Test (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
         run: python -m pytest -v --cov=mbuild --cov-report=xml --cov-append --cov-config=setup.cfg --color yes --pyargs mbuild
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           name: mBuild-Coverage
           verbose: true
@@ -64,18 +64,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, macOS-14, ubuntu-latest]
-        python-version: ["3.13"]
+        python-version: ["3.14"]
 
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Checkout Branch / Pull Request
 
       - name: Install Mamba (Linux)
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           micromamba-version: 'latest'
           cache-environment: false
@@ -96,10 +96,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Checkout Branch / Pull Request
 
-      - uses: Vampire/setup-wsl@v5
+      - uses: Vampire/setup-wsl@v7
         with:
           distribution: Ubuntu-24.04
           wsl-shell-user: runner

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: mbuild-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10,<=3.14
+  - python>=3.11,<=3.14
   - boltons
   - numpy>=2.0,<2.6
   - sympy

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,23 +2,22 @@ name: mbuild-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10,<=3.13
+  - python>=3.10,<=3.14
   - boltons
-  - numpy>=2.0,<2.3
+  - numpy>=2.0,<2.6
   - sympy
   - unyt>=2.9.5
-  - boltons
   - lark>=1.2
   - lxml
   - intermol
   - mdtraj
   - pydantic>=2
-  - networkx
+  - networkx>=2.5
   - nglview>=3
   - pytest
   - garnett>=0.7.1
   - openff-toolkit-base>0.16.7
-  - openmm
+  - openmm>=8.4
   - gsd>=2.9
   - freud>=3.2
   - parmed>=3.4.3

--- a/environment.yml
+++ b/environment.yml
@@ -3,13 +3,13 @@ channels:
   - conda-forge
 dependencies:
   - ele
-  - numpy>=2.0,<2.3
+  - numpy>=2.0,<2.6
   - packmol>=20.15
-  - gmso>=0.12.0
+  - gmso>=0.16.2
   - garnett
   - parmed>=3.4.3
   - pycifrw
-  - python>=3.10,<=3.13
+  - python>=3.11,<=3.14
   - rdkit>=2021
   - scipy
   - networkx

--- a/mbuild/lattice.py
+++ b/mbuild/lattice.py
@@ -593,7 +593,7 @@ class Lattice(object):
         transform_mat = self.lattice_vectors
         # Unit vectors
         transform_mat = np.asarray(transform_mat, dtype=np.float64)
-        transform_mat = np.reshape(transform_mat, newshape=(3, 3))
+        transform_mat = np.reshape(transform_mat, shape=(3, 3))
         norms = np.linalg.norm(transform_mat, axis=1)
 
         # Normalized vectors for change of basis


### PR DESCRIPTION
Similar to foyer and gmso, we can start updating the python coverage in mBuild as well. There is one small fix for a deprecation in numpy, and I bumped up the versions of the various actions in the CI.

### PR Summary:

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
