### PR TITLE
Avoid shell=True when invoking PACKMOL

### DIFF
--- a/mbuild/packing.py
+++ b/mbuild/packing.py
@@ -1196,15 +1196,15 @@ def _run_packmol(input_text, filled_xyz, temp_file, packmol_file):
         ):
             shutil.copyfileobj(inp_file, new_file)
 
-    proc = Popen(
-        f"{PACKMOL} < {packmol_inp.name}",
-        stdin=PIPE,
-        stdout=PIPE,
-        stderr=PIPE,
-        universal_newlines=True,
-        shell=True,
-    )
-    out, err = proc.communicate()
+    with open(packmol_inp.name) as inp_file:
+        proc = Popen(
+            [PACKMOL],
+            stdin=inp_file,
+            stdout=PIPE,
+            stderr=PIPE,
+            universal_newlines=True,
+        )
+        out, err = proc.communicate()
 
     if "WITHOUT PERFECT PACKING" in out:
         logger.warning(


### PR DESCRIPTION
## Summary

PACKMOL is currently launched through a shell with an interpolated temp path:

```python
proc = Popen(
    f"{PACKMOL} < {packmol_inp.name}",
    stdin=PIPE, stdout=PIPE, stderr=PIPE,
    universal_newlines=True, shell=True,
)
```

Two problems:

1. **Shell-injection anti-pattern** — building a shell command line by interpolating a path into an f-string with `shell=True`.
2. **Breaks on spaces / shell metacharacters** — if the temp file path contains a space (e.g. `TMPDIR` under a user directory with spaces, common on macOS/Windows), the `<` redirection targets the wrong token and PACKMOL fails.

The shell was only being used for the `<` input redirection; `stdin=PIPE` was set but nothing was ever written to it.

## Fix

Feed the input file directly as `stdin` and pass the executable as an argument list, dropping the shell. `PACKMOL` is a resolved absolute path from `shutil.which("packmol")`, so no shell word-splitting is needed.

```python
with open(packmol_inp.name) as inp_file:
    proc = Popen(
        [PACKMOL],
        stdin=inp_file, stdout=PIPE, stderr=PIPE,
        universal_newlines=True,
    )
    out, err = proc.communicate()
```

Behavior is unchanged (PACKMOL reads its config from stdin exactly as before), and the call is now injection-safe and robust to paths with spaces.