### PR TITLE
Refactor simulation.py for consistent Hoomd and OpenMM Simulation classes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@ formats:
 conda:
   environment: docs/docs-env.yml
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-latest"
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2908,23 +2908,22 @@ class Compound(object):
                     "Particles outside of its containment hierarchy."
                 )
 
-    def _add_sim_data(self, state=None, forces=None, forcefield=None):
-        if state:
+    def _add_sim_data(self, state=None, forces=None, build_params=None):
+        """Used by simulation.HoomdSimulation to store state, forces and build params."""
+        if state is not None:
             self._hoomd_data["state"] = state
-        if forces:
+        if forces is not None:
             self._hoomd_data["forces"] = forces
-        if forcefield:
-            self._hoomd_data["forcefield"] = forcefield
+        if build_params is not None:
+            self._hoomd_data["build_params"] = build_params
 
     def _get_sim_data(self):
-        if not self._hoomd_data:
-            return None, None, None
-        else:
-            return (
-                self._hoomd_data["state"],
-                self._hoomd_data["forces"],
-                self._hoomd_data["forcefield"],
-            )
+        """Return cached HOOMD state and forces, with the params they were built from."""
+        return (
+            self._hoomd_data.get("state"),
+            self._hoomd_data.get("forces"),
+            self._hoomd_data.get("build_params"),
+        )
 
 
 Particle = Compound

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -2203,15 +2203,22 @@ class Compound(object):
                 shift = particles[idx].pos - initial_coordinates[idx]
                 port.translate(shift)
 
-    def _kick(self):
+    def _kick(self, seed=None):
         """Slightly adjust all coordinates in a Compound.
 
         Provides a slight adjustment to coordinates to kick them out of local
         energy minima.
+
+        Parameters
+        ----------
+        seed : int, numpy.random.Generator, or None, default None
+            Seeds the perturbation. Pass an int (or a Generator) for
+            reproducible kicks. If None, a fresh unseeded generator is used.
         """
+        rng = np.random.default_rng(seed)
         xyz_init = self.xyz
         for particle in self.particles():
-            particle.pos += (np.random.rand(3) - 0.5) / 100
+            particle.pos += (rng.random(3) - 0.5) / 100
         self._update_port_locations(xyz_init)
 
     def save(

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -358,9 +358,11 @@ class Path:
         nthreads : int, optional, default 1
             Number of threads to use during OpenMM simulation.
         """
-        from mbuild.simulation import OpenMMSimulation
+        import mbuild.simulation
 
-        simulation = OpenMMSimulation(self, forcefield=None, nthreads=nthreads)
+        simulation = mbuild.simulation.OpenMMSimulation(
+            self, forcefield=None, nthreads=nthreads
+        )
         # TODO: Create a forcefield from bead_radius
         # energy_minimize_path(self, bead_radius, bond_length, steps, seed, nthreads)
         simulation.minimize(steps, tolerance=1)

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -356,12 +356,15 @@ class Path:
 
         Parameters
         ----------
-        bead_radius : float
-            WCA bead radius (center-to-center exclusion diameter).
-        bond_length : float, optional
-            Target bond length. Defaults to the path's mean bond length.
-        angles_sampler : mbuild.path.points.AnglesSampler, optional
-            If given, adds a tabulated angle potential from this distribution.
+        bead_radius : float or dict
+            WCA bead radius (center-to-center exclusion diameter). A dict keyed
+            by bead type gives each bead type its own size.
+        bond_length : float or dict, optional
+            Target bond length. Defaults to per-bond-type means over the path.
+            A dict is keyed by an unordered bead-type pair.
+        angles_sampler : mbuild.path.points.AnglesSampler or dict, optional
+            If given, adds a tabulated angle potential. A dict keyed by a
+            bead-type triple parameterizes angles per type.
         steps : int, optional, default 1,000
             Number of FIRE minimization steps.
         seed : int, optional, default 1
@@ -373,7 +376,12 @@ class Path:
             _mean_bond_length,
         )
 
-        bond_eff = bond_length if bond_length is not None else _mean_bond_length(self)
+        # Scalar length scale for the displacement cap, even if per-type lengths
+        # were given.
+        if isinstance(bond_length, (int, float)):
+            bond_eff = bond_length
+        else:
+            bond_eff = _mean_bond_length(self)
         forcefield = PathForcefield(
             radius=bead_radius, bond_length=bond_length, angles=angles_sampler
         )

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -294,11 +294,12 @@ class Path:
         """Convert a path and its bond graph to an mBuild Compound."""
         compound = Compound()
         compounds = []
-        # TODO: Should name be pulled from self.beads[noe_id] as well?
         # TODO: Should we have a mass parameter? Could be useful for density termination
-        for node_id, attrs in self.bond_graph.nodes(data=True):
+        for node_id in self.bond_graph.nodes:
             compounds.append(
-                Compound(name=attrs["name"], pos=self.coordinates[node_id], mass=1.0)
+                Compound(
+                    name=self.beads[node_id], pos=self.coordinates[node_id], mass=1.0
+                )
             )
         compound.add(compounds)
         for edge1, edge2 in self.bond_graph.edges():
@@ -357,9 +358,12 @@ class Path:
         nthreads : int, optional, default 1
             Number of threads to use during OpenMM simulation.
         """
-        from mbuild.simulation import energy_minimize_path
+        from mbuild.simulation import OpenMMSimulation
 
-        energy_minimize_path(self, bead_radius, bond_length, steps, seed, nthreads)
+        simulation = OpenMMSimulation(self, forcefield=None, nthreads=nthreads)
+        # TODO: Create a forcefield from bead_radius
+        # energy_minimize_path(self, bead_radius, bond_length, steps, seed, nthreads)
+        simulation.minimize(steps, tolerance=1)
         return
 
 

--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -340,33 +340,48 @@ class Path:
 
         return visualize_path(self, radius, hide_periodic_bonds)
 
-    def relax(self, bead_radius, bond_length=None, steps=1000, seed=1, nthreads=1):
-        """Perform a dpd simulation to relax the current path.
+    def relax(
+        self,
+        bead_radius,
+        bond_length=None,
+        angles_sampler=None,
+        steps=1000,
+        seed=1,
+    ):
+        """Relax the path with a coarse Kremer-Grest forcefield.
 
-        Runs a short energy minimization simulation in OpenMM.
+        Builds a WCA + FENE forcefield from the given parameters and runs a
+        capped-displacement warm-up followed by FIRE minimization in HOOMD.
+        Relaxed coordinates are synced back onto the path.
 
         Parameters
         ----------
         bead_radius : float
-            Bead size set in the simulation.
+            WCA bead radius (center-to-center exclusion diameter).
         bond_length : float, optional
-            Bond length used for all bonds.
+            Target bond length. Defaults to the path's mean bond length.
+        angles_sampler : mbuild.path.points.AnglesSampler, optional
+            If given, adds a tabulated angle potential from this distribution.
         steps : int, optional, default 1,000
-            Number of simulation steps to run.
+            Number of FIRE minimization steps.
         seed : int, optional, default 1
-            Random seed for integrator.
-        nthreads : int, optional, default 1
-            Number of threads to use during OpenMM simulation.
+            Random seed for the simulation.
         """
         import mbuild.simulation
-
-        simulation = mbuild.simulation.OpenMMSimulation(
-            self, forcefield=None, nthreads=nthreads
+        from mbuild.utils.simulation.path_forces import (
+            PathForcefield,
+            _mean_bond_length,
         )
-        # TODO: Create a forcefield from bead_radius
-        # energy_minimize_path(self, bead_radius, bond_length, steps, seed, nthreads)
-        simulation.minimize(steps, tolerance=1)
-        return
+
+        bond_eff = bond_length if bond_length is not None else _mean_bond_length(self)
+        forcefield = PathForcefield(
+            radius=bead_radius, bond_length=bond_length, angles=angles_sampler
+        )
+        sim = mbuild.simulation.HoomdSimulation(
+            self, forcefield=forcefield, seed=seed, run_on_gpu=False
+        )
+        sim.cap_displacement(n_steps=500, dt=1, max_displacement=0.01 * bond_eff)
+        sim.fire(n_steps=steps)
 
 
 def lamellar(

--- a/mbuild/path/constraints.py
+++ b/mbuild/path/constraints.py
@@ -161,6 +161,9 @@ class SphereConstraint(Constraint):
         self.radius = radius
         self.mins = self.center - self.radius
         self.maxs = self.center + self.radius
+        # Orthorhombic bounding lengths (diameter on each axis), e.g. for
+        # HoomdSimulation(..., box=constraint.box_lengths).
+        self.box_lengths = np.array([2 * radius] * 3, dtype=np.float32)
 
     def is_inside(self, points, buffer):
         """Check a set of coordinates against the volume constraint.
@@ -262,6 +265,9 @@ class CylinderConstraint(Constraint):
                 self.center[2] + self.height / 2,
             ]
         )
+        # Orthorhombic bounding lengths (radial diameter, radial diameter,
+        # height), e.g. for HoomdSimulation(..., box=constraint.box_lengths).
+        self.box_lengths = np.array([2 * radius, 2 * radius, height], dtype=np.float32)
 
     def is_inside(self, points, buffer):
         """Check a set of coordinates against the volume constraint.

--- a/mbuild/polymer.py
+++ b/mbuild/polymer.py
@@ -15,7 +15,7 @@ from mbuild.coordinate_transform import (
 )
 from mbuild.lib.atoms import H
 from mbuild.port import Port
-from mbuild.simulation import energy_minimize as e_min
+from mbuild.simulation import OpenMMSimulation
 from mbuild.utils.validation import assert_port_exists
 
 __all__ = ["Polymer"]
@@ -199,7 +199,8 @@ class Polymer(Compound):
             coordinates=path.coordinates,
         )
         if energy_minimize:
-            e_min(self)
+            sim = OpenMMSimulation(self)
+            sim.minimize()
 
     def set_monomer_positions(self, coordinates, energy_minimize=False):
         """Shift monomers so that their center of mass matches a set of pre-defined coordinates.
@@ -228,7 +229,8 @@ class Polymer(Compound):
         for i, xyz in enumerate(coordinates):
             self.children[i].translate_to(xyz)
         if energy_minimize:
-            e_min(self)
+            sim = OpenMMSimulation(self)
+            sim.energy_minimize()
 
     def build(
         self,

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -1,109 +1,132 @@
-"""Simulation methods that operate on mBuild compounds."""
+"""Simulation methods that operate on mBuild compounds and paths."""
 
 import logging
 import os
-import tempfile
-from warnings import warn
 
 import gmso
 import hoomd
 import numpy as np
-from ele.element import element_from_name, element_from_symbol
-from ele.exceptions import ElementError
 from gmso.parameterization import apply
 
 from mbuild import Compound
-from mbuild.exceptions import MBuildError
 from mbuild.utils.io import import_
 
 logger = logging.getLogger(__name__)
 
 
-class HoomdSimulation(hoomd.simulation.Simulation):
-    """A custom class to help in creating internal hoomd-based simulation methods.
+# ─────────────────────────────────────────────────────────────────────────────
+# Default force field parameters (used when no forcefield is provided)
+# ─────────────────────────────────────────────────────────────────────────────
 
-    See ``hoomd_cap_displacement`` and ``hoomd_fire``.
+DEFAULT_LJ_PARAMS = {"sigma": 0.34, "epsilon": 0.36}  # nm, kJ/mol
+DEFAULT_BOND_PARAMS = {"k": 300000.0, "r0": 0.15}  # kJ/mol/nm^2, nm
+DEFAULT_ANGLE_PARAMS = {"k": 400.0, "theta0": 1.9111}  # kJ/mol/rad^2, ~109.5 deg
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Input resolution helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _resolve_input(system):
+    """Convert a Path or Compound input into an mBuild Compound.
 
     Parameters
     ----------
+    system : mb.Compound or mbuild.path.build.Path
+        The input system.
+
+    Returns
+    -------
     compound : mb.Compound
-        The compound to use in the simulation
-    forcefield : foyer.forcefield.Forcefield or gmso.core.Forcefield
-        The forcefield to apply to the system
+    is_path : bool
+        Whether the original input was a Path.
+    original : the original input object
+    """
+    from mbuild.path.build import Path
+
+    if isinstance(system, Path):
+        return system.to_compound(), True, system
+    elif isinstance(system, Compound):
+        return system, False, system
+    else:
+        raise TypeError(
+            f"Expected an mb.Compound or mbuild.path.Path, got {type(system)}."
+        )
+
+
+def _sync_back(compound, is_path, original):
+    """If the original was a Path, copy positions back."""
+    if is_path:
+        original.coordinates = compound.xyz
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Property Logger
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class PropertyLogger:
+    """Collects energies and other scalar properties during a simulation.
+
+    Parameters
+    ----------
+    log_every : int
+        Frequency (in steps) at which properties are recorded.
+    properties : list of str
+        Which properties to log. Options depend on the backend:
+        - HOOMD: "potential_energy", "kinetic_energy", "temperature", "pressure"
+        - OpenMM: "potential_energy", "kinetic_energy", "temperature", "volume"
+    """
+
+    def __init__(self, log_every=100, properties=None):
+        self.log_every = log_every
+        if properties is None:
+            properties = ["potential_energy"]
+        self.properties = properties
+        self.data = {p: [] for p in properties}
+
+    def reset(self):
+        self.data = {p: [] for p in self.properties}
+
+    def as_dict(self):
+        return {k: np.array(v) for k, v in self.data.items()}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HOOMD Simulation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class HoomdSimulation(hoomd.simulation.Simulation):
+    """A custom class for hoomd-based simulation methods.
+
+    Accepts either an mb.Compound or an mbuild.path.Path as input.
+
+    Parameters
+    ----------
+    system : mb.Compound or mbuild.path.build.Path
+        The system to simulate. If a Path is given, it is converted
+        to a Compound internally and positions are synced back after runs.
+    forcefield : foyer/gmso Forcefield or None
+        The forcefield to apply. If None, default LJ + harmonic bond/angle
+        parameters are used.
     r_cut : float (nm)
-        The cutoff distance (nm) used in the non-bonded pair neighborlist.
-        Use smaller values for unstable starting conditions and faster performance.
+        The cutoff distance used in the non-bonded pair neighborlist.
     fixed_compounds : list of mb.Compound, default None
-        If given, these compounds will be removed from the integration updates and
-        held "frozen" during the hoomd simulation.
-        They are still able to interact with other particles in the simulation.
-        If desired, pass in a subset of children from `compound.children`.
     integrate_compounds : list of mb.Compound, default None
-        If given, then only these compounds will be updated during integration
-        and all other compunds in `compound` are removed from the integration group.
-    run_on_gpu : bool, default False
-        When `True` the HOOMD simulation uses the hoomd.device.GPU() device.
-        This requires that you have a GPU compatible HOOMD install and
-        a compatible GPU device.
-    seed : int, default 42
-        The seed passed to HOOMD
-    gsd_filename : str, default None
-        A filename to write out with.
-        TODO: Not currently implemented.
-
-    Notes
-    -----
-    Running on GPU:
-        The hoomd-based methods in ``mbuild.simulation``
-        are able to utilize and run on GPUs to perform energy minimization for larger systems if needed.
-        Performance improvements of using GPU over CPU may not be significant until systems reach a
-        size of ~1,000 particles.
-
-    Running multiple simulations:
-        The information needed to run the HOOMD simulation is saved after the first simulation.
-        Therefore, calling hoomd-based simulation methods multiple times (e.g., in a for loop or while loop)
-        does not require re-running performing atom-typing, applying the forcefield, or running hoomd
-        format writers again.
-
-    Examples
-    --------
-
-    ```python
-    ff = gmso.ForceField("path_to_ff")
-
-    # Scale bonds and angles, replace 12-6 LJ pair force with DPDConservative
-    fhandler = ForcesHandler(scale_bonds=0.1, scale_angles=0.2, dpd=4)
-
-    # Pass in the mBuild Compound you are removing overlaps from
-    sim = HOOMDSimulation(compound, ff, r_cut=0.6, box_buffer=5,)
-
-    hoomd_cap_displacement(compound, sim, fhandler, n_steps=1000)
-
-    # Re-run with without DPD and bond and angle scaling:
-    fhandler = ForcesHandler(scale_bonds=1, scale_angles=1, dpd=None)
-    hoomd_cap_displacement(compound, sim, fhandler, n_steps=1000)
-    ```
-
-    Use in a while loop along with Compound.check_for_overlap()
-    to run capped-displacement simulations in small increments.
-
-    ```python
-    ff = gmso.ForceField("path_to_ff")
-    fhandler = ForcesHandler(scale_bonds=0.1, scale_angles=0.2, dpd=4)
-
-    # Pass in the mBuild Compound you are removing overlaps from
-    sim = HOOMDSimulation(compound, ff, r_cut=0.6, box_buffer=5,)
-
-    while len(compound.check_for_overlap(exlcuded_bond_depth=1, minimum_distance=0.12)) > 0:
-        hoomd_cap_displacement(compound, sim, fhandler, n_steps=200)
-    ```
+    run_on_gpu : bool or None, default None
+    seed : int, default 1
+    automatic_box : bool, default False
+    box_buffer : float, default 10
+    logger : PropertyLogger or None
     """
 
     def __init__(
         self,
-        compound,
-        forcefield,
-        r_cut,
+        system,
+        forcefield=None,
+        r_cut=1.0,
         run_on_gpu=None,
         seed=1,
         automatic_box=False,
@@ -111,7 +134,11 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         integrate_compounds=None,
         fixed_compounds=None,
         gsd_file_name=None,
+        logger=None,
     ):
+        # Resolve input type
+        compound, self._is_path, self._original_system = _resolve_input(system)
+
         if run_on_gpu is None:
             device = hoomd.device.auto_select()
         elif run_on_gpu:
@@ -120,13 +147,13 @@ class HoomdSimulation(hoomd.simulation.Simulation):
                 print(f"GPU found, running on device {device.device}")
             except RuntimeError:
                 print(
-                    "Unable to find compatible GPU device. ",
-                    "set `run_on_gpu = False` or see HOOMD documentation "
-                    "for further information about GPU support.",
+                    "Unable to find compatible GPU device. "
+                    "Set `run_on_gpu = False` or see HOOMD documentation."
                 )
                 device = hoomd.device.CPU()
         else:
             device = hoomd.device.CPU()
+
         self.compound = compound
         self.forcefield = forcefield
         self.r_cut = r_cut
@@ -134,49 +161,113 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         self.fixed_compounds = fixed_compounds
         self.automatic_box = automatic_box
         self.box_buffer = box_buffer
-        self.energies = []  # each step of run energy values
-        # Check if a hoomd sim method has been used on this compound already
+        self.energies = []
+        self.logger = logger
+
         if compound._hoomd_data:
             last_snapshot, last_forces, last_forcefield = compound._get_sim_data()
-            # Check if the forcefield passed this time matches last time
             if forcefield == last_forcefield:
                 snapshot = last_snapshot
                 self.forces = last_forces
-            else:  # New foyer/gmso forcefield has been passed, reapply
+            else:
                 snapshot, self.forces = self._to_hoomd_snap_forces()
                 compound._add_sim_data(
                     state=snapshot, forces=self.forces, forcefield=forcefield
                 )
-        else:  # Sim method not used on this compound previously
+        else:
             snapshot, self.forces = self._to_hoomd_snap_forces()
             compound._add_sim_data(
                 state=snapshot, forces=self.forces, forcefield=forcefield
             )
-        # Place holders for forces added/changed by specific methods below
+
         self.active_forces = []
         self.inactive_forces = []
-        self._orig_force_params = {}  # populated after forces are known
+        self._orig_force_params = {}
         super(HoomdSimulation, self).__init__(device=device, seed=seed)
         self.create_state_from_snapshot(snapshot)
         self._orig_force_params = self._snapshot_force_params()
 
     def _to_hoomd_snap_forces(self):
-        # If a box isn't set, make one with the buffer
+        """Convert compound to HOOMD snapshot and forces."""
         if not self.compound.box:
             self.compound.box = self.compound.get_boundingbox(pad_box=self.box_buffer)
-        # Convert to GMSO, apply forcefield
+
         top = self.compound.to_gmso()
         top.identify_connections()
-        # TODO: Make a parameter for ignoring dihedrals?
-        apply(top, forcefields=self.forcefield, ignore_params=["dihedral", "improper"])
-        # Get hoomd snapshot and force objects
-        forces, _ = gmso.external.to_hoomd_forcefield(top, r_cut=self.r_cut)
-        snap, _ = gmso.external.to_gsd_snapshot(top=top)
-        forces = list(set().union(*forces.values()))
+
+        if self.forcefield is not None:
+            apply(
+                top,
+                forcefields=self.forcefield,
+                ignore_params=["dihedral", "improper"],
+            )
+            forces, _ = gmso.external.to_hoomd_forcefield(top, r_cut=self.r_cut)
+            snap, _ = gmso.external.to_gsd_snapshot(top=top)
+            forces = list(set().union(*forces.values()))
+        else:
+            snap, _ = gmso.external.to_gsd_snapshot(top=top)
+            forces = self._build_default_forces(top, snap)
+
         return snap, forces
 
+    def _build_default_forces(self, top, snap):
+        """Build default HOOMD forces (LJ, bonds, angles) from topology."""
+        particle_types = list(set(snap.particles.types))
+
+        nlist = hoomd.md.nlist.Cell(buffer=0.4)
+        lj = hoomd.md.pair.LJ(nlist=nlist, default_r_cut=self.r_cut)
+        for i, t1 in enumerate(particle_types):
+            for t2 in particle_types[i:]:
+                lj.params[(t1, t2)] = dict(
+                    sigma=DEFAULT_LJ_PARAMS["sigma"],
+                    epsilon=DEFAULT_LJ_PARAMS["epsilon"],
+                )
+        forces = [lj]
+
+        if top.n_bonds > 0:
+            bond_types = list(
+                set(
+                    tuple(
+                        sorted(
+                            [b.connection_members[0].name, b.connection_members[1].name]
+                        )
+                    )
+                    for b in top.bonds
+                )
+            )
+            bond_force = hoomd.md.bond.Harmonic()
+            for bt in bond_types:
+                type_str = f"{bt[0]}-{bt[1]}"
+                bond_force.params[type_str] = dict(
+                    k=DEFAULT_BOND_PARAMS["k"], r0=DEFAULT_BOND_PARAMS["r0"]
+                )
+            forces.append(bond_force)
+
+        if top.n_angles > 0:
+            angle_types = list(
+                set(
+                    tuple(
+                        [
+                            a.connection_members[0].name,
+                            a.connection_members[1].name,
+                            a.connection_members[2].name,
+                        ]
+                    )
+                    for a in top.angles
+                )
+            )
+            angle_force = hoomd.md.angle.Harmonic()
+            for at in angle_types:
+                type_str = f"{at[0]}-{at[1]}-{at[2]}"
+                angle_force.params[type_str] = dict(
+                    k=DEFAULT_ANGLE_PARAMS["k"], t0=DEFAULT_ANGLE_PARAMS["theta0"]
+                )
+            forces.append(angle_force)
+
+        return forces
+
     def _snapshot_force_params(self):
-        """Snapshot current force params so ForcesHandler can restore before re-scaling."""
+        """Snapshot current force params for later restoration."""
         orig = {}
         for force in self.forces:
             if not hasattr(force, "params"):
@@ -187,7 +278,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         return orig
 
     def get_integrate_group(self):
-        # Get indices of compounds to include in integration
+        """Return the HOOMD filter for the integration group."""
         if self.integrate_compounds and not self.fixed_compounds:
             if all([isinstance(i, Compound) for i in self.integrate_compounds]):
                 integrate_indices = []
@@ -198,7 +289,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             elif all([isinstance(i, int) for i in self.integrate_compounds]):
                 integrate_indices = self.integrate_compounds
             return hoomd.filter.Tags(integrate_indices)
-        # Get indices of compounds to NOT include in integration
         elif self.fixed_compounds and not self.integrate_compounds:
             if all([isinstance(i, Compound) for i in self.fixed_compounds]):
                 fix_indices = []
@@ -209,12 +299,10 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             return hoomd.filter.SetDifference(
                 hoomd.filter.All(), hoomd.filter.Tags(fix_indices)
             )
-        # Both are passed in, not supported
         elif self.integrate_compounds and self.fixed_compounds:
             raise RuntimeError(
                 "You can specify only one of integrate_compounds and fixed_compounds."
             )
-        # Neither are given, include everything in integration
         else:
             return hoomd.filter.All()
 
@@ -278,22 +366,18 @@ class HoomdSimulation(hoomd.simulation.Simulation):
 
     def _update_snapshot(self):
         snapshot = self.state.get_snapshot()
-        # snapshot_copy = hoomd.Snapshot(snapshot)  # full copy
         self.compound._add_sim_data(state=snapshot)
 
-    def add_gsd_writer(self, file_name, write_period):
-        """"""
-        pass
-
     def update_positions(self):
-        """Update compound positions from snapshot."""
+        """Update compound positions from snapshot and sync back to Path if needed."""
         with self.state.cpu_local_snapshot as snap:
             particles = snap.particles.rtag[:]
             pos = snap.particles.position[particles]
             self.compound.xyz = np.copy(pos)
+        _sync_back(self.compound, self._is_path, self._original_system)
 
     def store_current_energies(self):
-        """Store energy simulations progress."""
+        """Store energy from active forces."""
         new_energy = {}
         for force in self.active_forces:
             ffname = force.__class__.__module__ + "." + force.__class__.__name__
@@ -302,7 +386,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             self.energies.append(new_energy)
 
     def get_energy(self):
-        """Return each energy by index for previously run energy breakdown."""
+        """Return energies by force type across all stored frames."""
         if not self.energies:
             print(f"No energies currently stored in {self}")
             return None
@@ -315,37 +399,580 @@ class HoomdSimulation(hoomd.simulation.Simulation):
                 returnDict[ffkey][frame] = energyDict[ffkey]
         return returnDict
 
+    def _log_properties(self):
+        """Record properties to the logger if one is attached."""
+        if self.logger is None:
+            return
+        for prop in self.logger.properties:
+            if prop == "potential_energy":
+                pe = sum(f.energy for f in self.active_forces)
+                self.logger.data["potential_energy"].append(pe)
+            elif prop == "kinetic_energy":
+                self.logger.data["kinetic_energy"].append(None)
+            elif prop == "temperature":
+                self.logger.data["temperature"].append(None)
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Simulation methods
+    # ─────────────────────────────────────────────────────────────────────
+
+    def nvt(
+        self,
+        forces_handler,
+        n_steps,
+        kT,
+        dt,
+        tau,
+        thermostat=hoomd.md.methods.thermostats.Berendsen,
+    ):
+        """Run an NVT simulation.
+
+        Parameters
+        ----------
+        forces_handler : ForcesHandler or None
+        n_steps : int
+        kT : float
+        dt : float
+        tau : float
+        thermostat : hoomd thermostat class
+        """
+        if forces_handler is not None:
+            forces_handler.scale_sim(self)
+        else:
+            self.active_forces = list(self.forces)
+
+        nvt_method = hoomd.md.methods.ConstantVolume(
+            filter=self.get_integrate_group(),
+            thermostat=thermostat(kT=kT, tau=tau),
+        )
+        self.set_integrator(method=nvt_method, dt=dt)
+        self.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=kT)
+
+        if self.energies == []:
+            self.run(0)
+            self.store_current_energies()
+
+        self.run(n_steps)
+        self.store_current_energies()
+        self._log_properties()
+        self.operations.integrator = None
+        self.update_positions()
+        self._update_snapshot()
+
+    def npt(
+        self,
+        forces_handler,
+        n_steps,
+        kT,
+        dt,
+        tau,
+        pressure,
+        tauS,
+        couple="xyz",
+        thermostat=hoomd.md.methods.thermostats.Berendsen,
+    ):
+        """Run an NPT simulation."""
+        if forces_handler is not None:
+            forces_handler.scale_sim(self)
+        else:
+            self.active_forces = list(self.forces)
+
+        npt_method = hoomd.md.methods.ConstantPressure(
+            filter=self.get_integrate_group(),
+            thermostat=thermostat(kT=kT, tau=tau),
+            S=pressure,
+            tauS=tauS,
+            couple=couple,
+        )
+        self.set_integrator(method=npt_method, dt=dt)
+        self.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=kT)
+
+        if self.energies == []:
+            self.run(0)
+            self.store_current_energies()
+
+        self.run(n_steps)
+        self.store_current_energies()
+        self._log_properties()
+        self.operations.integrator = None
+        self.update_positions()
+        self._update_snapshot()
+
+    def cap_displacement(
+        self,
+        forces_handler,
+        n_steps,
+        dt,
+        max_displacement=1e-3,
+    ):
+        """Run a capped-displacement simulation.
+
+        Parameters
+        ----------
+        forces_handler : ForcesHandler or None
+        n_steps : int
+        dt : float
+        max_displacement : float (nm)
+        """
+        self.compound._kick()
+        if forces_handler is not None:
+            forces_handler.scale_sim(self)
+        else:
+            self.active_forces = list(self.forces)
+
+        displacement_capped = hoomd.md.methods.DisplacementCapped(
+            filter=self.get_integrate_group(),
+            maximum_displacement=max_displacement,
+        )
+        self.set_integrator(method=displacement_capped, dt=dt)
+
+        if self.energies == []:
+            self.run(0)
+            self.store_current_energies()
+
+        self.run(n_steps)
+        self.store_current_energies()
+        self._log_properties()
+        self.operations.integrator = None
+        self.update_positions()
+        self._update_snapshot()
+
+    def fire(
+        self,
+        forces_handler,
+        n_steps,
+        n_iterations=1,
+        dt=1e-5,
+        min_steps_adapt=5,
+        min_steps_conv=100,
+        finc_dt=1.1,
+        fdec_dt=0.5,
+        alpha_start=0.1,
+        fdec_alpha=0.95,
+        force_tol=1e-2,
+        angmom_tol=1e-2,
+        energy_tol=1e-6,
+    ):
+        """Run FIRE energy minimization.
+
+        Parameters
+        ----------
+        forces_handler : ForcesHandler or None
+        n_steps : int
+        n_iterations : int
+        dt : float
+        """
+        self.compound._kick()
+        if forces_handler is not None:
+            forces_handler.scale_sim(self)
+        else:
+            self.active_forces = list(self.forces)
+
+        nvt_method = hoomd.md.methods.ConstantVolume(filter=self.get_integrate_group())
+        self.set_fire_integrator(
+            dt=dt,
+            force_tol=force_tol,
+            angmom_tol=angmom_tol,
+            energy_tol=energy_tol,
+            finc_dt=finc_dt,
+            fdec_dt=fdec_dt,
+            alpha_start=alpha_start,
+            fdec_alpha=fdec_alpha,
+            min_steps_adapt=min_steps_adapt,
+            min_steps_conv=min_steps_conv,
+            methods=[nvt_method],
+        )
+
+        if self.energies == []:
+            self.run(0)
+            self.store_current_energies()
+
+        for _ in range(n_iterations):
+            self.run(n_steps)
+            self.operations.integrator.reset()
+
+        self.store_current_energies()
+        self._log_properties()
+        self.operations.integrator = None
+        self._update_snapshot()
+        self.update_positions()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OpenMM Simulation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class OpenMMSimulation:
+    """A wrapper around OpenMM for running simulations on mBuild Compounds or Paths.
+
+    Accepts either an mb.Compound or an mbuild.path.Path as input.
+
+    Parameters
+    ----------
+    system : mb.Compound or mbuild.path.build.Path
+        The system to simulate.
+    forcefield : str or None
+        A foyer-compatible forcefield name or XML path.
+        If None, default LJ + harmonic bond/angle parameters are applied.
+    box : mb.Box or None
+        Simulation box. If None, uses compound.box or a bounding box.
+    constraints : str or None, default is None
+        Bond constraints: None, "HBonds", "AllBonds", "HAngles".
+    platform : str
+        OpenMM platform: "CPU", "CUDA", "OpenCL", "Reference".
+    nthreads : int
+        Number of CPU threads (only relevant for CPU platform).
+    logger : PropertyLogger or None
+        Optional property logger.
+    """
+
+    def __init__(
+        self,
+        system,
+        forcefield=None,
+        box=None,
+        constraints=None,
+        platform="CPU",
+        nthreads=1,
+        logger=None,
+    ):
+        from openmm import Platform
+        from openmm.app import AllBonds, HAngles, HBonds
+
+        # Resolve input type
+        compound, self._is_path, self._original_system = _resolve_input(system)
+
+        self.compound = compound
+        self.forcefield_name = forcefield
+        self.logger = logger
+        self.energies = []
+
+        # Set up platform
+        self._platform = Platform.getPlatformByName(platform)
+        if platform == "CPU":
+            self._platform.setPropertyDefaultValue("Threads", str(nthreads))
+
+        # Parse constraints
+        constraint_map = {
+            None: None,
+            "AllBonds": AllBonds,
+            "HBonds": HBonds,
+            "HAngles": HAngles,
+        }
+        if constraints not in constraint_map:
+            raise ValueError(
+                f"Invalid constraints: {constraints}. "
+                f"Options: {list(constraint_map.keys())}"
+            )
+        self._constraints = constraint_map[constraints]
+
+        # Build system
+        if forcefield is not None:
+            self._build_from_forcefield(compound, forcefield)
+        else:
+            self._build_default_system(compound)
+
+    def _build_from_forcefield(self, compound, forcefield):
+        """Build OpenMM system using foyer."""
+        import openmm
+
+        foyer = import_("foyer")
+
+        to_parmed = compound.to_parmed()
+        extension = os.path.splitext(forcefield)[-1]
+        if extension == ".xml":
+            ff = foyer.Forcefield(forcefield_files=forcefield)
+        else:
+            ff = foyer.Forcefield(name=forcefield)
+        self._parmed = ff.apply(to_parmed)
+
+        if self._constraints is not None:
+            self.system = self._parmed.createSystem(constraints=self._constraints)
+        else:
+            self.system = self._parmed.createSystem()
+
+        # For non-periodic compounds, ensure NonbondedForce uses NoCutoff
+        if not compound.box:
+            for i in range(self.system.getNumForces()):
+                force = self.system.getForce(i)
+                if isinstance(force, openmm.NonbondedForce):
+                    force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+
+        self.topology = self._parmed.topology
+        self.positions = self._parmed.positions
+
+    def _build_default_system(self, compound):
+        """Build OpenMM system with default LJ + bond + angle parameters."""
+        import openmm
+        import openmm.unit as u
+        from openmm.app import Topology
+
+        positions = compound.xyz  # nm
+        n_particles = compound.n_particles
+
+        self.system = openmm.System()
+        for i in range(n_particles):
+            self.system.addParticle(12.0 * u.amu)
+
+        # Set periodic box vectors if compound has a box
+        if compound.box:
+            Lx, Ly, Lz = compound.box.lengths  # nm
+            self.system.setDefaultPeriodicBoxVectors(
+                openmm.Vec3(Lx, 0, 0) * u.nanometer,
+                openmm.Vec3(0, Ly, 0) * u.nanometer,
+                openmm.Vec3(0, 0, Lz) * u.nanometer,
+            )
+
+        # Default LJ nonbonded
+        nonbonded = openmm.NonbondedForce()
+        if compound.box:
+            nonbonded.setNonbondedMethod(openmm.NonbondedForce.CutoffPeriodic)
+            nonbonded.setCutoffDistance(1.0 * u.nanometer)
+        else:
+            nonbonded.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+
+        sigma = DEFAULT_LJ_PARAMS["sigma"] * u.nanometer
+        epsilon = DEFAULT_LJ_PARAMS["epsilon"] * u.kilojoules_per_mole
+        for i in range(n_particles):
+            nonbonded.addParticle(0.0, sigma, epsilon)
+        self.system.addForce(nonbonded)
+
+        # Get topology info via GMSO
+        top = compound.to_gmso()
+        top.identify_connections()
+        sites_list = list(top.sites)
+
+        # Default harmonic bonds
+        if top.n_bonds > 0:
+            bond_force = openmm.HarmonicBondForce()
+            for bond in top.bonds:
+                members = bond.connection_members
+                i_idx = sites_list.index(members[0])
+                j_idx = sites_list.index(members[1])
+                bond_force.addBond(
+                    i_idx,
+                    j_idx,
+                    DEFAULT_BOND_PARAMS["r0"] * u.nanometer,
+                    DEFAULT_BOND_PARAMS["k"] * u.kilojoules_per_mole / u.nanometer**2,
+                )
+                nonbonded.addException(i_idx, j_idx, 0.0, 1.0, 0.0)
+            self.system.addForce(bond_force)
+
+        # Default harmonic angles
+        if top.n_angles > 0:
+            angle_force = openmm.HarmonicAngleForce()
+            for angle in top.angles:
+                members = angle.connection_members
+                i_idx = sites_list.index(members[0])
+                j_idx = sites_list.index(members[1])
+                k_idx = sites_list.index(members[2])
+                angle_force.addAngle(
+                    i_idx,
+                    j_idx,
+                    k_idx,
+                    DEFAULT_ANGLE_PARAMS["theta0"] * u.radian,
+                    DEFAULT_ANGLE_PARAMS["k"] * u.kilojoules_per_mole / u.radian**2,
+                )
+            self.system.addForce(angle_force)
+
+        # Build OpenMM topology
+        particles_list = list(compound.particles())
+        topology = Topology()
+        chain = topology.addChain()
+        for i, p in enumerate(particles_list):
+            residue = topology.addResidue(f"R{i}", chain)
+            topology.addAtom(p.name, openmm.app.Element.getByMass(12), residue)
+        atoms_list = list(topology.atoms())
+        if top.n_bonds > 0:
+            for bond in top.bonds:
+                members = bond.connection_members
+                i_idx = sites_list.index(members[0])
+                j_idx = sites_list.index(members[1])
+                topology.addBond(atoms_list[i_idx], atoms_list[j_idx])
+
+        self.topology = topology
+        self.positions = positions * u.nanometer
+
+    def _create_simulation(self, integrator):
+        """Create an OpenMM Simulation object."""
+        from openmm.app.simulation import Simulation
+
+        self.simulation = Simulation(
+            self.topology, self.system, integrator, self._platform
+        )
+        self.simulation.context.setPositions(self.positions)
+
+    def _update_compound_positions(self):
+        """Write positions back to compound and sync to Path if needed."""
+        state = self.simulation.context.getState(getPositions=True)
+        pos = state.getPositions(asNumpy=True)
+        pos_array = np.array(pos)  # nm
+        if not np.any(np.isnan(pos_array)):
+            self.compound.xyz = pos_array
+            # Store updated positions so next _create_simulation uses them
+            self.positions = pos
+        else:
+            logger.warning("NaN positions detected; compound not updated.")
+            return
+        _sync_back(self.compound, self._is_path, self._original_system)
+
+    def _record_energies(self):
+        """Record current potential energy."""
+        import openmm.unit as u
+
+        state = self.simulation.context.getState(getEnergy=True)
+        pe = state.getPotentialEnergy().value_in_unit(u.kilojoules_per_mole)
+        self.energies.append({"potential_energy": pe})
+        if self.logger and "potential_energy" in self.logger.properties:
+            self.logger.data["potential_energy"].append(pe)
+        if self.logger and "kinetic_energy" in self.logger.properties:
+            ke_state = self.simulation.context.getState(getEnergy=True)
+            ke = ke_state.getKineticEnergy().value_in_unit(u.kilojoules_per_mole)
+            self.logger.data["kinetic_energy"].append(ke)
+        if self.logger and "temperature" in self.logger.properties:
+            # Approximate from KE
+            self.logger.data["temperature"].append(None)
+        if self.logger and "volume" in self.logger.properties:
+            box_vecs = state.getPeriodicBoxVectors(asNumpy=True)
+            vol = np.dot(box_vecs[0], np.cross(box_vecs[1], box_vecs[2]))
+            self.logger.data["volume"].append(float(vol))
+
+    def get_energy(self):
+        """Return recorded energies as dict of arrays."""
+        if not self.energies:
+            return None
+        keys = self.energies[0].keys()
+        return {k: np.array([e.get(k) for e in self.energies]) for k in keys}
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Simulation methods
+    # ─────────────────────────────────────────────────────────────────────
+
+    def minimize(self, steps=1000, tolerance=10.0):
+        """Energy minimize the system.
+
+        Parameters
+        ----------
+        steps : int
+        tolerance : float
+            Tolerance in kJ/mol/nm.
+        """
+        import openmm.unit as u
+        from openmm.openmm import LangevinIntegrator
+
+        integrator = LangevinIntegrator(
+            298 * u.kelvin, 1.0 / u.picosecond, 0.002 * u.picoseconds
+        )
+        self._create_simulation(integrator)
+        self.simulation.minimizeEnergy(
+            maxIterations=steps,
+            tolerance=tolerance * u.kilojoules_per_mole / u.nanometer,
+        )
+        self._record_energies()
+        self._update_compound_positions()
+
+    def nvt(self, n_steps, kT=300, dt=0.002, friction=1.0, report_interval=None):
+        """Run an NVT (Langevin) simulation.
+
+        Parameters
+        ----------
+        n_steps : int
+        kT : float
+            Temperature in Kelvin.
+        dt : float
+            Timestep in picoseconds.
+        friction : float
+            Friction coefficient in 1/ps.
+        report_interval : int or None
+            If given, record energies every this many steps.
+        """
+        import openmm.unit as u
+        from openmm.openmm import LangevinIntegrator
+
+        integrator = LangevinIntegrator(
+            kT * u.kelvin, friction / u.picosecond, dt * u.picoseconds
+        )
+        self._create_simulation(integrator)
+
+        if report_interval:
+            for i in range(0, n_steps, report_interval):
+                chunk = min(report_interval, n_steps - i)
+                self.simulation.step(chunk)
+                self._record_energies()
+        else:
+            self.simulation.step(n_steps)
+            self._record_energies()
+
+        self._update_compound_positions()
+
+    def npt(
+        self,
+        n_steps,
+        kT=300,
+        dt=0.002,
+        friction=1.0,
+        pressure=1.0,
+        barostat_interval=25,
+        report_interval=None,
+    ):
+        """Run an NPT simulation using Monte Carlo barostat.
+
+        Parameters
+        ----------
+        n_steps : int
+        kT : float (Kelvin)
+        dt : float (ps)
+        friction : float (1/ps)
+        pressure : float (atm)
+        barostat_interval : int
+        report_interval : int or None
+        """
+        import openmm
+        import openmm.unit as u
+        from openmm.openmm import LangevinIntegrator
+
+        barostat = openmm.MonteCarloBarostat(
+            pressure * u.atmospheres, kT * u.kelvin, barostat_interval
+        )
+        self.system.addForce(barostat)
+
+        integrator = LangevinIntegrator(
+            kT * u.kelvin, friction / u.picosecond, dt * u.picoseconds
+        )
+        self._create_simulation(integrator)
+
+        if report_interval:
+            for i in range(0, n_steps, report_interval):
+                chunk = min(report_interval, n_steps - i)
+                self.simulation.step(chunk)
+                self._record_energies()
+        else:
+            self.simulation.step(n_steps)
+            self._record_energies()
+
+        self._update_compound_positions()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ForcesHandler
+# ─────────────────────────────────────────────────────────────────────────────
+
 
 class ForcesHandler:
-    """Provides a quick method for tuning HOOMD forces to better handle
-    high-energy configurations.
+    """Provides a quick method for tuning HOOMD forces.
 
     Parameters
     ----------
     dpd : float, default 0.0
-        If greater than 0.0, then replaces the LJ 12-6 pair potential
-        with the softer hoomd.md.pair.DPDConservative pair force from HOOMD.
-        This should be used for highly unstable configurations.
-        The value passed to `dpd` is used as the the repulsion force constant.
-    scale_bonds : float, default 1.0
-    scale_angles : float, default 1.0
-    scale_lj : float, default 0.0
+        If > 0, replaces LJ with DPDConservative.
+    scale_bond : float, default 1.0
+    scale_angle : float, default 1.0
+    scale_lj : float, default 1.0
     scale_periodic : float, default 0.0
     scale_opls : float, default 0.0
     scale_improper : float, default 0.0
     scale_charge : float, default 0.0
-        Scaling factors multiplied against each energy term
-        in the forcefield. A value of 0.0 will exclude that interaction
-        during the simulation, a value of 1.0 includes the interaction
-        as described by the forcefield.
-
-    Notes
-    -----
-    The default behavior uses only non-bonded pairs, bond-stretching
-    and bond-bending potentials. Excluding electrostatics, dihedrals, and
-    impropers favors efficient relaxation to quickly remove high energy configurations.
-    See examples in `hoomd_cap_displacement` and `hoomd_fire` for tips about using
-    multiple instances of ForcesHandler in series.
     """
 
     def __init__(
@@ -372,8 +999,8 @@ class ForcesHandler:
         self.forcesDict = {}
 
     def scale_sim(self, sim):
-        "Iterate through HOOMD force objects and apply scaling factors."
-        sim.active_forces = []  # reset active forces
+        """Iterate through HOOMD force objects and apply scaling factors."""
+        sim.active_forces = []
         forcesDict = {
             "lj": (hoomd.md.pair.LJ, ("epsilon")),
             "charge": (hoomd.md.special_pair.Coulomb, ("alpha")),
@@ -384,7 +1011,7 @@ class ForcesHandler:
             "improper": (hoomd.md.improper.Periodic, ("k")),
         }
         for key, scalar in self.scale_forces.items():
-            if not scalar:  # skip scalars of 0
+            if not scalar:
                 continue
             if key == "lj" and self.dpd:
                 dpd = sim.get_dpd_from_lj(A=self.dpd)
@@ -393,7 +1020,10 @@ class ForcesHandler:
                 self.forcesDict["dpd"] = dpd
                 continue
 
-            force = sim.get_force(forcesDict[key][0])
+            try:
+                force = sim.get_force(forcesDict[key][0])
+            except ValueError:
+                continue
             orig_params = sim._orig_force_params.get(id(force), {})
             for param in force.params:
                 for term in forcesDict[key][1:]:
@@ -402,1021 +1032,4 @@ class ForcesHandler:
                     else:
                         force.params[param][term] *= scalar
             sim.active_forces.append(force)
-            self.forcesDict[key] = force  # store for usage elsewhere
-
-
-## HOOMD RUN METHODS ##
-def hoomd_nvt(
-    compound,
-    sim,
-    forces_handler,
-    n_steps,
-    kT,
-    dt,
-    tau,
-    thermostat=hoomd.md.methods.thermostats.Berendsen,
-):
-    """Run a short NVT simulation on an mBuild Compound.
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound to use in the simulation
-    sim : mb.simulation.HOOMDSimulation
-        The simulation context used during the simulation.
-    forces_handler : mb.simulation.ForceHander
-        The way to handle forces for this simulation method. Will apply specified forces,
-        scaling as needed.
-        Set to `None` to use the force field as-is.
-    n_steps : int
-        The number of simulation time steps to run.
-    dt : float
-        The simulation timestep. Note that for running capped displacement on highly unstable
-        systems (e.g. overlapping particles), it is often more stable to use a larger
-        value of dt and let the displacement cap limit position updates.
-    kT : float
-        The temperature set point for the thermostat in units of energy.
-    tau : float
-        The thermostat time constant
-    thermostat : Instance of hoomd.md.methods.thermostats
-        The thermostat to use. Defaults to the Berendsen thermostat.
-        For shorter, equilibraiton runs, Berendsen is the most efficient choice.
-        Other options include `hoomd.md.methods.thermostats.MTTK` (i.e., Nose-Hoover) and
-        `hoomd.md.methods.thermostats.Bussi` (i.e., Stochastic velocity rescaling).
-
-    Notes
-    -----
-    kT is in units of energy rather than Kelvin or Celsius. Use the `unyt` package to
-    easily convert T to kT with the energy units used by your force field.
-
-    ```python
-        hoomd_nvt(
-            compound=compound,
-            sim=sim,
-            forces_handler=ForcesHandler(scale_angle=1, scale_bond=1, dpd=0),
-            kT=(300 * u.K).to_equivalent("kJ/mol", "thermal").value,
-            dt=1e-4,
-            tau=1e-2,
-            n_steps=10000
-        )
-    ````
-    """
-    forces_handler.scale_sim(sim)
-
-    # Set up and run
-    nvt = hoomd.md.methods.ConstantVolume(
-        filter=sim.get_integrate_group(), thermostat=thermostat(kT=kT, tau=tau)
-    )
-    sim.set_integrator(method=nvt, dt=dt)
-    # Create random initial velocities
-    sim.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=kT)
-    # Store the initial energy if this is the first simulation call.
-    if sim.energies == []:
-        sim.run(0)
-        sim.store_current_energies()
-    # Run and store resulting energies.
-    sim.run(n_steps)
-    sim.store_current_energies()
-    sim.operations.integrator = None
-    sim.update_positions()
-    sim._update_snapshot()
-
-
-def hoomd_cap_displacement(
-    compound,
-    sim,
-    forces_handler,
-    n_steps,
-    dt,
-    max_displacement=1e-3,
-):
-    """Run a short simulation with hoomd.md.methods.DisplacementCapped
-
-    Parameters
-    ----------
-    compound : mb.Compound
-        The compound to use in the simulation
-    sim : mb.simulation.HOOMDSimulation
-        The simulation context used during the simulation.
-    forces_handler : mb.simulation.ForceHander
-        The way to handle forces for this simulation method. Will apply specified forces,
-        scaling as needed.
-    n_steps : int
-        The number of simulation time steps to run with the modified forcefield
-        created by bond_k_scale, angle_k_scale, and dpd_A.
-        See these parameters for more information.
-    dt : float
-        The simulation timestep. Note that for running capped displacement on highly unstable
-        systems (e.g. overlapping particles), it is often more stable to use a larger
-        value of dt and let the displacement cap limit position updates.
-    max_displacement : float (nm), default = 1e-3 nm
-        The maximum displacement (nm) allowed per timestep. Use smaller values for
-        highly unstable systems.
-
-    """
-    compound._kick()
-
-    forces_handler.scale_sim(sim)
-
-    # Set up and run
-    displacement_capped = hoomd.md.methods.DisplacementCapped(
-        filter=sim.get_integrate_group(),
-        maximum_displacement=max_displacement,
-    )
-    sim.set_integrator(method=displacement_capped, dt=dt)
-    # Store the initial energy if this is the first simulation call.
-    if sim.energies == []:
-        sim.run(0)
-        sim.store_current_energies()
-    # Run and store resulting energies.
-    sim.run(n_steps)
-    sim.store_current_energies()
-    sim.operations.integrator = None
-    sim.update_positions()
-    sim._update_snapshot()
-
-
-def hoomd_fire(
-    compound,
-    sim,
-    forces_handler,
-    n_steps,
-    n_iterations=1,
-    dt=1e-5,
-    min_steps_adapt=5,
-    min_steps_conv=100,
-    finc_dt=1.1,
-    fdec_dt=0.5,
-    alpha_start=0.1,
-    fdec_alpha=0.95,
-    force_tol=1e-2,
-    angmom_tol=1e-2,
-    energy_tol=1e-6,
-):
-    """Run a short HOOMD-Blue simulation with the FIRE integrator.
-    This method can be helpful for relaxing high-energy
-    configurations or for removing overlapping particles.
-
-    Parameters:
-    -----------
-    compound : mb.Compound
-        The compound to use in the simulation
-    sim : mb.simulation.HOOMDSimulation
-        The simulation context used during the simulation.
-    forces_handler : mb.simulation.ForceHander
-        The way to handle forces for this simulation method. Will apply specified forces,
-        scaling as needed.
-    steps : int; required
-        The number of simulation steps to run
-    dt : float, default 1e-5
-        Simulation step size. Consider system stability when setting.
-    min_steps_adapt : int, default 5
-        Minimum number of steps with negative energy change before `dt`
-        and ``alpha`` are allowed to adapt.
-    min_steps_conv : int, default 100
-        Minimum number of steps taken before convergence criteria are
-        evaluated.
-    finc_dt : float, default 1.1
-        Multiplicative factor by which ``dt`` is increased on successful steps.
-    fdec_dt : float, default 0.5
-        Multiplicative factor by which ``dt`` is decreased on unsuccessful steps.
-    alpha_start : float, default 0.1
-        Initial and maximum value of the velocity mixing parameter ``alpha``.
-    fdec_alpha : float, default 0.95
-        Multiplicative factor by which ``alpha`` is decreased each adapting step.
-    force_tol : float, default 1e-2
-        Convergence threshold for the per-particle force magnitude.
-    angmom_tol : float, default 1e-2
-        Convergence threshold for the per-particle angular momentum magnitude.
-    energy_tol : float, default 1e-6
-        Convergence threshold for the fractional change in system energy.
-    """
-    compound._kick()
-    forces_handler.scale_sim(sim)
-    # Set up and run
-    nvt = hoomd.md.methods.ConstantVolume(filter=sim.get_integrate_group())
-    sim.set_fire_integrator(
-        dt=dt,
-        force_tol=force_tol,
-        angmom_tol=angmom_tol,
-        energy_tol=energy_tol,
-        finc_dt=finc_dt,
-        fdec_dt=fdec_dt,
-        alpha_start=alpha_start,
-        fdec_alpha=fdec_alpha,
-        min_steps_adapt=min_steps_adapt,
-        min_steps_conv=min_steps_conv,
-        methods=[nvt],
-    )
-    # Store the initial energy if this is the first simulation call.
-    if sim.energies == []:
-        sim.run(0)
-        sim.store_current_energies()
-    # Run and store resulting energies.
-    for sim_num in range(n_iterations):
-        sim.run(n_steps)
-        sim.operations.integrator.reset()
-
-    # Update particle positions, save latest state point snapshot
-    sim.store_current_energies()
-    sim.operations.integrator = None
-    sim._update_snapshot()
-    sim.update_positions()
-
-
-# Openbabel and OpenMM
-def energy_minimize(
-    compound,
-    forcefield="UFF",
-    steps=1000,
-    shift_com=True,
-    anchor=None,
-    **kwargs,
-):
-    """Perform an energy minimization on a Compound.
-
-    Default behavior utilizes `Open Babel <http://openbabel.org/docs/dev/>`_
-    to perform an energy minimization/geometry optimization on a Compound by
-    applying a generic force field
-
-    Can also utilize `OpenMM <http://openmm.org/>`_ to energy minimize after
-    atomtyping a Compound using
-    `Foyer <https://github.com/mosdef-hub/foyer>`_ to apply a forcefield XML
-    file that contains valid SMARTS strings.
-
-    This function is primarily intended to be used on smaller components,
-    with sizes on the order of 10's to 100's of particles, as the energy
-    minimization scales poorly with the number of particles.
-
-    Parameters
-    ----------
-    compound : mbuid.Compound, required
-        The compound to perform energy minimization on.
-    steps : int, optional, default=1000
-        The number of optimization iterations
-    forcefield : str, optional, default='UFF'
-        The generic force field to apply to the Compound for minimization.
-        Valid options are 'MMFF94', 'MMFF94s', ''UFF', 'GAFF', 'Ghemical'.
-        Please refer to the `Open Babel documentation
-        <http://open-babel.readthedocs.io/en/latest/Forcefields/Overview.html>`_
-        when considering your choice of force field.
-        Utilizing OpenMM for energy minimization requires a forcefield
-        XML file with valid SMARTS strings. Please refer to `OpenMM docs
-        <http://docs.openmm.org/7.0.0/userguide/application.html#creating-force-fields>`_
-        for more information.
-    shift_com : bool, optional, default=True
-        If True, the energy-minimized Compound is translated such that the
-        center-of-mass is unchanged relative to the initial configuration.
-    anchor : Compound, optional, default=None
-        Translates the energy-minimized Compound such that the
-        position of the anchor Compound is unchanged relative to the
-        initial configuration.
-
-    Other Parameters
-    ----------------
-    algorithm : str, optional, default='cg'
-        The energy minimization algorithm.  Valid options are 'steep', 'cg',
-        and 'md', corresponding to steepest descent, conjugate gradient, and
-        equilibrium molecular dynamics respectively.
-        For _energy_minimize_openbabel
-    fixed_compounds : Compound, optional, default=None
-        An individual Compound or list of Compounds that will have their
-        position fixed during energy minimization. Note, positions are fixed
-        using a restraining potential and thus may change slightly.
-        Position fixing will apply to all Particles (i.e., atoms) that exist
-        in the Compound and to particles in any subsequent sub-Compounds.
-        By default x,y, and z position is fixed. This can be toggled by instead
-        passing a list containing the Compound and an list or tuple of bool values
-        corresponding to x,y and z; e.g., [Compound, (True, True, False)]
-        will fix the x and y position but allow z to be free.
-        For _energy_minimize_openbabel
-    ignore_compounds: Compound, optional, default=None
-        An individual compound or list of Compounds whose underlying particles
-        will have their positions fixed and not interact with other atoms via
-        the specified force field during the energy minimization process.
-        Note, a restraining potential used and thus absolute position may vary
-        as a result of the energy minimization process.
-        Interactions of these ignored atoms can  be specified by the user,
-        e.g., by explicitly setting a distance constraint.
-        For _energy_minimize_openbabel
-    distance_constraints: list, optional, default=None
-        A list containing a pair of Compounds as a tuple or list and
-        a float value specifying the target distance between the two Compounds, e.g.,:
-        [(compound1, compound2), distance].
-        To specify more than one constraint, pass constraints as a 2D list, e.g.,:
-        [ [(compound1, compound2), distance1],  [(compound3, compound4), distance2] ].
-        Note, Compounds specified here must represent individual point particles.
-        For _energy_minimize_openbabel
-    constraint_factor: float, optional, default=50000.0
-        Harmonic springs are used to constrain distances and fix atom positions, where
-        the resulting energy associated with the spring is scaled by the
-        constraint_factor; the energy of this spring is considering during the minimization.
-        As such, very small values of the constraint_factor may result in an energy
-        minimized state that does not adequately restrain the distance/position of atoms.
-        For _energy_minimize_openbabel
-    scale_bonds : float, optional, default=1
-        Scales the bond force constant (1 is completely on).
-        For _energy_minimize_openmm
-    scale_angles : float, optional, default=1
-        Scales the angle force constant (1 is completely on)
-        For _energy_minimize_openmm
-    scale_torsions : float, optional, default=1
-        Scales the torsional force constants (1 is completely on)
-        For _energy_minimize_openmm
-        Note: Only Ryckaert-Bellemans style torsions are currently supported
-    scale_nonbonded : float, optional, default=1
-        Scales epsilon (1 is completely on)
-        For _energy_minimize_openmm
-    constraints : str, optional, default="AllBonds"
-        Specify constraints on the molecule to minimize, options are:
-        None, "HBonds", "AllBonds", "HAngles"
-        For _energy_minimize_openmm
-
-    References
-    ----------
-    If using _energy_minimize_openmm(), please cite:
-
-    .. [Eastman2013] P. Eastman, M. S. Friedrichs, J. D. Chodera,
-       R. J. Radmer, C. M. Bruns, J. P. Ku, K. A. Beauchamp, T. J. Lane,
-       L.-P. Wang, D. Shukla, T. Tye, M. Houston, T. Stich, C. Klein,
-       M. R. Shirts, and V. S. Pande. "OpenMM 4: A Reusable, Extensible,
-       Hardware Independent Library for High Performance Molecular
-       Simulation." J. Chem. Theor. Comput. 9(1): 461-469. (2013).
-
-    If using _energy_minimize_openbabel(), please cite:
-
-    .. [OBoyle2011] O'Boyle, N.M.; Banck, M.; James, C.A.; Morley, C.;
-       Vandermeersch, T.; Hutchison, G.R. "Open Babel: An open chemical
-       toolbox." (2011) J. Cheminf. 3, 33
-
-    .. [OpenBabel] Open Babel, version X.X.X http://openbabel.org,
-       (installed Month Year)
-
-    If using the 'MMFF94' force field please also cite the following:
-
-    .. [Halgren1996a] T.A. Halgren, "Merck molecular force field. I. Basis,
-       form, scope, parameterization, and performance of MMFF94." (1996)
-       J. Comput. Chem. 17, 490-519
-
-    .. [Halgren1996b] T.A. Halgren, "Merck molecular force field. II. MMFF94
-       van der Waals and electrostatic parameters for intermolecular
-       interactions." (1996) J. Comput. Chem. 17, 520-552
-
-    .. [Halgren1996c] T.A. Halgren, "Merck molecular force field. III.
-       Molecular geometries and vibrational frequencies for MMFF94." (1996)
-       J. Comput. Chem. 17, 553-586
-
-    .. [Halgren1996d] T.A. Halgren and R.B. Nachbar, "Merck molecular force
-       field. IV. Conformational energies and geometries for MMFF94." (1996)
-       J. Comput. Chem. 17, 587-615
-
-    .. [Halgren1996e] T.A. Halgren, "Merck molecular force field. V.
-       Extension of MMFF94 using experimental data, additional computational
-       data, and empirical rules." (1996) J. Comput. Chem. 17, 616-641
-
-    If using the 'MMFF94s' force field please cite the above along with:
-
-    .. [Halgren1999] T.A. Halgren, "MMFF VI. MMFF94s option for energy minimization
-       studies." (1999) J. Comput. Chem. 20, 720-729
-
-    If using the 'UFF' force field please cite the following:
-
-    .. [Rappe1992] Rappe, A.K., Casewit, C.J., Colwell, K.S., Goddard, W.A.
-       III, Skiff, W.M. "UFF, a full periodic table force field for
-       molecular mechanics and molecular dynamics simulations." (1992)
-       J. Am. Chem. Soc. 114, 10024-10039
-
-    If using the 'GAFF' force field please cite the following:
-
-    .. [Wang2004] Wang, J., Wolf, R.M., Caldwell, J.W., Kollman, P.A.,
-       Case, D.A. "Development and testing of a general AMBER force field"
-       (2004) J. Comput. Chem. 25, 1157-1174
-
-    If using the 'Ghemical' force field please cite the following:
-
-    .. [Hassinen2001] T. Hassinen and M. Perakyla, "New energy terms for
-       reduced protein models implemented in an off-lattice force field"
-       (2001) J. Comput. Chem. 22, 1229-1242
-
-    """
-    # TODO: Update mbuild tutorials to provide overview of new features
-    #   Preliminary tutorials: https://github.com/chrisiacovella/mbuild_energy_minimization
-    com = compound.pos
-    anchor_in_compound = False
-    if anchor is not None:
-        # check to see if the anchor exists
-        # in the Compound to be energy minimized
-        for succesor in compound.successors():
-            if id(anchor) == id(succesor):
-                anchor_in_compound = True
-                anchor_pos_old = anchor.pos
-
-        if not anchor_in_compound:
-            raise MBuildError(
-                f"Anchor: {anchor} is not part of the Compound: {compound}"
-                "that you are trying to energy minimize."
-            )
-    compound._kick()
-    extension = os.path.splitext(forcefield)[-1]
-    openbabel_ffs = ["MMFF94", "MMFF94s", "UFF", "GAFF", "Ghemical"]
-    if forcefield in openbabel_ffs:
-        _energy_minimize_openbabel(
-            compound=compound, forcefield=forcefield, steps=steps, **kwargs
-        )
-    else:
-        tmp_dir = tempfile.mkdtemp()
-        compound.save(os.path.join(tmp_dir, "un-minimized.mol2"))
-
-        if extension == ".xml":
-            _energy_minimize_openmm(
-                compound=compound,
-                tmp_dir=tmp_dir,
-                forcefield_files=forcefield,
-                forcefield_name=None,
-                steps=steps,
-                **kwargs,
-            )
-        else:
-            _energy_minimize_openmm(
-                compound=compound,
-                tmp_dir=tmp_dir,
-                forcefield_files=None,
-                forcefield_name=forcefield,
-                steps=steps,
-                **kwargs,
-            )
-
-        compound.update_coordinates(os.path.join(tmp_dir, "minimized.pdb"))
-
-    if shift_com:
-        compound.translate_to(com)
-
-    if anchor_in_compound:
-        anchor_pos_new = anchor.pos
-        delta = anchor_pos_old - anchor_pos_new
-        compound.translate(delta)
-
-
-def _energy_minimize_openmm(
-    compound,
-    tmp_dir,
-    forcefield_files=None,
-    forcefield_name=None,
-    steps=1000,
-    scale_bonds=1,
-    scale_angles=1,
-    scale_torsions=1,
-    scale_nonbonded=1,
-    constraints="AllBonds",
-):
-    """Perform energy minimization using OpenMM.
-
-    Converts an mBuild Compound to a ParmEd Structure,
-    applies a forcefield using Foyer, and creates an OpenMM System.
-
-    Parameters
-    ----------
-    compound : mbuid.Compound, required
-        The compound to perform energy minimization on.
-    forcefield_files : str or list of str, optional, default=None
-        Forcefield files to load
-    forcefield_name : str, optional, default=None
-        Apply a named forcefield to the output file using the `foyer`
-        package, e.g. 'oplsaa'. `Foyer forcefields`
-        <https://github.com/mosdef-hub/foyer/tree/master/foyer/forcefields>_
-    steps : int, optional, default=1000
-        Number of energy minimization iterations
-    scale_bonds : float, optional, default=1
-        Scales the bond force constant (1 is completely on)
-    scale_angles : float, optiona, default=1
-        Scales the angle force constant (1 is completely on)
-    scale_torsions : float, optional, default=1
-        Scales the torsional force constants (1 is completely on)
-    scale_nonbonded : float, optional, default=1
-        Scales epsilon (1 is completely on)
-    constraints : str, optional, default="AllBonds"
-        Specify constraints on the molecule to minimize, options are:
-        None, "HBonds", "AllBonds", "HAngles"
-
-    Notes
-    -----
-    Assumes a particular organization for the force groups
-    (HarmonicBondForce, HarmonicAngleForce, RBTorsionForce, NonBondedForce)
-
-    References
-    ----------
-    [Eastman2013]_
-    """
-    foyer = import_("foyer")
-
-    to_parmed = compound.to_parmed()
-    ff = foyer.Forcefield(forcefield_files=forcefield_files, name=forcefield_name)
-    to_parmed = ff.apply(to_parmed)
-
-    import openmm.unit as u
-    from openmm.app import AllBonds, HAngles, HBonds
-    from openmm.app.pdbreporter import PDBReporter
-    from openmm.app.simulation import Simulation
-    from openmm.openmm import LangevinIntegrator
-
-    if constraints:
-        if constraints == "AllBonds":
-            constraints = AllBonds
-        elif constraints == "HBonds":
-            constraints = HBonds
-        elif constraints == "HAngles":
-            constraints = HAngles
-        else:
-            raise ValueError(
-                f"Provided constraints value of: {constraints}.\n"
-                f'Expected "HAngles", "AllBonds" "HBonds".'
-            )
-        system = to_parmed.createSystem(
-            constraints=constraints
-        )  # Create an OpenMM System
-    else:
-        system = to_parmed.createSystem()  # Create an OpenMM System
-    # Create a Langenvin Integrator in OpenMM
-    integrator = LangevinIntegrator(
-        298 * u.kelvin, 1 / u.picosecond, 0.002 * u.picoseconds
-    )
-    # Create Simulation object in OpenMM
-    simulation = Simulation(to_parmed.topology, system, integrator)
-
-    # Loop through forces in OpenMM System and set parameters
-    for force in system.getForces():
-        if type(force).__name__ == "HarmonicBondForce":
-            for bond_index in range(force.getNumBonds()):
-                atom1, atom2, r0, k = force.getBondParameters(bond_index)
-                force.setBondParameters(bond_index, atom1, atom2, r0, k * scale_bonds)
-            force.updateParametersInContext(simulation.context)
-
-        elif type(force).__name__ == "HarmonicAngleForce":
-            for angle_index in range(force.getNumAngles()):
-                atom1, atom2, atom3, r0, k = force.getAngleParameters(angle_index)
-                force.setAngleParameters(
-                    angle_index, atom1, atom2, atom3, r0, k * scale_angles
-                )
-            force.updateParametersInContext(simulation.context)
-
-        elif type(force).__name__ == "RBTorsionForce":
-            for torsion_index in range(force.getNumTorsions()):
-                (
-                    atom1,
-                    atom2,
-                    atom3,
-                    atom4,
-                    c0,
-                    c1,
-                    c2,
-                    c3,
-                    c4,
-                    c5,
-                ) = force.getTorsionParameters(torsion_index)
-                force.setTorsionParameters(
-                    torsion_index,
-                    atom1,
-                    atom2,
-                    atom3,
-                    atom4,
-                    c0 * scale_torsions,
-                    c1 * scale_torsions,
-                    c2 * scale_torsions,
-                    c3 * scale_torsions,
-                    c4 * scale_torsions,
-                    c5 * scale_torsions,
-                )
-            force.updateParametersInContext(simulation.context)
-
-        elif type(force).__name__ == "NonbondedForce":
-            for nb_index in range(force.getNumParticles()):
-                charge, sigma, epsilon = force.getParticleParameters(nb_index)
-                force.setParticleParameters(
-                    nb_index, charge, sigma, epsilon * scale_nonbonded
-                )
-            force.updateParametersInContext(simulation.context)
-
-        elif type(force).__name__ == "CMMotionRemover":
-            pass
-
-        else:
-            warn(
-                f"OpenMM Force {type(force).__name__} is "
-                "not currently supported in _energy_minimize_openmm. "
-                "This Force will not be updated!"
-            )
-
-    simulation.context.setPositions(to_parmed.positions)
-    # Run energy minimization through OpenMM
-    simulation.minimizeEnergy(maxIterations=steps)
-    reporter = PDBReporter(os.path.join(tmp_dir, "minimized.pdb"), 1)
-    reporter.report(simulation, simulation.context.getState(getPositions=True))
-
-
-def _check_openbabel_constraints(
-    compound,
-    particle_list,
-    successors_list,
-    check_if_particle=False,
-):
-    """Provide routines commonly used to check constraint inputs."""
-    for part in particle_list:
-        if not isinstance(part, Compound):
-            raise MBuildError(f"{part} is not a Compound.")
-        if id(part) != id(compound) and id(part) not in successors_list:
-            raise MBuildError(f"{part} is not a member of Compound {compound}.")
-
-        if check_if_particle:
-            if len(part.children) != 0:
-                raise MBuildError(
-                    f"{part} does not correspond to an individual particle."
-                )
-
-
-def _energy_minimize_openbabel(
-    compound,
-    steps=1000,
-    algorithm="cg",
-    forcefield="UFF",
-    constraint_factor=50000.0,
-    distance_constraints=None,
-    fixed_compounds=None,
-    ignore_compounds=None,
-):
-    """Perform an energy minimization on a Compound.
-
-    Utilizes Open Babel (http://openbabel.org/docs/dev/) to perform an
-    energy minimization/geometry optimization on a Compound by applying
-    a generic force field.
-
-    This function is primarily intended to be used on smaller components,
-    with sizes on the order of 10's to 100's of particles, as the energy
-    minimization scales poorly with the number of particles.
-
-    Parameters
-    ----------
-    compound : mbuid.Compound, required
-        The compound to perform energy minimization on.
-    steps : int, optionl, default=1000
-        The number of optimization iterations
-    algorithm : str, optional, default='cg'
-        The energy minimization algorithm.  Valid options are 'steep',
-        'cg', and 'md', corresponding to steepest descent, conjugate
-        gradient, and equilibrium molecular dynamics respectively.
-    forcefield : str, optional, default='UFF'
-        The generic force field to apply to the Compound for minimization.
-        Valid options are 'MMFF94', 'MMFF94s', ''UFF', 'GAFF', 'Ghemical'.
-        Please refer to the Open Babel documentation
-        (http://open-babel.readthedocs.io/en/latest/Forcefields/Overview.html)
-        when considering your choice of force field.
-    fixed_compounds : Compound, optional, default=None
-        An individual Compound or list of Compounds that will have their
-        position fixed during energy minimization. Note, positions are fixed
-        using a restraining potential and thus may change slightly.
-        Position fixing will apply to all Particles (i.e., atoms) that exist
-        in the Compound and to particles in any subsequent sub-Compounds.
-        By default x,y, and z position is fixed. This can be toggled by instead
-        passing a list containing the Compound and a list or tuple of bool values
-        corresponding to x,y and z; e.g., [Compound, (True, True, False)]
-        will fix the x and y position but allow z to be free.
-    ignore_compounds: Compound, optional, default=None
-        An individual compound or list of Compounds whose underlying particles
-        will have their positions fixed and not interact with other atoms via
-        the specified force field during the energy minimization process.
-        Note, a restraining potential is used and thus absolute position may vary
-        as a result of the energy minimization process.
-        Interactions of these ignored atoms can  be specified by the user,
-        e.g., by explicitly setting a distance constraint.
-    distance_constraints: list, optional, default=None
-        A list containing a pair of Compounds as a tuple or list and
-        a float value specifying the target distance between the two Compounds, e.g.,:
-        [(compound1, compound2), distance].
-        To specify more than one constraint, pass constraints as a 2D list, e.g.,:
-        [ [(compound1, compound2), distance1],  [(compound3, compound4), distance2] ].
-        Note, Compounds specified here must represent individual point particles.
-    constraint_factor: float, optional, default=50000.0
-        Harmonic springs are used to constrain distances and fix atom positions, where
-        the resulting energy associated with the spring is scaled by the
-        constraint_factor; the energy of this spring is considering during the minimization.
-        As such, very small values of the constraint_factor may result in an energy
-        minimized state that does not adequately restrain the distance/position of atom(s)e.
-
-
-    References
-    ----------
-    [OBoyle2011]_
-    [OpenBabel]_
-
-    If using the 'MMFF94' force field please also cite the following:
-    [Halgren1996a]_
-    [Halgren1996b]_
-    [Halgren1996c]_
-    [Halgren1996d]_
-    [Halgren1996e]_
-
-    If using the 'MMFF94s' force field please cite the above along with:
-    [Halgren1999]_
-
-    If using the 'UFF' force field please cite the following:
-    [Rappe1992]_
-
-    If using the 'GAFF' force field please cite the following:
-    [Wang2001]_
-
-    If using the 'Ghemical' force field please cite the following:
-    [Hassinen2001]_
-    """
-    openbabel = import_("openbabel")
-    for particle in compound.particles():
-        if particle.element is None:
-            try:
-                particle._element = element_from_symbol(particle.name)
-            except ElementError:
-                try:
-                    particle._element = element_from_name(particle.name)
-                except ElementError:
-                    raise MBuildError(
-                        f"No element assigned to {particle}; element could not be"
-                        f"inferred from particle name {particle.name}. Cannot perform"
-                        "an energy minimization."
-                    )
-    # Create a dict containing particle id and associated index to speed up looping
-    particle_idx = {
-        id(particle): idx for idx, particle in enumerate(compound.particles())
-    }
-
-    # A list containing all Compounds ids contained in compound. Will be used to check if
-    # compounds refered to in the constrains are actually in the Compound we are minimizing.
-    successors_list = [id(comp) for comp in compound.successors()]
-
-    # initialize constraints
-    ob_constraints = openbabel.OBFFConstraints()
-
-    if distance_constraints is not None:
-        # if a user passes single constraint as a 1-D array,
-        # i.e., [(p1,p2), 2.0]  rather than [[(p1,p2), 2.0]],
-        # just add it to a list so we can use the same looping code
-        if len(np.array(distance_constraints, dtype=object).shape) == 1:
-            distance_constraints = [distance_constraints]
-
-        for con_temp in distance_constraints:
-            p1 = con_temp[0][0]
-            p2 = con_temp[0][1]
-
-            _check_openbabel_constraints(
-                compound=compound,
-                particle_list=[p1, p2],
-                successors_list=successors_list,
-                check_if_particle=True,
-            )
-            if id(p1) == id(p2):
-                raise MBuildError(
-                    f"Cannot create a constraint between a Particle and itself: {p1} {p2} ."
-                )
-
-            # openbabel indices start at 1
-            pid_1 = particle_idx[id(p1)] + 1
-            # openbabel indices start at 1
-            pid_2 = particle_idx[id(p2)] + 1
-            dist = (
-                con_temp[1] * 10.0
-            )  # obenbabel uses angstroms, not nm, convert to angstroms
-
-            ob_constraints.AddDistanceConstraint(pid_1, pid_2, dist)
-
-    if fixed_compounds is not None:
-        # if we are just passed a single Compound, wrap it into
-        # and array so we can just use the same looping code
-        if isinstance(fixed_compounds, Compound):
-            fixed_compounds = [fixed_compounds]
-
-        # if fixed_compounds is a 1-d array and it is of length 2, we need to determine whether it is
-        # a list of two Compounds or if fixed_compounds[1] should correspond to the directions to constrain
-        if len(np.array(fixed_compounds, dtype=object).shape) == 1:
-            if len(fixed_compounds) == 2:
-                if not isinstance(fixed_compounds[1], Compound):
-                    # if it is not a list of two Compounds, make a 2d array so we can use the same looping code
-                    fixed_compounds = [fixed_compounds]
-
-        for fixed_temp in fixed_compounds:
-            # if an individual entry is a list, validate the input
-            if isinstance(fixed_temp, list):
-                if len(fixed_temp) == 2:
-                    msg1 = (
-                        "Expected tuple or list of length 3 to set"
-                        "which dimensions to fix motion."
-                    )
-                    assert isinstance(fixed_temp[1], (list, tuple)), msg1
-
-                    msg2 = (
-                        "Expected tuple or list of length 3 to set"
-                        "which dimensions to fix motion, "
-                        f"{len(fixed_temp[1])} found."
-                    )
-                    assert len(fixed_temp[1]) == 3, msg2
-
-                    dims = [dim for dim in fixed_temp[1]]
-                    msg3 = (
-                        "Expected bool values for which directions are fixed."
-                        f"Found instead {dims}."
-                    )
-                    assert all(isinstance(dim, bool) for dim in dims), msg3
-
-                    p1 = fixed_temp[0]
-
-                # if fixed_compounds is defined as [[Compound],[Compound]],
-                # fixed_temp will be a list of length 1
-                elif len(fixed_temp) == 1:
-                    p1 = fixed_temp[0]
-                    dims = [True, True, True]
-
-            else:
-                p1 = fixed_temp
-                dims = [True, True, True]
-
-            all_true = all(dims)
-
-            _check_openbabel_constraints(
-                compound=compound, particle_list=[p1], successors_list=successors_list
-            )
-
-            if len(p1.children) == 0:
-                pid = particle_idx[id(p1)] + 1  # openbabel indices start at 1
-
-                if all_true:
-                    ob_constraints.AddAtomConstraint(pid)
-                else:
-                    if dims[0]:
-                        ob_constraints.AddAtomXConstraint(pid)
-                    if dims[1]:
-                        ob_constraints.AddAtomYConstraint(pid)
-                    if dims[2]:
-                        ob_constraints.AddAtomZConstraint(pid)
-            else:
-                for particle in p1.particles():
-                    pid = particle_idx[id(particle)] + 1  # openbabel indices start at 1
-
-                    if all_true:
-                        ob_constraints.AddAtomConstraint(pid)
-                    else:
-                        if dims[0]:
-                            ob_constraints.AddAtomXConstraint(pid)
-                        if dims[1]:
-                            ob_constraints.AddAtomYConstraint(pid)
-                        if dims[2]:
-                            ob_constraints.AddAtomZConstraint(pid)
-
-    if ignore_compounds is not None:
-        temp1 = np.array(ignore_compounds, dtype=object)
-        if len(temp1.shape) == 2:
-            ignore_compounds = list(temp1.reshape(-1))
-
-        # Since the ignore_compounds can only be passed as a list
-        # we can check the whole list at once before looping over it
-        _check_openbabel_constraints(
-            compound=compound,
-            particle_list=ignore_compounds,
-            successors_list=successors_list,
-        )
-
-        for ignore in ignore_compounds:
-            p1 = ignore
-            if len(p1.children) == 0:
-                pid = particle_idx[id(p1)] + 1  # openbabel indices start at 1
-                ob_constraints.AddIgnore(pid)
-
-            else:
-                for particle in p1.particles():
-                    pid = particle_idx[id(particle)] + 1  # openbabel indices start at 1
-                    ob_constraints.AddIgnore(pid)
-
-    mol = compound.to_pybel()
-    mol = mol.OBMol
-
-    mol.PerceiveBondOrders()
-    mol.SetAtomTypesPerceived()
-
-    ff = openbabel.OBForceField.FindForceField(forcefield)
-    if ff is None:
-        raise MBuildError(
-            f"Force field '{forcefield}' not supported for energy "
-            "minimization. Valid force fields are 'MMFF94', "
-            "'MMFF94s', 'UFF', 'GAFF', and 'Ghemical'."
-            ""
-        )
-    warn(
-        "Performing energy minimization using the Open Babel package. "
-        "Please refer to the documentation to find the appropriate "
-        f"citations for Open Babel and the {forcefield} force field"
-    )
-
-    if (
-        distance_constraints is not None
-        or fixed_compounds is not None
-        or ignore_compounds is not None
-    ):
-        ob_constraints.SetFactor(constraint_factor)
-        if ff.Setup(mol, ob_constraints) == 0:
-            raise MBuildError("Could not setup forcefield for OpenBabel Optimization.")
-    else:
-        if ff.Setup(mol) == 0:
-            raise MBuildError("Could not setup forcefield for OpenBabel Optimization.")
-
-    if algorithm == "steep":
-        ff.SteepestDescent(steps)
-    elif algorithm == "md":
-        ff.MolecularDynamicsTakeNSteps(steps, 300)
-    elif algorithm == "cg":
-        ff.ConjugateGradients(steps)
-    else:
-        raise MBuildError(
-            "Invalid minimization algorithm. Valid options are 'steep', 'cg', and 'md'."
-        )
-    ff.UpdateCoordinates(mol)
-
-    # update the coordinates in the Compound
-    for i, obatom in enumerate(openbabel.OBMolAtomIter(mol)):
-        x = obatom.GetX() / 10.0
-        y = obatom.GetY() / 10.0
-        z = obatom.GetZ() / 10.0
-        compound[i].pos = np.array([x, y, z])
-
-
-def energy_minimize_path(
-    path, bead_size=0.3, bond_length=None, steps=1000, seed=1, nthreads=1
-):
-    # TODO: Set equilibrium or constrained angle
-    positions = path.coordinates
-    n_particles = len(positions)
-
-    import openmm
-    import openmm.unit as u
-    from openmm import Platform
-    from openmm.app import Topology
-    from openmm.app.simulation import Simulation
-    from openmm.openmm import LangevinIntegrator
-
-    # Create platform without parallelization
-    platform = Platform.getPlatformByName("CPU")
-    platform.setPropertyDefaultValue("Threads", str(nthreads))
-
-    system = openmm.System()
-    for i in range(n_particles):
-        system.addParticle(1.0 * u.amu)
-
-    # Create a Langenvin Integrator in OpenMM
-    integrator = LangevinIntegrator(
-        298 * u.kelvin,
-        1 / u.picosecond,
-        0.001 * u.picoseconds,
-    )
-    integrator.setRandomNumberSeed(seed)  # set seed
-
-    # Set nonbonded force for each particle
-    nonbonded_force = openmm.NonbondedForce()
-    nonbonded_force.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
-    sigma = bead_size * u.nanometer
-    epsilon = 0.1 * u.kilocalories_per_mole
-    for i in range(n_particles):
-        nonbonded_force.addParticle(0.0, sigma, epsilon)
-    system.addForce(nonbonded_force)
-
-    if not bond_length:
-        for i, j in path.bond_graph.edges():
-            bond_length = np.linalg.norm(positions[j] - positions[i])
-            system.addConstraint(i, j, bond_length * u.nanometer)
-    else:
-        # Use HarmonicBondForce instead of constraints
-        harmonic_force = openmm.HarmonicBondForce()
-        for i, j in path.bond_graph.edges():
-            harmonic_force.addBond(
-                i,
-                j,
-                bond_length * u.nanometer,
-                300 * u.kilocalories_per_mole / u.nanometer**2,
-            )
-        system.addForce(harmonic_force)
-
-    topology = Topology()
-    chain = topology.addChain()
-    for i in range(n_particles):
-        residue = topology.addResidue(f"LJ{i}", chain)
-        topology.addAtom(f"P{i}", openmm.app.Element.getByMass(1), residue)
-    # Add bonds to topology
-    atomsList = list(topology.atoms())
-    for i, j in path.bond_graph.edges():
-        topology.addBond(atomsList[i], atomsList[j])
-
-    simulation = Simulation(topology, system, integrator, platform)
-    simulation.context.setPositions(positions)
-
-    # Run energy minimization through OpenMM
-    simulation.minimizeEnergy(maxIterations=steps)
-
-    # Get positions directly
-    state = simulation.context.getState(getPositions=True)
-    pos = np.array(state.getPositions(asNumpy=True))
-    if np.any(np.isnan(pos)):
-        logger.warning("Unable to energy minimize. Nan values detected.")
-    else:
-        path.coordinates = np.array(state.getPositions(asNumpy=True))
+            self.forcesDict[key] = force

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -57,15 +57,17 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         compound,
         forcefield,
         r_cut,
-        run_on_gpu,
-        seed,
+        run_on_gpu=None,
+        seed=1,
         automatic_box=False,
         box_buffer=10,
         integrate_compounds=None,
         fixed_compounds=None,
         gsd_file_name=None,
     ):
-        if run_on_gpu:
+        if run_on_gpu is None:
+            device = hoomd.device.auto_select()
+        elif run_on_gpu:
             try:
                 device = hoomd.device.GPU()
                 print(f"GPU found, running on device {device.device}")
@@ -85,6 +87,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         self.fixed_compounds = fixed_compounds
         self.automatic_box = automatic_box
         self.box_buffer = box_buffer
+        self.energies = []  # append all energy values
         # Check if a hoomd sim method has been used on this compound already
         if compound._hoomd_data:
             last_snapshot, last_forces, last_forcefield = compound._get_sim_data()
@@ -162,8 +165,12 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         else:
             return hoomd.filter.All()
 
-    def get_force(self, instance):
-        for force in set(self.forces + self.active_forces + self.inactive_forces):
+    def get_force(self, instance, active_only=False):
+        if active_only:
+            iterForcesSet = set(self.active_forces)
+        else:
+            iterForcesSet = set(self.forces)
+        for force in iterForcesSet:
             if isinstance(force, instance):
                 return force
         raise ValueError(f"No force of {instance} was found.")
@@ -232,6 +239,16 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             pos = snap.particles.position[particles]
             self.compound.xyz = np.copy(pos)
 
+    def store_current_energies(self):
+        """Store energy simulations progress."""
+        new_energy = {}
+        for force in self.active_forces:
+            ffname = force.__class__.__name__ + "." + force.__class__.__module__
+            print(f"{ffname} Energy: {force.energy:.2e}")
+            new_energy[ffname] = force.energy
+        if new_energy:
+            self.energies.append(new_energy)
+
 
 class ForcesHandler:
     """Provides a quick method for tuning HOOMD forces to better handle
@@ -290,6 +307,7 @@ class ForcesHandler:
 
     def scale_sim(self, sim):
         "Iterate through HOOMD force objects and apply scaling factors."
+        sim.active_forces = []  # reset active forces
         forcesDict = {
             "lj": (hoomd.md.pair.LJ, ("epsilon")),
             "charge": (hoomd.md.special_pair.Coulomb, ("alpha")),
@@ -414,7 +432,13 @@ def hoomd_cap_displacement(
         maximum_displacement=max_displacement,
     )
     sim.set_integrator(method=displacement_capped, dt=dt)
+    if sim.energies == []:
+        print("Initial Energy States:")
+        sim.run(0)
+        sim.store_current_energies()
+        print("\n")
     sim.run(n_steps)
+    sim.store_current_energies()
     sim.operations.integrator = None
     sim.update_positions()
     sim._update_snapshot()
@@ -526,11 +550,17 @@ def hoomd_fire(
         min_steps_conv=min_steps_conv,
         methods=[nvt],
     )
+    if sim.energies == []:
+        print("Initial Energy States:")
+        sim.run(0)
+        sim.store_current_energies()
+        print("\n")
     for sim_num in range(n_iterations):
         sim.run(n_steps)
         sim.operations.integrator.reset()
 
     # Update particle positions, save latest state point snapshot
+    sim.store_current_energies()
     sim.operations.integrator = None
     sim._update_snapshot()
     sim.update_positions()

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -128,6 +128,11 @@ class HoomdSimulation(hoomd.simulation.Simulation):
                 state=snapshot, forces=self.forces, forcefield=forcefield
             )
 
+        # Undo the translation to -L/2 L/2 used by HOOMD
+        self._frame_offset = self.compound.xyz.mean(axis=0) - np.asarray(
+            snapshot.particles.position
+        ).mean(axis=0)
+
         self.active_forces = []
         self.inactive_forces = []
         self._orig_force_params = {}
@@ -254,12 +259,19 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         )
         self.operations.updaters.append(box_resizer)
 
+        # HOOMD resizes the box about the origin. Track the box lengths so the
+        # frame offset can be adjusted, keeping the compound's box corner fixed
+        # when positions are synced back after the resize (see _update_positions).
+        L_before = np.asarray(self.state.box.L)
+
         if self.energies == []:
             self.run(0)
             self._store_current_energies()
 
         self.run(n_steps)
         self.operations.updaters.remove(box_resizer)
+        L_after = np.asarray(self.state.box.L)
+        self._frame_offset = self._frame_offset + (L_after - L_before) / 2
         self._store_current_energies()
         self._log_properties()
         self.operations.integrator = None
@@ -576,7 +588,9 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         with self.state.cpu_local_snapshot as snap:
             particles = snap.particles.rtag[:]
             pos = snap.particles.position[particles]
-            self.compound.xyz = np.copy(pos)
+            # Undo the box-centering translation applied when building the
+            # snapshot so coordinates return to the compound's original frame.
+            self.compound.xyz = np.copy(pos) + self._frame_offset
         _sync_back(self.compound, self._is_path, self._original_system)
 
     def _store_current_energies(self):

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -37,12 +37,14 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         If True, size the simulation box from the compound automatically.
     box_buffer : float, default 10
         Padding (nm) added around the compound when a bounding box is generated.
-    integrate_compounds : list of mb.Compound, default None
+    integrate_compounds : list of mb.Compound or list of int, default None
         Compounds to integrate while all others are held fixed. Mutually
         exclusive with fixed_compounds.
-    fixed_compounds : list of mb.Compound, default None
+        If a list of integers are passed, particles are chosen by matching indices.
+    fixed_compounds : list of mb.Compound or list of int, default None
         Compounds held fixed while all others are integrated. Mutually
         exclusive with integrate_compounds.
+        If a list of integers are passed, particles are chosen by matching indices.
     gsd_file_name : str or None, default None
         Name of a GSD file to write trajectory output to.
     kick : bool, default True
@@ -67,6 +69,16 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         kick=True,
         logger=None,
     ):
+
+        if integrate_compounds and fixed_compounds:
+            raise RuntimeError(
+                "You can specify only one of integrate_compounds and fixed_compounds."
+            )
+        if isinstance(integrate_compounds, Compound):
+            integrate_compounds = [integrate_compounds]
+        if isinstance(fixed_compounds, Compound):
+            fixed_compounds = [fixed_compounds]
+
         # Resolve input type
         compound, self._is_path, self._original_system, self.original_coords = (
             _resolve_input(system)
@@ -490,10 +502,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
                 fix_indices = self.fixed_compounds
             return hoomd.filter.SetDifference(
                 hoomd.filter.All(), hoomd.filter.Tags(fix_indices)
-            )
-        elif self.integrate_compounds and self.fixed_compounds:
-            raise RuntimeError(
-                "You can specify only one of integrate_compounds and fixed_compounds."
             )
         else:
             return hoomd.filter.All()

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -449,7 +449,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             forces, _ = gmso.external.to_hoomd_forcefield(top, r_cut=self.r_cut)
             snap, _ = gmso.external.to_gsd_snapshot(top=top)
             forces = list(set().union(*forces.values()))
-        else: # No GMSO/Foyer FF given, use the UFF-generated parameters
+        else:  # No GMSO/Foyer FF given, use the UFF-generated parameters
             from mbuild.utils.simulation.uff import assign_uff_types, uff_forces
 
             _, order_map = assign_uff_types(top, self.compound)

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -8,7 +8,7 @@ import hoomd
 import numpy as np
 from gmso.parameterization import apply
 
-from mbuild import Compound
+from mbuild import Box, Compound
 from mbuild.utils.io import import_
 
 logger = logging.getLogger(__name__)
@@ -37,6 +37,12 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         If True, size the simulation box from the compound automatically.
     box_buffer : float, default 10
         Padding (nm) added around the compound when a bounding box is generated.
+        Used only when neither box nor compound.box is set.
+    box : mb.Box or sequence of float or None, default None
+        Explicit orthorhombic box as [Lx, Ly, Lz] (or an mb.Box). Overrides
+        compound.box and the bounding-box fallback. Pass a constraint's
+        box_lengths so a packed Path keeps one fixed periodic cell across
+        repeated MC/MD rounds.
     integrate_compounds : list of mb.Compound or list of int, default None
         Compounds to integrate while all others are held fixed. Mutually
         exclusive with fixed_compounds.
@@ -63,6 +69,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         seed=1,
         automatic_box=False,
         box_buffer=10,
+        box=None,
         integrate_compounds=None,
         fixed_compounds=None,
         gsd_file_name=None,
@@ -109,6 +116,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         self.fixed_compounds = fixed_compounds
         self.automatic_box = automatic_box
         self.box_buffer = box_buffer
+        self.box = box
         self.energies = []
         self.logger = logger
 
@@ -434,7 +442,13 @@ class HoomdSimulation(hoomd.simulation.Simulation):
 
     def _to_hoomd_snap_forces(self):
         """Convert compound to HOOMD snapshot and forces."""
-        if not self.compound.box:
+        if self.box is not None:
+            # Explicit box (e.g. a constraint's orthorhombic box_lengths) wins,
+            # so the periodic cell is stable across repeated MC/MD rounds.
+            self.compound.box = (
+                self.box if isinstance(self.box, Box) else Box(lengths=list(self.box))
+            )
+        elif not self.compound.box:
             self.compound.box = self.compound.get_boundingbox(pad_box=self.box_buffer)
 
         from mbuild.utils.simulation.path_forces import (
@@ -456,13 +470,13 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             )
             snap, _ = gmso.external.to_gsd_snapshot(top=top)
             forces = generate_ff_from_path(
-                self._original_system,
                 snap,
                 radius=pff.radius,
                 bond_length=pff.bond_length,
                 angles_sampler=pff.angles,
                 dihedrals_sampler=pff.dihedrals,
                 epsilon=pff.epsilon,
+                r_cut=pff.r_cut,
             )
         elif self.forcefield is not None:
             apply(
@@ -480,6 +494,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             snap, _ = gmso.external.to_gsd_snapshot(top=top)
             forces = uff_forces(top, snap, order_map, r_cut=self.r_cut)
 
+        _wrap_into_box(snap)
         return snap, forces
 
     def _snapshot_force_params(self):
@@ -628,8 +643,12 @@ class OpenMMSimulation:
     forcefield : str or None
         A foyer-compatible forcefield name or XML path.
         If None, default LJ + harmonic bond/angle parameters are applied.
-    box : mb.Box or None
-        Simulation box. If None, uses compound.box or a bounding box.
+    box : mb.Box or sequence of float or None, default None
+        Explicit orthorhombic box as [Lx, Ly, Lz] (or an mb.Box). Overrides
+        compound.box, mirroring HoomdSimulation. Pass a constraint's box_lengths
+        so a packed system keeps one fixed periodic cell across repeated rounds.
+        If None and the compound has no box, the system is treated as
+        non-periodic (OpenMM NoCutoff).
     constraints : str or None, default is None
         Bond constraints: None, "HBonds", "AllBonds", "HAngles".
     platform : str
@@ -675,6 +694,13 @@ class OpenMMSimulation:
         self.r_cut = r_cut
         self.logger = logger
         self.energies = []
+        self.box = box
+
+        # Explicit box overrides compound.box (parity with HoomdSimulation).
+        if self.box is not None:
+            compound.box = (
+                self.box if isinstance(self.box, Box) else Box(lengths=list(self.box))
+            )
 
         if kick:
             compound._kick(seed=seed)
@@ -702,9 +728,8 @@ class OpenMMSimulation:
         from mbuild.utils.simulation.path_forces import PathForcefield
 
         if isinstance(forcefield, PathForcefield):
-            # TODO: Add an OpenMM backend to build_path_ff (WCA via
-            # CustomNonbondedForce, FENE via CustomBondForce, tabulated angles/
-            # dihedrals) so paths relax through OpenMM as they do through HOOMD.
+            # Path relaxation is HOOMD-only by design; there is no OpenMM
+            # backend for the coarse Kremer-Grest path forcefield.
             raise NotImplementedError(
                 "OpenMMSimulation does not yet support PathForcefield. Use "
                 "HoomdSimulation for coarse Kremer-Grest path relaxation."
@@ -1068,6 +1093,22 @@ def _resolve_input(system):
         raise TypeError(
             f"Expected an mb.Compound or mbuild.path.Path, got {type(system)}."
         )
+
+
+def _wrap_into_box(snap):
+    """Wrap snapshot positions into the half-open box [-L/2, L/2).
+
+    HOOMD rejects a particle on or past a face, e.g. one nudged there by _kick
+    against a tight box. Uses floor (not round) so +L/2 maps to -L/2. No-op for
+    padded boxes.
+    """
+    L = np.asarray(snap.configuration.box[:3], dtype=float)
+    pos = np.asarray(snap.particles.position, dtype=float)
+    periodic = L > 0
+    pos[:, periodic] -= L[periodic] * np.floor(
+        (pos[:, periodic] + L[periodic] / 2.0) / L[periodic]
+    )
+    snap.particles.position = pos.astype(np.float32)
 
 
 def _sync_back(compound, is_path, original):

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -68,7 +68,9 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         logger=None,
     ):
         # Resolve input type
-        compound, self._is_path, self._original_system, self.original_coords = _resolve_input(system)
+        compound, self._is_path, self._original_system, self.original_coords = (
+            _resolve_input(system)
+        )
 
         if kick:
             compound._kick()
@@ -240,7 +242,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         )
         self.operations.updaters.append(box_resizer)
 
-
         if self.energies == []:
             self.run(0)
             self._store_current_energies()
@@ -396,7 +397,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
 
     def recover(self):
         """Reset the system coordinates as they were before the last simulation."""
-        #TODO: Also reset last snapshot, delete last store_energy call?
+        # TODO: Also reset last snapshot, delete last store_energy call?
         _recover(self._original_system, self.original_coords)
 
     def _to_hoomd_snap_forces(self):
@@ -612,7 +613,9 @@ class OpenMMSimulation:
         from openmm.app import AllBonds, HAngles, HBonds
 
         # Resolve input type
-        compound, self._is_path, self._original_system, self.original_coords = _resolve_input(system)
+        compound, self._is_path, self._original_system, self.original_coords = (
+            _resolve_input(system)
+        )
 
         self.compound = compound
         self.forcefield_name = forcefield
@@ -798,9 +801,7 @@ class OpenMMSimulation:
         chain = topology.addChain()
         for p in particles_list:
             residue = topology.addResidue(p.name, chain)
-            topology.addAtom(
-                p.name, Element.getBySymbol(p.element.symbol), residue
-            )
+            topology.addAtom(p.name, Element.getBySymbol(p.element.symbol), residue)
         atoms_list = list(topology.atoms())
         for bond in top.bonds:
             m0, m1 = bond.connection_members

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -43,9 +43,9 @@ def _resolve_input(system):
         Whether the original input was a Path.
     original : the original input object
     """
-    from mbuild.path.build import Path
+    import mbuild.path.build
 
-    if isinstance(system, Path):
+    if isinstance(system, mbuild.path.build.Path):
         return system.to_compound(), True, system
     elif isinstance(system, Compound):
         return system, False, system

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -1,6 +1,7 @@
 """Simulation methods that operate on mBuild compounds and paths."""
 
 import logging
+import numbers
 import os
 
 import gmso
@@ -12,6 +13,9 @@ from mbuild import Box, Compound
 from mbuild.utils.io import import_
 
 logger = logging.getLogger(__name__)
+
+# Stands in for forcefield=None in the sim data cache key.
+_DEFAULT_FF = "default"
 
 
 class HoomdSimulation(hoomd.simulation.Simulation):
@@ -33,8 +37,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         If None, auto-select a device. If True use the GPU, if False the CPU.
     seed : int, default 1
         Seed for the HOOMD random number generator.
-    automatic_box : bool, default False
-        If True, size the simulation box from the compound automatically.
     box_buffer : float, default 10
         Padding (nm) added around the compound when a bounding box is generated.
         Used only when neither box nor compound.box is set.
@@ -51,13 +53,9 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         Compounds held fixed while all others are integrated. Mutually
         exclusive with integrate_compounds.
         If a list of integers are passed, particles are chosen by matching indices.
-    gsd_file_name : str or None, default None
-        Name of a GSD file to write trajectory output to.
     kick : bool, default True
         Nudge coordinates before simulating. This can be critical to remove
         flat dihedrals.
-    logger : PropertyLogger or None
-        Logger used to record scalar properties during runs.
     """
 
     def __init__(
@@ -67,24 +65,26 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         r_cut=1.0,
         run_on_gpu=None,
         seed=1,
-        automatic_box=False,
         box_buffer=10,
         box=None,
         integrate_compounds=None,
         fixed_compounds=None,
-        gsd_file_name=None,
         kick=True,
-        logger=None,
     ):
+
+        if isinstance(integrate_compounds, Compound):
+            integrate_compounds = [integrate_compounds]
+        elif integrate_compounds is not None:
+            integrate_compounds = list(integrate_compounds)
+        if isinstance(fixed_compounds, Compound):
+            fixed_compounds = [fixed_compounds]
+        elif fixed_compounds is not None:
+            fixed_compounds = list(fixed_compounds)
 
         if integrate_compounds and fixed_compounds:
             raise RuntimeError(
                 "You can specify only one of integrate_compounds and fixed_compounds."
             )
-        if isinstance(integrate_compounds, Compound):
-            integrate_compounds = [integrate_compounds]
-        if isinstance(fixed_compounds, Compound):
-            fixed_compounds = [fixed_compounds]
 
         # Resolve input type
         compound, self._is_path, self._original_system, self.original_coords = (
@@ -114,26 +114,22 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         self.r_cut = r_cut
         self.integrate_compounds = integrate_compounds
         self.fixed_compounds = fixed_compounds
-        self.automatic_box = automatic_box
         self.box_buffer = box_buffer
         self.box = box
         self.energies = []
-        self.logger = logger
 
-        if compound._hoomd_data:
-            last_snapshot, last_forces, last_forcefield = compound._get_sim_data()
-            if forcefield == last_forcefield:
-                snapshot = last_snapshot
-                self.forces = last_forces
-            else:
-                snapshot, self.forces = self._to_hoomd_snap_forces()
-                compound._add_sim_data(
-                    state=snapshot, forces=self.forces, forcefield=forcefield
-                )
+        self._get_integrate_group()
+
+        # State and forces are built together, so reuse them only when every
+        # build input still matches.
+        last_snapshot, last_forces, last_params = compound._get_sim_data()
+        if last_snapshot is not None and _same_build(self._build_params(), last_params):
+            snapshot = last_snapshot
+            self.forces = last_forces
         else:
             snapshot, self.forces = self._to_hoomd_snap_forces()
             compound._add_sim_data(
-                state=snapshot, forces=self.forces, forcefield=forcefield
+                state=snapshot, forces=self.forces, build_params=self._build_params()
             )
 
         # Undo the translation to -L/2 L/2 used by HOOMD
@@ -142,7 +138,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         ).mean(axis=0)
 
         self.active_forces = []
-        self.inactive_forces = []
         self._orig_force_params = {}
         super(HoomdSimulation, self).__init__(device=device, seed=seed)
         self.create_state_from_snapshot(snapshot)
@@ -175,6 +170,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         thermostat : hoomd thermostat class
             Thermostat used by the integration method.
         """
+        self.original_coords = np.copy(self.compound.xyz)
         if forces_handler is not None:
             forces_handler.scale_sim(self)
         else:
@@ -193,7 +189,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
 
         self.run(n_steps)
         self._store_current_energies()
-        self._log_properties()
         self.operations.integrator = None
         self._update_positions()
         self._update_snapshot()
@@ -232,6 +227,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         thermostat : hoomd thermostat class
             Thermostat used by the integration method.
         """
+        self.original_coords = np.copy(self.compound.xyz)
         if forces_handler is not None:
             forces_handler.scale_sim(self)
         else:
@@ -241,7 +237,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         if isinstance(kT, (list, tuple, np.ndarray)):
             thermal_kT = kT[0]
             kT = hoomd.variant.Ramp(
-                A=kT[0], B=kT[0], t_start=self.timestep, t_ramp=int(n_steps)
+                A=kT[0], B=kT[1], t_start=self.timestep, t_ramp=int(n_steps)
             )
         else:
             thermal_kT = kT
@@ -281,7 +277,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         L_after = np.asarray(self.state.box.L)
         self._frame_offset = self._frame_offset + (L_after - L_before) / 2
         self._store_current_energies()
-        self._log_properties()
         self.operations.integrator = None
         self._update_positions()
         self._update_snapshot()
@@ -315,6 +310,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         cap from engaging and reverts to plain NVE dynamics, which can build up
         velocity and run away on stiff potentials.
         """
+        self.original_coords = np.copy(self.compound.xyz)
         if forces_handler is not None:
             forces_handler.scale_sim(self)
         else:
@@ -332,7 +328,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
 
         self.run(n_steps)
         self._store_current_energies()
-        self._log_properties()
         self.operations.integrator = None
         self._update_positions()
         self._update_snapshot()
@@ -387,6 +382,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         energy_tol : float, default 1e-6
             Energy convergence tolerance.
         """
+        self.original_coords = np.copy(self.compound.xyz)
         if forces_handler is not None:
             forces_handler.scale_sim(self)
         else:
@@ -416,13 +412,23 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             self.operations.integrator.reset()
 
         self._store_current_energies()
-        self._log_properties()
         self.operations.integrator = None
-        self._update_snapshot()
         self._update_positions()
+        self._update_snapshot()
 
     def get_energy(self):
-        """Return energies by force type across all stored frames."""
+        """Return energies by force type across all stored frames.
+
+        Frames where a force was not active are NaN.
+
+        Notes:
+        ------
+        Energies are calcualted from the last snapshot of the simulation,
+        and use the forces and integrator from the last simulation call.
+        Therefore, the values from multiple simulation calls may not be
+        directly comparable when changing the underlying forces or
+        integration method (e.g., using ForcesHandler).
+        """
         if not self.energies:
             print(f"No energies currently stored in {self}")
             return None
@@ -431,14 +437,43 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         for frame, energyDict in enumerate(self.energies):
             for ffkey in energyDict:
                 if ffkey not in returnDict:
-                    returnDict[ffkey] = np.zeros(n_frames)
+                    returnDict[ffkey] = np.full(n_frames, np.nan)
                 returnDict[ffkey][frame] = energyDict[ffkey]
         return returnDict
 
     def recover(self):
-        """Reset the system coordinates as they were before the last simulation."""
-        # TODO: Also reset last snapshot, delete last store_energy call?
+        """Reset the system coordinates as they were before the last run.
+
+        Rewinds the HOOMD state and the cached snapshot as well, so a later run
+        or a new Simulation built from this compound starts from the restored
+        coordinates. Energies stored by that run are dropped.
+        """
         _recover(self._original_system, self.original_coords)
+        self.compound.xyz = self.original_coords
+        with self.state.cpu_local_snapshot as snap:
+            particles = snap.particles.rtag[:]
+            snap.particles.position[particles] = (
+                self.original_coords - self._frame_offset
+            )
+        self._update_snapshot()
+        if self.energies:
+            self.energies.pop()
+
+    def _build_params(self):
+        """Inputs the cached snapshot and forces are built from."""
+        if self.box is not None:
+            lengths = self.box.lengths if isinstance(self.box, Box) else self.box
+        elif self.compound.box:
+            lengths = self.compound.box.lengths
+        else:
+            lengths = None
+        return {
+            "forcefield": self.forcefield
+            if self.forcefield is not None
+            else _DEFAULT_FF,
+            "box": tuple(float(i) for i in lengths) if lengths is not None else None,
+            "r_cut": self.r_cut,
+        }
 
     def _to_hoomd_snap_forces(self):
         """Convert compound to HOOMD snapshot and forces."""
@@ -508,27 +543,30 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             }
         return orig
 
+    def _particle_tags(self, compounds, name):
+        """Resolve Compounds or particle indices into a list of HOOMD tags."""
+        if all(isinstance(i, Compound) for i in compounds):
+            indices = []
+            for comp in compounds:
+                indices.extend(self.compound.get_child_indices(comp))
+        elif all(isinstance(i, numbers.Integral) for i in compounds):
+            indices = compounds
+        else:
+            got = sorted({type(i).__name__ for i in compounds})
+            raise TypeError(
+                f"{name} must be all mb.Compound or all integers, got {got}."
+            )
+        return [int(i) for i in indices]
+
     def _get_integrate_group(self):
         """Return the HOOMD filter for the integration group."""
         if self.integrate_compounds and not self.fixed_compounds:
-            if all([isinstance(i, Compound) for i in self.integrate_compounds]):
-                integrate_indices = []
-                for comp in self.integrate_compounds:
-                    integrate_indices.extend(
-                        list(self.compound.get_child_indices(comp))
-                    )
-            elif all([isinstance(i, int) for i in self.integrate_compounds]):
-                integrate_indices = self.integrate_compounds
-            return hoomd.filter.Tags(integrate_indices)
+            tags = self._particle_tags(self.integrate_compounds, "integrate_compounds")
+            return hoomd.filter.Tags(tags)
         elif self.fixed_compounds and not self.integrate_compounds:
-            if all([isinstance(i, Compound) for i in self.fixed_compounds]):
-                fix_indices = []
-                for comp in self.fixed_compounds:
-                    fix_indices.extend(list(self.compound.get_child_indices(comp)))
-            elif all([isinstance(i, int) for i in self.fixed_compounds]):
-                fix_indices = self.fixed_compounds
+            tags = self._particle_tags(self.fixed_compounds, "fixed_compounds")
             return hoomd.filter.SetDifference(
-                hoomd.filter.All(), hoomd.filter.Tags(fix_indices)
+                hoomd.filter.All(), hoomd.filter.Tags(tags)
             )
         else:
             return hoomd.filter.All()
@@ -583,7 +621,12 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         self.operations.integrator = fire
 
     def set_integrator(self, dt, method):
-        """Used internally to set the integration method."""
+        """Set the integration method used.
+
+        This is used internally by HoomdSimulation, but
+        it is possible for users to call this directly
+        while passing an instance of ``hoomd.md.methods``
+        """
         integrator = hoomd.md.Integrator(dt=dt)
         integrator.forces = self.active_forces
         integrator.methods = [method]
@@ -594,9 +637,13 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         self.operations.integrator.forces = self.active_forces
 
     def _update_snapshot(self):
-        """Update the last snapshot stored in memory."""
+        """Update the last snapshot and the compound's box stored in memory."""
         snapshot = self.state.get_snapshot()
         self.compound._add_sim_data(state=snapshot)
+        Lx, Ly, Lz, xy, xz, yz = snapshot.configuration.box
+        self.compound.box = Box.from_lengths_tilt_factors(
+            lengths=(Lx, Ly, Lz), tilt_factors=(xy, xz, yz)
+        )
 
     def _update_positions(self):
         """Update compound positions from snapshot and sync back to Path if needed."""
@@ -616,22 +663,9 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             ffname = force.__class__.__module__ + "." + force.__class__.__name__
             new_energy[ffname] = force.energy
             current_total_energy += force.energy
-        new_energy["total"] = current_total_energy
+        new_energy["potential_energy"] = current_total_energy
         if new_energy:
             self.energies.append(new_energy)
-
-    def _log_properties(self):
-        """Record properties to the logger if one is attached."""
-        if self.logger is None:
-            return
-        for prop in self.logger.properties:
-            if prop == "potential_energy":
-                pe = sum(f.energy for f in self.active_forces)
-                self.logger.data["potential_energy"].append(pe)
-            elif prop == "kinetic_energy":
-                self.logger.data["kinetic_energy"].append(None)
-            elif prop == "temperature":
-                self.logger.data["temperature"].append(None)
 
 
 class OpenMMSimulation:
@@ -667,8 +701,6 @@ class OpenMMSimulation:
     kick : bool, default True
         Nudge coordinates before simulating. This can be critical to remove
         flat dihedrals.
-    logger : PropertyLogger or None
-        Optional property logger.
     """
 
     def __init__(
@@ -682,7 +714,6 @@ class OpenMMSimulation:
         r_cut=1.0,
         seed=1,
         kick=True,
-        logger=None,
     ):
         from openmm import Platform
         from openmm.app import AllBonds, HAngles, HBonds
@@ -695,7 +726,6 @@ class OpenMMSimulation:
         self.compound = compound
         self.forcefield_name = forcefield
         self.r_cut = r_cut
-        self.logger = logger
         self.energies = []
         self.box = box
 
@@ -769,13 +799,13 @@ class OpenMMSimulation:
         self._record_energies()
         self._update_compound_positions()
 
-    def nvt(self, n_steps, kT=300, dt=0.002, friction=1.0, report_interval=None):
+    def nvt(self, n_steps, T=300, dt=0.002, friction=1.0, report_interval=None):
         """Run an NVT (Langevin) simulation.
 
         Parameters
         ----------
         n_steps : int
-        kT : float
+        T : float
             Temperature in Kelvin.
         dt : float
             Timestep in picoseconds.
@@ -788,7 +818,7 @@ class OpenMMSimulation:
         from openmm.openmm import LangevinIntegrator
 
         integrator = LangevinIntegrator(
-            kT * u.kelvin, friction / u.picosecond, dt * u.picoseconds
+            T * u.kelvin, friction / u.picosecond, dt * u.picoseconds
         )
         self._create_simulation(integrator)
 
@@ -804,8 +834,17 @@ class OpenMMSimulation:
         self._update_compound_positions()
 
     def recover(self):
-        """Reset the system coordinates as they were before the last simulation."""
+        """Reset the coordinates to what they were when this Simulation was made.
+
+        Rewinds the positions the next run starts from, and clears stored
+        energies along with them.
+        """
+        import openmm.unit as u
+
         _recover(self._original_system, self.original_coords)
+        self.compound.xyz = self.original_coords
+        self.positions = self.original_coords * u.nanometer
+        self.energies = []
 
     def get_energy(self):
         """Return recorded energies as dict of arrays."""
@@ -951,19 +990,6 @@ class OpenMMSimulation:
         state = self.simulation.context.getState(getEnergy=True)
         pe = state.getPotentialEnergy().value_in_unit(u.kilojoules_per_mole)
         self.energies.append({"potential_energy": pe})
-        if self.logger and "potential_energy" in self.logger.properties:
-            self.logger.data["potential_energy"].append(pe)
-        if self.logger and "kinetic_energy" in self.logger.properties:
-            ke_state = self.simulation.context.getState(getEnergy=True)
-            ke = ke_state.getKineticEnergy().value_in_unit(u.kilojoules_per_mole)
-            self.logger.data["kinetic_energy"].append(ke)
-        if self.logger and "temperature" in self.logger.properties:
-            # Approximate from KE
-            self.logger.data["temperature"].append(None)
-        if self.logger and "volume" in self.logger.properties:
-            box_vecs = state.getPeriodicBoxVectors(asNumpy=True)
-            vol = np.dot(box_vecs[0], np.cross(box_vecs[1], box_vecs[2]))
-            self.logger.data["volume"].append(float(vol))
 
 
 class ForcesHandler:
@@ -1042,35 +1068,6 @@ class ForcesHandler:
             self.forcesDict[key] = force
 
 
-class PropertyLogger:
-    """Collects energies and other scalar properties during a simulation.
-
-    Parameters
-    ----------
-    log_every : int
-        Frequency (in steps) at which properties are recorded.
-    properties : list of str
-        Which properties to log. Options depend on the backend:
-        - HOOMD: "potential_energy", "kinetic_energy", "temperature", "pressure"
-        - OpenMM: "potential_energy", "kinetic_energy", "temperature", "volume"
-    """
-
-    def __init__(self, log_every=100, properties=None):
-        self.log_every = log_every
-        if properties is None:
-            properties = ["potential_energy"]
-        self.properties = properties
-        self.data = {p: [] for p in properties}
-
-    def reset(self):
-        """Clear all recorded property data."""
-        self.data = {p: [] for p in self.properties}
-
-    def as_dict(self):
-        """Return the recorded properties as a dict of arrays."""
-        return {k: np.array(v) for k, v in self.data.items()}
-
-
 def _resolve_input(system):
     """Convert a Path or Compound input into an mBuild Compound.
 
@@ -1096,6 +1093,17 @@ def _resolve_input(system):
         raise TypeError(
             f"Expected an mb.Compound or mbuild.path.Path, got {type(system)}."
         )
+
+
+def _same_build(new, cached):
+    """Compare two sets of build params, matching forcefields by identity."""
+    if cached is None:
+        return False
+    return (
+        new["forcefield"] is cached["forcefield"]
+        and new["box"] == cached["box"]
+        and new["r_cut"] == cached["r_cut"]
+    )
 
 
 def _wrap_into_box(snap):

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -73,7 +73,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         )
 
         if kick:
-            compound._kick()
+            compound._kick(seed=seed)
 
         if run_on_gpu is None:
             device = hoomd.device.auto_select()
@@ -274,6 +274,14 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             active at full strength.
         max_displacement : float (nm), default 1e-3
             Maximum distance a particle may move in a single timestep.
+
+        Notes
+        -----
+        A larger dt is often more stable here: it lets max_displacement
+        dominate the position update, so the step behaves like a steepest
+        descent minimizer capped at max_displacement. Too small a dt keeps the
+        cap from engaging and reverts to plain NVE dynamics, which can build up
+        velocity and run away on stiff potentials.
         """
         if forces_handler is not None:
             forces_handler.scale_sim(self)
@@ -405,10 +413,34 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         if not self.compound.box:
             self.compound.box = self.compound.get_boundingbox(pad_box=self.box_buffer)
 
+        from mbuild.utils.simulation.path_forces import (
+            PathForcefield,
+            generate_ff_from_path,
+        )
+
         top = self.compound.to_gmso()
         top.identify_connections()
 
-        if self.forcefield is not None:
+        if isinstance(self.forcefield, PathForcefield) or (
+            self._is_path and self.forcefield is None
+        ):
+            # No atomistic information available, use a KG-based CG forcefield.
+            pff = (
+                self.forcefield
+                if isinstance(self.forcefield, PathForcefield)
+                else PathForcefield()
+            )
+            snap, _ = gmso.external.to_gsd_snapshot(top=top)
+            forces = generate_ff_from_path(
+                self._original_system,
+                snap,
+                radius=pff.radius,
+                bond_length=pff.bond_length,
+                angles_sampler=pff.angles,
+                dihedrals_sampler=pff.dihedrals,
+                epsilon=pff.epsilon,
+            )
+        elif self.forcefield is not None:
             apply(
                 top,
                 forcefields=self.forcefield,
@@ -417,11 +449,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             forces, _ = gmso.external.to_hoomd_forcefield(top, r_cut=self.r_cut)
             snap, _ = gmso.external.to_gsd_snapshot(top=top)
             forces = list(set().union(*forces.values()))
-        else:
-            # No explicit forcefield: parameterize with UFF, computed on the fly
-            # from elements + bond orders. The topology must be UFF-typed before
-            # the snapshot is built so its particle/bond/angle type strings stay
-            # consistent with the generated forces.
+        else: # No GMSO/Foyer FF given, use the UFF-generated parameters
             from mbuild.utils.simulation.uff import assign_uff_types, uff_forces
 
             _, order_map = assign_uff_types(top, self.compound)
@@ -590,6 +618,8 @@ class OpenMMSimulation:
         Nonbonded cutoff distance (nm). Applied to any force that uses a
         cutoff, regardless of forcefield. Forces set to NoCutoff (for example
         non-periodic compounds) are unaffected.
+    seed : int, default 1
+        Seed for the coordinate kick, so kicks are reproducible.
     kick : bool, default True
         Nudge coordinates before simulating. This can be critical to remove
         flat dihedrals.
@@ -606,6 +636,7 @@ class OpenMMSimulation:
         platform="CPU",
         nthreads=1,
         r_cut=1.0,
+        seed=1,
         kick=True,
         logger=None,
     ):
@@ -624,7 +655,7 @@ class OpenMMSimulation:
         self.energies = []
 
         if kick:
-            compound._kick()
+            compound._kick(seed=seed)
 
         # Set up platform
         self._platform = Platform.getPlatformByName(platform)
@@ -646,6 +677,16 @@ class OpenMMSimulation:
         self._constraints = constraint_map[constraints]
 
         # Build system
+        from mbuild.utils.simulation.path_forces import PathForcefield
+
+        if isinstance(forcefield, PathForcefield):
+            # TODO: Add an OpenMM backend to build_path_ff (WCA via
+            # CustomNonbondedForce, FENE via CustomBondForce, tabulated angles/
+            # dihedrals) so paths relax through OpenMM as they do through HOOMD.
+            raise NotImplementedError(
+                "OpenMMSimulation does not yet support PathForcefield. Use "
+                "HoomdSimulation for coarse Kremer-Grest path relaxation."
+            )
         if forcefield is not None:
             self._build_from_forcefield(compound, forcefield)
         else:

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -157,7 +157,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         forces_handler=None,
         thermostat=hoomd.md.methods.thermostats.Berendsen,
     ):
-        """Run an NVT simulation.
+        """Run an NVT simulation on an mBuild Compound or Path.
 
         Parameters
         ----------
@@ -611,9 +611,12 @@ class HoomdSimulation(hoomd.simulation.Simulation):
     def _store_current_energies(self):
         """Store energy from active forces."""
         new_energy = {}
+        current_total_energy = 0
         for force in self.active_forces:
             ffname = force.__class__.__module__ + "." + force.__class__.__name__
             new_energy[ffname] = force.energy
+            current_total_energy += force.energy
+        new_energy["total"] = current_total_energy
         if new_energy:
             self.energies.append(new_energy)
 

--- a/mbuild/simulation.py
+++ b/mbuild/simulation.py
@@ -14,90 +14,6 @@ from mbuild.utils.io import import_
 logger = logging.getLogger(__name__)
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Default force field parameters (used when no forcefield is provided)
-# ─────────────────────────────────────────────────────────────────────────────
-
-DEFAULT_LJ_PARAMS = {"sigma": 0.34, "epsilon": 0.36}  # nm, kJ/mol
-DEFAULT_BOND_PARAMS = {"k": 300000.0, "r0": 0.15}  # kJ/mol/nm^2, nm
-DEFAULT_ANGLE_PARAMS = {"k": 400.0, "theta0": 1.9111}  # kJ/mol/rad^2, ~109.5 deg
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Input resolution helper
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-def _resolve_input(system):
-    """Convert a Path or Compound input into an mBuild Compound.
-
-    Parameters
-    ----------
-    system : mb.Compound or mbuild.path.build.Path
-        The input system.
-
-    Returns
-    -------
-    compound : mb.Compound
-    is_path : bool
-        Whether the original input was a Path.
-    original : the original input object
-    """
-    import mbuild.path.build
-
-    if isinstance(system, mbuild.path.build.Path):
-        return system.to_compound(), True, system
-    elif isinstance(system, Compound):
-        return system, False, system
-    else:
-        raise TypeError(
-            f"Expected an mb.Compound or mbuild.path.Path, got {type(system)}."
-        )
-
-
-def _sync_back(compound, is_path, original):
-    """If the original was a Path, copy positions back."""
-    if is_path:
-        original.coordinates = compound.xyz
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Property Logger
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class PropertyLogger:
-    """Collects energies and other scalar properties during a simulation.
-
-    Parameters
-    ----------
-    log_every : int
-        Frequency (in steps) at which properties are recorded.
-    properties : list of str
-        Which properties to log. Options depend on the backend:
-        - HOOMD: "potential_energy", "kinetic_energy", "temperature", "pressure"
-        - OpenMM: "potential_energy", "kinetic_energy", "temperature", "volume"
-    """
-
-    def __init__(self, log_every=100, properties=None):
-        self.log_every = log_every
-        if properties is None:
-            properties = ["potential_energy"]
-        self.properties = properties
-        self.data = {p: [] for p in properties}
-
-    def reset(self):
-        self.data = {p: [] for p in self.properties}
-
-    def as_dict(self):
-        return {k: np.array(v) for k, v in self.data.items()}
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# HOOMD Simulation
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 class HoomdSimulation(hoomd.simulation.Simulation):
     """A custom class for hoomd-based simulation methods.
 
@@ -113,13 +29,27 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         parameters are used.
     r_cut : float (nm)
         The cutoff distance used in the non-bonded pair neighborlist.
-    fixed_compounds : list of mb.Compound, default None
-    integrate_compounds : list of mb.Compound, default None
     run_on_gpu : bool or None, default None
+        If None, auto-select a device. If True use the GPU, if False the CPU.
     seed : int, default 1
+        Seed for the HOOMD random number generator.
     automatic_box : bool, default False
+        If True, size the simulation box from the compound automatically.
     box_buffer : float, default 10
+        Padding (nm) added around the compound when a bounding box is generated.
+    integrate_compounds : list of mb.Compound, default None
+        Compounds to integrate while all others are held fixed. Mutually
+        exclusive with fixed_compounds.
+    fixed_compounds : list of mb.Compound, default None
+        Compounds held fixed while all others are integrated. Mutually
+        exclusive with integrate_compounds.
+    gsd_file_name : str or None, default None
+        Name of a GSD file to write trajectory output to.
+    kick : bool, default True
+        Nudge coordinates before simulating. This can be critical to remove
+        flat dihedrals.
     logger : PropertyLogger or None
+        Logger used to record scalar properties during runs.
     """
 
     def __init__(
@@ -134,10 +64,14 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         integrate_compounds=None,
         fixed_compounds=None,
         gsd_file_name=None,
+        kick=True,
         logger=None,
     ):
         # Resolve input type
-        compound, self._is_path, self._original_system = _resolve_input(system)
+        compound, self._is_path, self._original_system, self.original_coords = _resolve_input(system)
+
+        if kick:
+            compound._kick()
 
         if run_on_gpu is None:
             device = hoomd.device.auto_select()
@@ -187,6 +121,284 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         self.create_state_from_snapshot(snapshot)
         self._orig_force_params = self._snapshot_force_params()
 
+    def nvt(
+        self,
+        n_steps,
+        kT,
+        dt,
+        tau,
+        forces_handler=None,
+        thermostat=hoomd.md.methods.thermostats.Berendsen,
+    ):
+        """Run an NVT simulation.
+
+        Parameters
+        ----------
+        n_steps : int
+            Number of timesteps to run.
+        kT : float
+            Thermal energy of the thermostat.
+        dt : float
+            Timestep size.
+        tau : float
+            Thermostat coupling time constant.
+        forces_handler : ForcesHandler or None, default None
+            Scales the active forces before the run. If None, all forces are
+            active at full strength.
+        thermostat : hoomd thermostat class
+            Thermostat used by the integration method.
+        """
+        if forces_handler is not None:
+            forces_handler.scale_sim(self)
+        else:
+            self.active_forces = list(self.forces)
+
+        nvt_method = hoomd.md.methods.ConstantVolume(
+            filter=self._get_integrate_group(),
+            thermostat=thermostat(kT=kT, tau=tau),
+        )
+        self.set_integrator(method=nvt_method, dt=dt)
+        self.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=kT)
+
+        if self.energies == []:
+            self.run(0)
+            self._store_current_energies()
+
+        self.run(n_steps)
+        self._store_current_energies()
+        self._log_properties()
+        self.operations.integrator = None
+        self._update_positions()
+        self._update_snapshot()
+
+    def box_update(
+        self,
+        n_steps,
+        kT,
+        dt,
+        tau,
+        target_box,
+        update_period,
+        forces_handler=None,
+        thermostat=hoomd.md.methods.thermostats.Berendsen,
+    ):
+        """Run an NVT simulation while updating the simulation volume,
+        and optionally annealing between an initial and final temperature.
+
+        Parameters
+        ----------
+        n_steps : int
+            Number of timesteps to run.
+        kT : float or list of float
+            Thermal energy. A list of two values ramps between them.
+        dt : float
+            Timestep size.
+        tau : float
+            Thermostat coupling time constant.
+        target_box : hoomd.Box
+            Box to interpolate the simulation volume toward.
+        update_period : int
+            Number of timesteps between box resize updates.
+        forces_handler : ForcesHandler or None, default None
+            Scales the active forces before the run. If None, all forces are
+            active at full strength.
+        thermostat : hoomd thermostat class
+            Thermostat used by the integration method.
+        """
+        if forces_handler is not None:
+            forces_handler.scale_sim(self)
+        else:
+            self.active_forces = list(self.forces)
+
+        # Set kT ramp if user passed in a [start, finish] array:
+        if isinstance(kT, (list, tuple, np.ndarray)):
+            thermal_kT = kT[0]
+            kT = hoomd.variant.Ramp(
+                A=kT[0], B=kT[0], t_start=self.timestep, t_ramp=int(n_steps)
+            )
+        else:
+            thermal_kT = kT
+
+        nvt_method = hoomd.md.methods.ConstantVolume(
+            filter=self._get_integrate_group(),
+            thermostat=thermostat(kT=kT, tau=tau),
+        )
+        self.set_integrator(method=nvt_method, dt=dt)
+        self.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=thermal_kT)
+
+        # Set box updater here
+        resize_trigger = hoomd.trigger.Periodic(update_period)
+        box_ramp = hoomd.variant.Ramp(
+            A=0, B=1, t_start=self.timestep, t_ramp=int(n_steps)
+        )
+        box_variant = hoomd.variant.box.Interpolate(
+            initial_box=self.state.box, final_box=target_box, variant=box_ramp
+        )
+        box_resizer = hoomd.update.BoxResize(
+            box=box_variant,
+            trigger=resize_trigger,
+        )
+        self.operations.updaters.append(box_resizer)
+
+
+        if self.energies == []:
+            self.run(0)
+            self._store_current_energies()
+
+        self.run(n_steps)
+        self.operations.updaters.remove(box_resizer)
+        self._store_current_energies()
+        self._log_properties()
+        self.operations.integrator = None
+        self._update_positions()
+        self._update_snapshot()
+
+    def cap_displacement(
+        self,
+        n_steps,
+        dt,
+        forces_handler=None,
+        max_displacement=1e-3,
+    ):
+        """Run a capped-displacement simulation.
+
+        Parameters
+        ----------
+        n_steps : int
+            Number of timesteps to run.
+        dt : float
+            Timestep size.
+        forces_handler : ForcesHandler or None, default None
+            Scales the active forces before the run. If None, all forces are
+            active at full strength.
+        max_displacement : float (nm), default 1e-3
+            Maximum distance a particle may move in a single timestep.
+        """
+        if forces_handler is not None:
+            forces_handler.scale_sim(self)
+        else:
+            self.active_forces = list(self.forces)
+
+        displacement_capped = hoomd.md.methods.DisplacementCapped(
+            filter=self._get_integrate_group(),
+            maximum_displacement=max_displacement,
+        )
+        self.set_integrator(method=displacement_capped, dt=dt)
+
+        if self.energies == []:
+            self.run(0)
+            self._store_current_energies()
+
+        self.run(n_steps)
+        self._store_current_energies()
+        self._log_properties()
+        self.operations.integrator = None
+        self._update_positions()
+        self._update_snapshot()
+
+    def fire(
+        self,
+        n_steps,
+        forces_handler=None,
+        n_iterations=1,
+        dt=1e-5,
+        min_steps_adapt=5,
+        min_steps_conv=100,
+        finc_dt=1.1,
+        fdec_dt=0.5,
+        alpha_start=0.1,
+        fdec_alpha=0.95,
+        force_tol=1e-2,
+        angmom_tol=1e-2,
+        energy_tol=1e-6,
+    ):
+        """Run FIRE energy minimization.
+
+        Parameters
+        ----------
+        n_steps : int
+            Number of timesteps per minimization iteration.
+        forces_handler : ForcesHandler or None, default None
+            Scales the active forces before the run. If None, all forces are
+            active at full strength.
+        n_iterations : int, default 1
+            Number of minimization iterations, resetting the integrator between
+            each.
+        dt : float, default 1e-5
+            Timestep size.
+        min_steps_adapt : int, default 5
+            Number of steps energy must decrease before adapting the timestep.
+        min_steps_conv : int, default 100
+            Number of consecutive steps meeting the tolerances before the run is
+            considered converged.
+        finc_dt : float, default 1.1
+            Factor by which the timestep is increased.
+        fdec_dt : float, default 0.5
+            Factor by which the timestep is decreased.
+        alpha_start : float, default 0.1
+            Initial value of the velocity mixing parameter.
+        fdec_alpha : float, default 0.95
+            Factor by which the mixing parameter is decreased.
+        force_tol : float, default 1e-2
+            Force convergence tolerance.
+        angmom_tol : float, default 1e-2
+            Angular momentum convergence tolerance.
+        energy_tol : float, default 1e-6
+            Energy convergence tolerance.
+        """
+        if forces_handler is not None:
+            forces_handler.scale_sim(self)
+        else:
+            self.active_forces = list(self.forces)
+
+        nvt_method = hoomd.md.methods.ConstantVolume(filter=self._get_integrate_group())
+        self._set_fire_integrator(
+            dt=dt,
+            force_tol=force_tol,
+            angmom_tol=angmom_tol,
+            energy_tol=energy_tol,
+            finc_dt=finc_dt,
+            fdec_dt=fdec_dt,
+            alpha_start=alpha_start,
+            fdec_alpha=fdec_alpha,
+            min_steps_adapt=min_steps_adapt,
+            min_steps_conv=min_steps_conv,
+            methods=[nvt_method],
+        )
+
+        if self.energies == []:
+            self.run(0)
+            self._store_current_energies()
+
+        for _ in range(n_iterations):
+            self.run(n_steps)
+            self.operations.integrator.reset()
+
+        self._store_current_energies()
+        self._log_properties()
+        self.operations.integrator = None
+        self._update_snapshot()
+        self._update_positions()
+
+    def get_energy(self):
+        """Return energies by force type across all stored frames."""
+        if not self.energies:
+            print(f"No energies currently stored in {self}")
+            return None
+        returnDict = {}
+        n_frames = len(self.energies)
+        for frame, energyDict in enumerate(self.energies):
+            for ffkey in energyDict:
+                if ffkey not in returnDict:
+                    returnDict[ffkey] = np.zeros(n_frames)
+                returnDict[ffkey][frame] = energyDict[ffkey]
+        return returnDict
+
+    def recover(self):
+        """Reset the system coordinates as they were before the last simulation."""
+        #TODO: Also reset last snapshot, delete last store_energy call?
+        _recover(self._original_system, self.original_coords)
+
     def _to_hoomd_snap_forces(self):
         """Convert compound to HOOMD snapshot and forces."""
         if not self.compound.box:
@@ -205,66 +417,17 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             snap, _ = gmso.external.to_gsd_snapshot(top=top)
             forces = list(set().union(*forces.values()))
         else:
+            # No explicit forcefield: parameterize with UFF, computed on the fly
+            # from elements + bond orders. The topology must be UFF-typed before
+            # the snapshot is built so its particle/bond/angle type strings stay
+            # consistent with the generated forces.
+            from mbuild.utils.simulation.uff import assign_uff_types, uff_forces
+
+            _, order_map = assign_uff_types(top, self.compound)
             snap, _ = gmso.external.to_gsd_snapshot(top=top)
-            forces = self._build_default_forces(top, snap)
+            forces = uff_forces(top, snap, order_map, r_cut=self.r_cut)
 
         return snap, forces
-
-    def _build_default_forces(self, top, snap):
-        """Build default HOOMD forces (LJ, bonds, angles) from topology."""
-        particle_types = list(set(snap.particles.types))
-
-        nlist = hoomd.md.nlist.Cell(buffer=0.4)
-        lj = hoomd.md.pair.LJ(nlist=nlist, default_r_cut=self.r_cut)
-        for i, t1 in enumerate(particle_types):
-            for t2 in particle_types[i:]:
-                lj.params[(t1, t2)] = dict(
-                    sigma=DEFAULT_LJ_PARAMS["sigma"],
-                    epsilon=DEFAULT_LJ_PARAMS["epsilon"],
-                )
-        forces = [lj]
-
-        if top.n_bonds > 0:
-            bond_types = list(
-                set(
-                    tuple(
-                        sorted(
-                            [b.connection_members[0].name, b.connection_members[1].name]
-                        )
-                    )
-                    for b in top.bonds
-                )
-            )
-            bond_force = hoomd.md.bond.Harmonic()
-            for bt in bond_types:
-                type_str = f"{bt[0]}-{bt[1]}"
-                bond_force.params[type_str] = dict(
-                    k=DEFAULT_BOND_PARAMS["k"], r0=DEFAULT_BOND_PARAMS["r0"]
-                )
-            forces.append(bond_force)
-
-        if top.n_angles > 0:
-            angle_types = list(
-                set(
-                    tuple(
-                        [
-                            a.connection_members[0].name,
-                            a.connection_members[1].name,
-                            a.connection_members[2].name,
-                        ]
-                    )
-                    for a in top.angles
-                )
-            )
-            angle_force = hoomd.md.angle.Harmonic()
-            for at in angle_types:
-                type_str = f"{at[0]}-{at[1]}-{at[2]}"
-                angle_force.params[type_str] = dict(
-                    k=DEFAULT_ANGLE_PARAMS["k"], t0=DEFAULT_ANGLE_PARAMS["theta0"]
-                )
-            forces.append(angle_force)
-
-        return forces
 
     def _snapshot_force_params(self):
         """Snapshot current force params for later restoration."""
@@ -277,7 +440,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             }
         return orig
 
-    def get_integrate_group(self):
+    def _get_integrate_group(self):
         """Return the HOOMD filter for the integration group."""
         if self.integrate_compounds and not self.fixed_compounds:
             if all([isinstance(i, Compound) for i in self.integrate_compounds]):
@@ -306,7 +469,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         else:
             return hoomd.filter.All()
 
-    def get_force(self, instance, active_only=False):
+    def _get_force(self, instance, active_only=False):
         if active_only:
             iterForcesSet = set(self.active_forces)
         else:
@@ -316,16 +479,16 @@ class HoomdSimulation(hoomd.simulation.Simulation):
                 return force
         raise ValueError(f"No force of {instance} was found.")
 
-    def get_dpd_from_lj(self, A):
+    def _get_dpd_from_lj(self, A):
         """Make a best-guess DPD force from types and parameters of an LJ force."""
-        lj_force = self.get_force(hoomd.md.pair.LJ)
+        lj_force = self._get_force(hoomd.md.pair.LJ)
         dpd = hoomd.md.pair.DPDConservative(nlist=lj_force.nlist)
         for param in lj_force.params:
             dpd.params[param] = dict(A=A)
             dpd.r_cut[param] = lj_force.params[param]["sigma"]
         return dpd
 
-    def set_fire_integrator(
+    def _set_fire_integrator(
         self,
         dt,
         force_tol,
@@ -356,19 +519,22 @@ class HoomdSimulation(hoomd.simulation.Simulation):
         self.operations.integrator = fire
 
     def set_integrator(self, dt, method):
+        """Used internally to set the integration method."""
         integrator = hoomd.md.Integrator(dt=dt)
         integrator.forces = self.active_forces
         integrator.methods = [method]
         self.operations.integrator = integrator
 
     def _update_integrator_forces(self):
+        """Sets which forces are passed to the integrator."""
         self.operations.integrator.forces = self.active_forces
 
     def _update_snapshot(self):
+        """Update the last snapshot stored in memory."""
         snapshot = self.state.get_snapshot()
         self.compound._add_sim_data(state=snapshot)
 
-    def update_positions(self):
+    def _update_positions(self):
         """Update compound positions from snapshot and sync back to Path if needed."""
         with self.state.cpu_local_snapshot as snap:
             particles = snap.particles.rtag[:]
@@ -376,7 +542,7 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             self.compound.xyz = np.copy(pos)
         _sync_back(self.compound, self._is_path, self._original_system)
 
-    def store_current_energies(self):
+    def _store_current_energies(self):
         """Store energy from active forces."""
         new_energy = {}
         for force in self.active_forces:
@@ -384,20 +550,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
             new_energy[ffname] = force.energy
         if new_energy:
             self.energies.append(new_energy)
-
-    def get_energy(self):
-        """Return energies by force type across all stored frames."""
-        if not self.energies:
-            print(f"No energies currently stored in {self}")
-            return None
-        returnDict = {}
-        n_frames = len(self.energies)
-        for frame, energyDict in enumerate(self.energies):
-            for ffkey in energyDict:
-                if ffkey not in returnDict:
-                    returnDict[ffkey] = np.zeros(n_frames)
-                returnDict[ffkey][frame] = energyDict[ffkey]
-        return returnDict
 
     def _log_properties(self):
         """Record properties to the logger if one is attached."""
@@ -411,196 +563,6 @@ class HoomdSimulation(hoomd.simulation.Simulation):
                 self.logger.data["kinetic_energy"].append(None)
             elif prop == "temperature":
                 self.logger.data["temperature"].append(None)
-
-    # ─────────────────────────────────────────────────────────────────────
-    # Simulation methods
-    # ─────────────────────────────────────────────────────────────────────
-
-    def nvt(
-        self,
-        forces_handler,
-        n_steps,
-        kT,
-        dt,
-        tau,
-        thermostat=hoomd.md.methods.thermostats.Berendsen,
-    ):
-        """Run an NVT simulation.
-
-        Parameters
-        ----------
-        forces_handler : ForcesHandler or None
-        n_steps : int
-        kT : float
-        dt : float
-        tau : float
-        thermostat : hoomd thermostat class
-        """
-        if forces_handler is not None:
-            forces_handler.scale_sim(self)
-        else:
-            self.active_forces = list(self.forces)
-
-        nvt_method = hoomd.md.methods.ConstantVolume(
-            filter=self.get_integrate_group(),
-            thermostat=thermostat(kT=kT, tau=tau),
-        )
-        self.set_integrator(method=nvt_method, dt=dt)
-        self.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=kT)
-
-        if self.energies == []:
-            self.run(0)
-            self.store_current_energies()
-
-        self.run(n_steps)
-        self.store_current_energies()
-        self._log_properties()
-        self.operations.integrator = None
-        self.update_positions()
-        self._update_snapshot()
-
-    def npt(
-        self,
-        forces_handler,
-        n_steps,
-        kT,
-        dt,
-        tau,
-        pressure,
-        tauS,
-        couple="xyz",
-        thermostat=hoomd.md.methods.thermostats.Berendsen,
-    ):
-        """Run an NPT simulation."""
-        if forces_handler is not None:
-            forces_handler.scale_sim(self)
-        else:
-            self.active_forces = list(self.forces)
-
-        npt_method = hoomd.md.methods.ConstantPressure(
-            filter=self.get_integrate_group(),
-            thermostat=thermostat(kT=kT, tau=tau),
-            S=pressure,
-            tauS=tauS,
-            couple=couple,
-        )
-        self.set_integrator(method=npt_method, dt=dt)
-        self.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=kT)
-
-        if self.energies == []:
-            self.run(0)
-            self.store_current_energies()
-
-        self.run(n_steps)
-        self.store_current_energies()
-        self._log_properties()
-        self.operations.integrator = None
-        self.update_positions()
-        self._update_snapshot()
-
-    def cap_displacement(
-        self,
-        forces_handler,
-        n_steps,
-        dt,
-        max_displacement=1e-3,
-    ):
-        """Run a capped-displacement simulation.
-
-        Parameters
-        ----------
-        forces_handler : ForcesHandler or None
-        n_steps : int
-        dt : float
-        max_displacement : float (nm)
-        """
-        self.compound._kick()
-        if forces_handler is not None:
-            forces_handler.scale_sim(self)
-        else:
-            self.active_forces = list(self.forces)
-
-        displacement_capped = hoomd.md.methods.DisplacementCapped(
-            filter=self.get_integrate_group(),
-            maximum_displacement=max_displacement,
-        )
-        self.set_integrator(method=displacement_capped, dt=dt)
-
-        if self.energies == []:
-            self.run(0)
-            self.store_current_energies()
-
-        self.run(n_steps)
-        self.store_current_energies()
-        self._log_properties()
-        self.operations.integrator = None
-        self.update_positions()
-        self._update_snapshot()
-
-    def fire(
-        self,
-        forces_handler,
-        n_steps,
-        n_iterations=1,
-        dt=1e-5,
-        min_steps_adapt=5,
-        min_steps_conv=100,
-        finc_dt=1.1,
-        fdec_dt=0.5,
-        alpha_start=0.1,
-        fdec_alpha=0.95,
-        force_tol=1e-2,
-        angmom_tol=1e-2,
-        energy_tol=1e-6,
-    ):
-        """Run FIRE energy minimization.
-
-        Parameters
-        ----------
-        forces_handler : ForcesHandler or None
-        n_steps : int
-        n_iterations : int
-        dt : float
-        """
-        self.compound._kick()
-        if forces_handler is not None:
-            forces_handler.scale_sim(self)
-        else:
-            self.active_forces = list(self.forces)
-
-        nvt_method = hoomd.md.methods.ConstantVolume(filter=self.get_integrate_group())
-        self.set_fire_integrator(
-            dt=dt,
-            force_tol=force_tol,
-            angmom_tol=angmom_tol,
-            energy_tol=energy_tol,
-            finc_dt=finc_dt,
-            fdec_dt=fdec_dt,
-            alpha_start=alpha_start,
-            fdec_alpha=fdec_alpha,
-            min_steps_adapt=min_steps_adapt,
-            min_steps_conv=min_steps_conv,
-            methods=[nvt_method],
-        )
-
-        if self.energies == []:
-            self.run(0)
-            self.store_current_energies()
-
-        for _ in range(n_iterations):
-            self.run(n_steps)
-            self.operations.integrator.reset()
-
-        self.store_current_energies()
-        self._log_properties()
-        self.operations.integrator = None
-        self._update_snapshot()
-        self.update_positions()
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# OpenMM Simulation
-# ─────────────────────────────────────────────────────────────────────────────
 
 
 class OpenMMSimulation:
@@ -623,6 +585,13 @@ class OpenMMSimulation:
         OpenMM platform: "CPU", "CUDA", "OpenCL", "Reference".
     nthreads : int
         Number of CPU threads (only relevant for CPU platform).
+    r_cut : float, default 1.0
+        Nonbonded cutoff distance (nm). Applied to any force that uses a
+        cutoff, regardless of forcefield. Forces set to NoCutoff (for example
+        non-periodic compounds) are unaffected.
+    kick : bool, default True
+        Nudge coordinates before simulating. This can be critical to remove
+        flat dihedrals.
     logger : PropertyLogger or None
         Optional property logger.
     """
@@ -635,18 +604,24 @@ class OpenMMSimulation:
         constraints=None,
         platform="CPU",
         nthreads=1,
+        r_cut=1.0,
+        kick=True,
         logger=None,
     ):
         from openmm import Platform
         from openmm.app import AllBonds, HAngles, HBonds
 
         # Resolve input type
-        compound, self._is_path, self._original_system = _resolve_input(system)
+        compound, self._is_path, self._original_system, self.original_coords = _resolve_input(system)
 
         self.compound = compound
         self.forcefield_name = forcefield
+        self.r_cut = r_cut
         self.logger = logger
         self.energies = []
+
+        if kick:
+            compound._kick()
 
         # Set up platform
         self._platform = Platform.getPlatformByName(platform)
@@ -671,7 +646,79 @@ class OpenMMSimulation:
         if forcefield is not None:
             self._build_from_forcefield(compound, forcefield)
         else:
-            self._build_default_system(compound)
+            self._build_uff_system(compound, r_cut=self.r_cut)
+
+        # Apply the requested nonbonded cutoff to whichever forces use one,
+        # independent of how the system was parameterized.
+        self._apply_cutoff()
+
+    def minimize(self, n_steps=1000, tolerance=10.0):
+        """Energy minimize the system.
+
+        Parameters
+        ----------
+        n_steps : int
+        tolerance : float
+            Tolerance in kJ/mol/nm.
+        """
+        import openmm.unit as u
+        from openmm.openmm import LangevinIntegrator
+
+        integrator = LangevinIntegrator(
+            298 * u.kelvin, 1.0 / u.picosecond, 0.002 * u.picoseconds
+        )
+        self._create_simulation(integrator)
+        self.simulation.minimizeEnergy(
+            maxIterations=n_steps,
+            tolerance=tolerance * u.kilojoules_per_mole / u.nanometer,
+        )
+        self._record_energies()
+        self._update_compound_positions()
+
+    def nvt(self, n_steps, kT=300, dt=0.002, friction=1.0, report_interval=None):
+        """Run an NVT (Langevin) simulation.
+
+        Parameters
+        ----------
+        n_steps : int
+        kT : float
+            Temperature in Kelvin.
+        dt : float
+            Timestep in picoseconds.
+        friction : float
+            Friction coefficient in 1/ps.
+        report_interval : int or None
+            If given, record energies every this many steps.
+        """
+        import openmm.unit as u
+        from openmm.openmm import LangevinIntegrator
+
+        integrator = LangevinIntegrator(
+            kT * u.kelvin, friction / u.picosecond, dt * u.picoseconds
+        )
+        self._create_simulation(integrator)
+
+        if report_interval:
+            for i in range(0, n_steps, report_interval):
+                chunk = min(report_interval, n_steps - i)
+                self.simulation.step(chunk)
+                self._record_energies()
+        else:
+            self.simulation.step(n_steps)
+            self._record_energies()
+
+        self._update_compound_positions()
+
+    def recover(self):
+        """Reset the system coordinates as they were before the last simulation."""
+        _recover(self._original_system, self.original_coords)
+
+    def get_energy(self):
+        """Return recorded energies as dict of arrays."""
+        if not self.energies:
+            return None
+        keys = self.energies[0].keys()
+        return {k: np.array([e.get(k) for e in self.energies]) for k in keys}
 
     def _build_from_forcefield(self, compound, forcefield):
         """Build OpenMM system using foyer."""
@@ -702,97 +749,85 @@ class OpenMMSimulation:
         self.topology = self._parmed.topology
         self.positions = self._parmed.positions
 
-    def _build_default_system(self, compound):
-        """Build OpenMM system with default LJ + bond + angle parameters."""
+    def _build_uff_system(self, compound, r_cut=1.0):
+        """Build an OpenMM system parameterized with UFF.
+
+        Used when no explicit forcefield is given. Parameters are computed from
+        elements and bond orders and emitted as openmm.Force objects.
+
+        Parameters
+        ----------
+        compound : mb.Compound
+        r_cut : float, default 1.0
+            Nonbonded cutoff (nm), used only for periodic compounds.
+        """
         import openmm
         import openmm.unit as u
-        from openmm.app import Topology
+        from openmm.app import Element, Topology
 
-        positions = compound.xyz  # nm
-        n_particles = compound.n_particles
+        from mbuild.utils.simulation.uff import assign_uff_types, uff_forces
 
+        top = compound.to_gmso()
+        top.identify_connections()
+        # to_gmso always fills top.box with a bounding box; only treat the
+        # system as periodic when the compound itself defines a box.
+        if not compound.box:
+            top.box = None
+        _, order_map = assign_uff_types(top, compound)
+
+        particles_list = list(compound.particles())
         self.system = openmm.System()
-        for i in range(n_particles):
-            self.system.addParticle(12.0 * u.amu)
+        for p in particles_list:
+            self.system.addParticle(float(p.element.mass) * u.amu)
 
-        # Set periodic box vectors if compound has a box
         if compound.box:
-            Lx, Ly, Lz = compound.box.lengths  # nm
+            Lx, Ly, Lz = compound.box.lengths
             self.system.setDefaultPeriodicBoxVectors(
                 openmm.Vec3(Lx, 0, 0) * u.nanometer,
                 openmm.Vec3(0, Ly, 0) * u.nanometer,
                 openmm.Vec3(0, 0, Lz) * u.nanometer,
             )
 
-        # Default LJ nonbonded
-        nonbonded = openmm.NonbondedForce()
-        if compound.box:
-            nonbonded.setNonbondedMethod(openmm.NonbondedForce.CutoffPeriodic)
-            nonbonded.setCutoffDistance(1.0 * u.nanometer)
-        else:
-            nonbonded.setNonbondedMethod(openmm.NonbondedForce.NoCutoff)
+        for force in uff_forces(top, None, order_map, r_cut=r_cut, backend="openmm"):
+            self.system.addForce(force)
 
-        sigma = DEFAULT_LJ_PARAMS["sigma"] * u.nanometer
-        epsilon = DEFAULT_LJ_PARAMS["epsilon"] * u.kilojoules_per_mole
-        for i in range(n_particles):
-            nonbonded.addParticle(0.0, sigma, epsilon)
-        self.system.addForce(nonbonded)
-
-        # Get topology info via GMSO
-        top = compound.to_gmso()
-        top.identify_connections()
+        # Build an OpenMM topology with real elements and bonds.
         sites_list = list(top.sites)
-
-        # Default harmonic bonds
-        if top.n_bonds > 0:
-            bond_force = openmm.HarmonicBondForce()
-            for bond in top.bonds:
-                members = bond.connection_members
-                i_idx = sites_list.index(members[0])
-                j_idx = sites_list.index(members[1])
-                bond_force.addBond(
-                    i_idx,
-                    j_idx,
-                    DEFAULT_BOND_PARAMS["r0"] * u.nanometer,
-                    DEFAULT_BOND_PARAMS["k"] * u.kilojoules_per_mole / u.nanometer**2,
-                )
-                nonbonded.addException(i_idx, j_idx, 0.0, 1.0, 0.0)
-            self.system.addForce(bond_force)
-
-        # Default harmonic angles
-        if top.n_angles > 0:
-            angle_force = openmm.HarmonicAngleForce()
-            for angle in top.angles:
-                members = angle.connection_members
-                i_idx = sites_list.index(members[0])
-                j_idx = sites_list.index(members[1])
-                k_idx = sites_list.index(members[2])
-                angle_force.addAngle(
-                    i_idx,
-                    j_idx,
-                    k_idx,
-                    DEFAULT_ANGLE_PARAMS["theta0"] * u.radian,
-                    DEFAULT_ANGLE_PARAMS["k"] * u.kilojoules_per_mole / u.radian**2,
-                )
-            self.system.addForce(angle_force)
-
-        # Build OpenMM topology
-        particles_list = list(compound.particles())
+        site_idx = {s: i for i, s in enumerate(sites_list)}
         topology = Topology()
         chain = topology.addChain()
-        for i, p in enumerate(particles_list):
-            residue = topology.addResidue(f"R{i}", chain)
-            topology.addAtom(p.name, openmm.app.Element.getByMass(12), residue)
+        for p in particles_list:
+            residue = topology.addResidue(p.name, chain)
+            topology.addAtom(
+                p.name, Element.getBySymbol(p.element.symbol), residue
+            )
         atoms_list = list(topology.atoms())
-        if top.n_bonds > 0:
-            for bond in top.bonds:
-                members = bond.connection_members
-                i_idx = sites_list.index(members[0])
-                j_idx = sites_list.index(members[1])
-                topology.addBond(atoms_list[i_idx], atoms_list[j_idx])
+        for bond in top.bonds:
+            m0, m1 = bond.connection_members
+            topology.addBond(atoms_list[site_idx[m0]], atoms_list[site_idx[m1]])
 
         self.topology = topology
-        self.positions = positions * u.nanometer
+        self.positions = compound.xyz * u.nanometer
+
+    def _apply_cutoff(self):
+        """Set the nonbonded cutoff distance on every force that uses one.
+
+        In OpenMM the cutoff lives on each nonbonded force object, not on the
+        simulation. This sets self.r_cut on any NonbondedForce or
+        CustomNonbondedForce whose method uses a cutoff, leaving NoCutoff forces
+        untouched.
+        """
+        import openmm
+
+        for i in range(self.system.getNumForces()):
+            force = self.system.getForce(i)
+            if isinstance(force, openmm.NonbondedForce):
+                if force.getNonbondedMethod() != openmm.NonbondedForce.NoCutoff:
+                    force.setCutoffDistance(self.r_cut)
+            elif isinstance(force, openmm.CustomNonbondedForce):
+                no_cutoff = openmm.CustomNonbondedForce.NoCutoff
+                if force.getNonbondedMethod() != no_cutoff:
+                    force.setCutoffDistance(self.r_cut)
 
     def _create_simulation(self, integrator):
         """Create an OpenMM Simulation object."""
@@ -837,126 +872,6 @@ class OpenMMSimulation:
             box_vecs = state.getPeriodicBoxVectors(asNumpy=True)
             vol = np.dot(box_vecs[0], np.cross(box_vecs[1], box_vecs[2]))
             self.logger.data["volume"].append(float(vol))
-
-    def get_energy(self):
-        """Return recorded energies as dict of arrays."""
-        if not self.energies:
-            return None
-        keys = self.energies[0].keys()
-        return {k: np.array([e.get(k) for e in self.energies]) for k in keys}
-
-    # ─────────────────────────────────────────────────────────────────────
-    # Simulation methods
-    # ─────────────────────────────────────────────────────────────────────
-
-    def minimize(self, steps=1000, tolerance=10.0):
-        """Energy minimize the system.
-
-        Parameters
-        ----------
-        steps : int
-        tolerance : float
-            Tolerance in kJ/mol/nm.
-        """
-        import openmm.unit as u
-        from openmm.openmm import LangevinIntegrator
-
-        integrator = LangevinIntegrator(
-            298 * u.kelvin, 1.0 / u.picosecond, 0.002 * u.picoseconds
-        )
-        self._create_simulation(integrator)
-        self.simulation.minimizeEnergy(
-            maxIterations=steps,
-            tolerance=tolerance * u.kilojoules_per_mole / u.nanometer,
-        )
-        self._record_energies()
-        self._update_compound_positions()
-
-    def nvt(self, n_steps, kT=300, dt=0.002, friction=1.0, report_interval=None):
-        """Run an NVT (Langevin) simulation.
-
-        Parameters
-        ----------
-        n_steps : int
-        kT : float
-            Temperature in Kelvin.
-        dt : float
-            Timestep in picoseconds.
-        friction : float
-            Friction coefficient in 1/ps.
-        report_interval : int or None
-            If given, record energies every this many steps.
-        """
-        import openmm.unit as u
-        from openmm.openmm import LangevinIntegrator
-
-        integrator = LangevinIntegrator(
-            kT * u.kelvin, friction / u.picosecond, dt * u.picoseconds
-        )
-        self._create_simulation(integrator)
-
-        if report_interval:
-            for i in range(0, n_steps, report_interval):
-                chunk = min(report_interval, n_steps - i)
-                self.simulation.step(chunk)
-                self._record_energies()
-        else:
-            self.simulation.step(n_steps)
-            self._record_energies()
-
-        self._update_compound_positions()
-
-    def npt(
-        self,
-        n_steps,
-        kT=300,
-        dt=0.002,
-        friction=1.0,
-        pressure=1.0,
-        barostat_interval=25,
-        report_interval=None,
-    ):
-        """Run an NPT simulation using Monte Carlo barostat.
-
-        Parameters
-        ----------
-        n_steps : int
-        kT : float (Kelvin)
-        dt : float (ps)
-        friction : float (1/ps)
-        pressure : float (atm)
-        barostat_interval : int
-        report_interval : int or None
-        """
-        import openmm
-        import openmm.unit as u
-        from openmm.openmm import LangevinIntegrator
-
-        barostat = openmm.MonteCarloBarostat(
-            pressure * u.atmospheres, kT * u.kelvin, barostat_interval
-        )
-        self.system.addForce(barostat)
-
-        integrator = LangevinIntegrator(
-            kT * u.kelvin, friction / u.picosecond, dt * u.picoseconds
-        )
-        self._create_simulation(integrator)
-
-        if report_interval:
-            for i in range(0, n_steps, report_interval):
-                chunk = min(report_interval, n_steps - i)
-                self.simulation.step(chunk)
-                self._record_energies()
-        else:
-            self.simulation.step(n_steps)
-            self._record_energies()
-
-        self._update_compound_positions()
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# ForcesHandler
-# ─────────────────────────────────────────────────────────────────────────────
 
 
 class ForcesHandler:
@@ -1014,14 +929,14 @@ class ForcesHandler:
             if not scalar:
                 continue
             if key == "lj" and self.dpd:
-                dpd = sim.get_dpd_from_lj(A=self.dpd)
+                dpd = sim._get_dpd_from_lj(A=self.dpd)
                 sim.active_forces.append(dpd)
-                self.forcesDict["lj"] = sim.get_force(forcesDict["lj"][0])
+                self.forcesDict["lj"] = sim._get_force(forcesDict["lj"][0])
                 self.forcesDict["dpd"] = dpd
                 continue
 
             try:
-                force = sim.get_force(forcesDict[key][0])
+                force = sim._get_force(forcesDict[key][0])
             except ValueError:
                 continue
             orig_params = sim._orig_force_params.get(id(force), {})
@@ -1033,3 +948,75 @@ class ForcesHandler:
                         force.params[param][term] *= scalar
             sim.active_forces.append(force)
             self.forcesDict[key] = force
+
+
+class PropertyLogger:
+    """Collects energies and other scalar properties during a simulation.
+
+    Parameters
+    ----------
+    log_every : int
+        Frequency (in steps) at which properties are recorded.
+    properties : list of str
+        Which properties to log. Options depend on the backend:
+        - HOOMD: "potential_energy", "kinetic_energy", "temperature", "pressure"
+        - OpenMM: "potential_energy", "kinetic_energy", "temperature", "volume"
+    """
+
+    def __init__(self, log_every=100, properties=None):
+        self.log_every = log_every
+        if properties is None:
+            properties = ["potential_energy"]
+        self.properties = properties
+        self.data = {p: [] for p in properties}
+
+    def reset(self):
+        """Clear all recorded property data."""
+        self.data = {p: [] for p in self.properties}
+
+    def as_dict(self):
+        """Return the recorded properties as a dict of arrays."""
+        return {k: np.array(v) for k, v in self.data.items()}
+
+
+def _resolve_input(system):
+    """Convert a Path or Compound input into an mBuild Compound.
+
+    Parameters
+    ----------
+    system : mb.Compound or mbuild.path.build.Path
+        The input system.
+
+    Returns
+    -------
+    compound : mb.Compound
+    is_path : bool
+        Whether the original input was a Path.
+    original : the original input object
+    """
+    import mbuild.path.build
+
+    if isinstance(system, mbuild.path.build.Path):
+        return system.to_compound(), True, system, np.copy(system.coordinates)
+    elif isinstance(system, Compound):
+        return system, False, system, np.copy(system.xyz)
+    else:
+        raise TypeError(
+            f"Expected an mb.Compound or mbuild.path.Path, got {type(system)}."
+        )
+
+
+def _sync_back(compound, is_path, original):
+    """If the original was a Path, copy positions back."""
+    if is_path:
+        original.coordinates = compound.xyz
+
+
+def _recover(system, original_coordinates):
+    """Restore a Compound or Path's original coordinates"""
+    import mbuild.path.build
+
+    if isinstance(system, Compound):
+        system.xyz = original_coordinates
+    elif isinstance(system, mbuild.path.build.Path):
+        system.coordinates = original_coordinates

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -455,17 +455,9 @@ class TestHoomdSimulation(BaseTest):
         methane_after = np.array([p.pos for p in methane_particles])
         ethanol_after = ethanol_compound.xyz
 
-        # HOOMD centers its box at the origin, so sync-back applies a rigid frame
-        # shift to every particle. Compare positions relative to each set's centroid
-        # so the assertions test actual motion, not the global translation.
-        methane_before -= methane_before.mean(axis=0)
-        methane_after -= methane_after.mean(axis=0)
-        ethanol_before -= ethanol_before.mean(axis=0)
-        ethanol_after -= ethanol_after.mean(axis=0)
-
-        # Non-integrated methane particles do not move relative to each other
+        # Non-integrated methane coords stay fixed
         assert np.allclose(methane_before, methane_after, atol=1e-2)
-        # Integrated ethanol changes its internal configuration
+        # Integrated ethanol coords change
         assert not np.allclose(ethanol_before, ethanol_after, atol=1e-2)
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
@@ -489,6 +481,70 @@ class TestHoomdSimulation(BaseTest):
         assert np.allclose(anchor_pos_before, anchor_pos_after, atol=1e-2)
         # A non-fixed particle moves
         assert not np.allclose(other_pos_before, other_pos_after, atol=1e-2)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_positions_returned_in_original_frame(self):
+        """Regression: sync-back must undo HOOMD's box-centering translation."""
+        methane = mb.load("C", smiles=True)
+        box = mb.fill_box(compound=[methane], n_compounds=[5], box=[3, 3, 3])
+        frozen_indices = list(range(box.n_particles - 1))
+        sim = HoomdSimulation(
+            system=box,
+            fixed_compounds=frozen_indices,
+            r_cut=1.0,
+            box_buffer=2,
+            run_on_gpu=False,
+        )
+        frozen_before = np.copy(sim.compound.xyz[frozen_indices])
+        sim.nvt(n_steps=100, kT=2, dt=1e-4, tau=1e-2)
+        frozen_after = sim.compound.xyz[frozen_indices]
+        # The fixed particles do not move, so their absolute coordinates must be
+        assert np.allclose(frozen_before, frozen_after, atol=1e-6)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_box_update_bounding_box_within_target(self):
+        """box_update should leave the compound fitting inside the target box."""
+        methane = mb.load("C", smiles=True)
+        methane.name = "Methane"
+        box = mb.fill_box(compound=[methane], n_compounds=[8], box=[3, 3, 3])
+        sim = HoomdSimulation(system=box, r_cut=1.0, box_buffer=2, run_on_gpu=False)
+
+        target = hoomd.Box(5, 5, 5)
+        sim.box_update(
+            n_steps=3000,
+            kT=1.0,
+            dt=1e-4,
+            tau=1e-2,
+            target_box=target,
+            update_period=50,
+        )
+
+        bbox_lengths = np.asarray(sim.compound.get_boundingbox().lengths)
+        assert np.all(bbox_lengths <= np.asarray(target.L))
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_box_update_no_half_box_shift(self):
+        """Resizing must adjust the frame offset by dL/2, not leave it stale."""
+        methane = mb.load("C", smiles=True)
+        methane.name = "Methane"
+        box = mb.fill_box(compound=[methane], n_compounds=[8], box=[3, 3, 3])
+        sim = HoomdSimulation(system=box, r_cut=1.0, box_buffer=2, run_on_gpu=False)
+
+        sim.box_update(
+            n_steps=3000,
+            kT=1.0,
+            dt=1e-4,
+            tau=1e-2,
+            target_box=hoomd.Box(5, 5, 5),
+            update_period=50,
+        )
+
+        L_final = np.asarray(sim.state.box.L)
+        xyz = sim.compound.xyz
+        # Box corner is at the origin: all coords lie within [0, L_final].
+        # A stale offset would shift these by ~dL/2 (1 nm here) and go negative.
+        assert np.all(xyz >= -1e-4)
+        assert np.all(xyz <= L_final + 1e-4)
 
 
 class TestOpenMMSimulation(BaseTest):

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -8,7 +8,6 @@ from mbuild.simulation import (
     ForcesHandler,
     HoomdSimulation,
     OpenMMSimulation,
-    PropertyLogger,
 )
 from mbuild.tests.base_test import BaseTest
 from mbuild.utils.io import get_fn, has_foyer, has_hoomd
@@ -240,15 +239,6 @@ class TestHoomdSimulation(BaseTest):
         assert hoomd.md.angle.Harmonic in force_types
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_init_with_logger(self, octane, oplsaa):
-        """Test initialization with a PropertyLogger."""
-        logger = PropertyLogger(properties=["potential_energy"])
-        sim = HoomdSimulation(
-            octane, oplsaa, r_cut=0.3, run_on_gpu=False, logger=logger
-        )
-        assert sim.logger is logger
-
-    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_get_force_exists(self, sim):
         """Test retrieving existing forces."""
         force = sim._get_force(hoomd.md.pair.LJ)
@@ -352,6 +342,24 @@ class TestHoomdSimulation(BaseTest):
             assert len(energy[key]) == 2
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_get_energy_nan_for_inactive_forces(self, sim):
+        """Forces inactive in a frame read NaN, not zero."""
+        fh = ForcesHandler(dpd=1, scale_bond=0.1, scale_angle=0)
+        sim.cap_displacement(
+            forces_handler=fh, dt=1e-3, max_displacement=1e-3, n_steps=5
+        )
+        sim.fire(n_steps=5)
+        energy = sim.get_energy()
+
+        def key(cls):
+            return cls.__module__ + "." + cls.__name__
+
+        # DPD replaces LJ only while the handler is applied.
+        assert np.isnan(energy[key(hoomd.md.pair.DPDConservative)][-1])
+        assert np.all(np.isnan(energy[key(hoomd.md.pair.LJ)][:-1]))
+        assert not np.any(np.isnan(energy["potential_energy"]))
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_energies_accumulate(self, sim):
         """Test that energies accumulate over multiple calls."""
         fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
@@ -360,17 +368,6 @@ class TestHoomdSimulation(BaseTest):
         energy = sim.get_energy()
         for key in energy:
             assert len(energy[key]) == 3
-
-    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_property_logger(self, octane, oplsaa):
-        """Test that PropertyLogger records data during runs."""
-        logger = PropertyLogger(properties=["potential_energy"])
-        sim = HoomdSimulation(
-            octane, oplsaa, r_cut=0.3, run_on_gpu=False, logger=logger
-        )
-        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
-        sim.nvt(forces_handler=fh, n_steps=20, kT=2.0, dt=1e-4, tau=1e-2)
-        assert len(logger.data["potential_energy"]) > 0
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_path_fire(self):
@@ -673,6 +670,120 @@ class TestHoomdSimulation(BaseTest):
         assert np.all(xyz >= -1e-4)
         assert np.all(xyz <= L_final + 1e-4)
 
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_recover_undoes_only_the_last_run(self):
+        """recover() rewinds the last run's coordinates and drops its energies."""
+        octane = mb.load("CCCCCCCC", smiles=True)
+        sim = HoomdSimulation(system=octane, box=[3, 3, 3], run_on_gpu=False)
+
+        sim.fire(n_steps=10)
+        after_fire = np.copy(sim.compound.xyz)
+        n_energies = len(sim.energies)
+
+        sim.cap_displacement(n_steps=10, dt=1e-3)
+        assert not np.allclose(sim.compound.xyz, after_fire)
+
+        sim.recover()
+        assert np.allclose(sim.compound.xyz, after_fire, atol=1e-5)
+        assert len(sim.energies) == n_energies
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_recover_rewinds_cached_snapshot(self):
+        """A Simulation built after recover() starts from the restored coords."""
+        octane = mb.load("CCCCCCCC", smiles=True)
+        sim = HoomdSimulation(system=octane, box=[3, 3, 3], run_on_gpu=False)
+        before = np.copy(sim.compound.xyz)
+
+        sim.fire(n_steps=10)
+        sim.recover()
+
+        reused = HoomdSimulation(system=octane, box=[3, 3, 3], kick=False)
+        assert np.allclose(reused.compound.xyz, before, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_fixed_compounds_accepts_numpy_indices(self):
+        """Numpy integer indices work the same as built-in ints."""
+        chain = mb.load("CCCCCCCC", smiles=True)
+        sim = HoomdSimulation(
+            system=chain,
+            fixed_compounds=np.arange(3),
+            box_buffer=4,
+            run_on_gpu=False,
+        )
+        sim.nvt(n_steps=10, kT=1.0, dt=1e-4, tau=1e-2)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_integrate_compounds_mixed_types_raises(self, octane):
+        """A mix of Compounds and indices is rejected with a clear error."""
+        with pytest.raises(TypeError, match="integrate_compounds"):
+            HoomdSimulation(
+                system=octane,
+                integrate_compounds=[list(octane.particles())[0], 1],
+                box_buffer=4,
+                run_on_gpu=False,
+            )
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_box_update_syncs_compound_box(self):
+        """The compound's box must track the resized simulation box."""
+        methane = mb.load("C", smiles=True)
+        methane.name = "Methane"
+        box = mb.fill_box(compound=[methane], n_compounds=[8], box=[3, 3, 3])
+        sim = HoomdSimulation(system=box, r_cut=1.0, box_buffer=2, run_on_gpu=False)
+
+        sim.box_update(
+            n_steps=3000,
+            kT=1.0,
+            dt=1e-4,
+            tau=1e-2,
+            target_box=hoomd.Box(5, 5, 5),
+            update_period=50,
+        )
+
+        assert np.allclose(sim.compound.box.lengths, sim.state.box.L, atol=1e-4)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_nvt_leaves_compound_box_unchanged(self):
+        """Runs that do not resize must leave the compound's box alone."""
+        methane = mb.load("C", smiles=True)
+        methane.name = "Methane"
+        box = mb.fill_box(compound=[methane], n_compounds=[8], box=[3, 3, 3])
+        sim = HoomdSimulation(system=box, r_cut=1.0, box_buffer=2, run_on_gpu=False)
+        lengths_before = np.asarray(sim.compound.box.lengths)
+
+        sim.nvt(n_steps=100, kT=1.0, dt=1e-4, tau=1e-2)
+
+        assert np.allclose(sim.compound.box.lengths, lengths_before, atol=1e-4)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_second_sim_from_same_compound(self, oplsaa):
+        """A compound can be re-simulated after its sim data has been cached."""
+        octane = mb.load("CCCCCCCC", smiles=True)
+        sim = HoomdSimulation(system=octane, box=[3, 3, 3], run_on_gpu=False)
+        sim.fire(n_steps=10)
+        reused = HoomdSimulation(system=octane, box=[3, 3, 3], run_on_gpu=False)
+        assert reused.forces is sim.forces
+
+        rebuilt = HoomdSimulation(
+            system=octane, forcefield=oplsaa, box=[3, 3, 3], run_on_gpu=False
+        )
+        assert rebuilt.forces is not sim.forces
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_cached_sim_data_respects_box_and_r_cut(self):
+        """Changing the box or cutoff must not silently reuse cached sim data."""
+        octane = mb.load("CCCCCCCC", smiles=True)
+        sim = HoomdSimulation(system=octane, box=[3, 3, 3], run_on_gpu=False)
+
+        bigger = HoomdSimulation(system=octane, box=[9, 9, 9], run_on_gpu=False)
+        assert np.allclose(bigger.state.box.L, [9, 9, 9])
+
+        wider_cut = HoomdSimulation(
+            system=octane, box=[9, 9, 9], r_cut=2.5, run_on_gpu=False
+        )
+        assert wider_cut.forces is not bigger.forces
+        assert wider_cut.forces is not sim.forces
+
 
 class TestOpenMMSimulation(BaseTest):
     """Tests for the OpenMMSimulation class."""
@@ -734,12 +845,6 @@ class TestOpenMMSimulation(BaseTest):
         )
         assert sim is not None
 
-    def test_init_with_logger(self, simple_compound):
-        """Test initialization with a PropertyLogger."""
-        logger = PropertyLogger(properties=["potential_energy"])
-        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
-        assert sim.logger is logger
-
     def test_init_default_forces_with_bonds(self, simple_compound):
         """Test that default system has LJ + bond forces."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
@@ -791,16 +896,6 @@ class TestOpenMMSimulation(BaseTest):
         sim = OpenMMSimulation(octane, forcefield=get_fn("small_oplsaa.xml"))
         assert sim.system is not None
 
-    def test_init_platform_cpu(self, simple_compound):
-        """Test that CPU platform is set correctly."""
-        sim = OpenMMSimulation(simple_compound, forcefield=None, platform="CPU")
-        assert sim._platform.getName() == "CPU"
-
-    def test_init_nthreads(self, simple_compound):
-        """Test that nthreads is set."""
-        sim = OpenMMSimulation(simple_compound, forcefield=None, nthreads=2)
-        assert sim._platform.getPropertyDefaultValue("Threads") == "2"
-
     def test_minimize_compound(self, simple_compound):
         """Test energy minimization on a Compound."""
         old_coords = simple_compound.xyz.copy()
@@ -817,12 +912,6 @@ class TestOpenMMSimulation(BaseTest):
         assert "potential_energy" in energy
         assert len(energy["potential_energy"]) == 1
 
-    def test_minimize_custom_tolerance(self, simple_compound):
-        """Test minimize with custom tolerance."""
-        sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(n_steps=100, tolerance=1.0)
-        assert sim.get_energy() is not None
-
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_minimize_with_forcefield(self, octane):
         """Test minimize with a real forcefield."""
@@ -834,38 +923,11 @@ class TestOpenMMSimulation(BaseTest):
         sim.minimize(n_steps=100)
         assert not np.allclose(old_coords, octane.xyz, atol=1e-4)
 
-    def test_nvt_compound(self, simple_compound):
-        """Test NVT simulation on a Compound."""
-        sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(n_steps=1000)
-        old_coords = simple_compound.xyz.copy()
-        sim.nvt(n_steps=50, kT=300, dt=0.0001)
-        assert not np.allclose(old_coords, simple_compound.xyz, atol=1e-6)
-
-    def test_nvt_records_energy(self, simple_compound):
-        """Test that NVT records energy."""
-        sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(n_steps=50)
-        sim.nvt(n_steps=50, kT=300, dt=0.0001)
-        energy = sim.get_energy()
-        assert energy is not None
-        # minimize + nvt = 2 entries
-        assert len(energy["potential_energy"]) == 2
-
     def test_nvt_with_report_interval(self, simple_compound):
-        """Test NVT with periodic reporting."""
-        logger = PropertyLogger(properties=["potential_energy", "kinetic_energy"])
-        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
-        sim.nvt(n_steps=100, kT=300, dt=0.0001, report_interval=25)
-        assert len(logger.data["potential_energy"]) == 4
-        assert len(logger.data["kinetic_energy"]) == 4
-
-    def test_nvt_custom_friction(self, simple_compound):
-        """Test NVT with custom friction coefficient."""
+        """Test NVT records an energy frame per reporting chunk."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(n_steps=50)
-        sim.nvt(n_steps=20, kT=300, dt=0.0001, friction=5.0)
-        assert sim.get_energy() is not None
+        sim.nvt(n_steps=100, T=300, dt=0.0001, report_interval=25)
+        assert len(sim.get_energy()["potential_energy"]) == 4
 
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_nvt_with_forcefield(self, octane):
@@ -874,7 +936,7 @@ class TestOpenMMSimulation(BaseTest):
         sim = OpenMMSimulation(octane, forcefield="oplsaa")
         sim.minimize(n_steps=200)
         old_coords = octane.xyz.copy()
-        sim.nvt(n_steps=50, kT=300, dt=0.0001)
+        sim.nvt(n_steps=50, T=300, dt=0.0001)
         assert not np.allclose(old_coords, octane.xyz, atol=1e-6)
 
     def test_get_energy_empty(self, simple_compound):
@@ -882,52 +944,12 @@ class TestOpenMMSimulation(BaseTest):
         sim = OpenMMSimulation(simple_compound, forcefield=None)
         assert sim.get_energy() is None
 
-    def test_get_energy_accumulates(self, simple_compound):
-        """Test that energies accumulate across multiple calls."""
-        sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(n_steps=50)
-        sim.nvt(n_steps=20, kT=300, dt=0.0001)
-        energy = sim.get_energy()
-        assert len(energy["potential_energy"]) == 2
-
-    def test_logger_records_pe(self, simple_compound):
-        """Test logger records potential energy."""
-        logger = PropertyLogger(properties=["potential_energy"])
-        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
-        sim.minimize(n_steps=50)
-        assert len(logger.data["potential_energy"]) == 1
-        assert isinstance(logger.data["potential_energy"][0], float)
-
-    def test_logger_records_ke(self, simple_compound):
-        """Test logger records kinetic energy during dynamics."""
-        logger = PropertyLogger(properties=["kinetic_energy"])
-        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
-        sim.nvt(n_steps=50, kT=300, dt=0.0001, report_interval=25)
-        assert len(logger.data["kinetic_energy"]) == 2
-
-    def test_logger_as_dict(self, simple_compound):
-        """Test logger.as_dict() returns numpy arrays."""
-        logger = PropertyLogger(properties=["potential_energy"])
-        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
-        sim.minimize(n_steps=50)
-        data = logger.as_dict()
-        assert isinstance(data["potential_energy"], np.ndarray)
-
-    def test_logger_reset(self):
-        """Test logger reset clears all data."""
-        logger = PropertyLogger(properties=["potential_energy", "kinetic_energy"])
-        logger.data["potential_energy"].append(1.0)
-        logger.data["kinetic_energy"].append(2.0)
-        logger.reset()
-        assert len(logger.data["potential_energy"]) == 0
-        assert len(logger.data["kinetic_energy"]) == 0
-
     def test_minimize_then_nvt(self, simple_compound):
         """Test calling minimize then nvt sequentially."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
         sim.minimize(n_steps=50)
         coords_after_min = simple_compound.xyz.copy()
-        sim.nvt(n_steps=50, kT=300, dt=0.0001)
+        sim.nvt(n_steps=50, T=300, dt=0.0001)
         assert not np.allclose(coords_after_min, simple_compound.xyz, atol=1e-6)
         energy = sim.get_energy()
         assert len(energy["potential_energy"]) == 2

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -80,8 +80,8 @@ class TestForcesHandler(BaseTest):
         """Test that DPD replaces LJ when dpd > 0."""
         fh = ForcesHandler(dpd=1.0, scale_bond=0, scale_angle=0)
         fh.scale_sim(sim)
-        lj_force = sim.get_force(hoomd.md.pair.LJ)
-        dpd_force = sim.get_force(hoomd.md.pair.DPDConservative, active_only=True)
+        lj_force = sim._get_force(hoomd.md.pair.LJ)
+        dpd_force = sim._get_force(hoomd.md.pair.DPDConservative, active_only=True)
         for param in dpd_force.params:
             assert dpd_force.params[param]["A"] == 1.0
             assert dpd_force.r_cut[param] == lj_force.params[param]["sigma"]
@@ -108,7 +108,7 @@ class TestForcesHandler(BaseTest):
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_scale_bond_values(self, sim):
         """Test that bond k values are properly scaled."""
-        bond = sim.get_force(hoomd.md.bond.Harmonic)
+        bond = sim._get_force(hoomd.md.bond.Harmonic)
         orig_params = {p: dict(bond.params[p]) for p in bond.params}
 
         ForcesHandler(scale_bond=0.5, scale_angle=0).scale_sim(sim)
@@ -118,7 +118,7 @@ class TestForcesHandler(BaseTest):
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_scale_angle_values(self, sim):
         """Test that angle k values are properly scaled."""
-        angle = sim.get_force(hoomd.md.angle.Harmonic)
+        angle = sim._get_force(hoomd.md.angle.Harmonic)
         orig_params = {p: dict(angle.params[p]) for p in angle.params}
 
         ForcesHandler(scale_bond=0, scale_angle=0.3).scale_sim(sim)
@@ -136,8 +136,8 @@ class TestForcesHandler(BaseTest):
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_scale_restores_on_second_call(self, sim):
         """Test that calling scale_sim again restores original params before scaling."""
-        bond = sim.get_force(hoomd.md.bond.Harmonic)
-        angle = sim.get_force(hoomd.md.angle.Harmonic)
+        bond = sim._get_force(hoomd.md.bond.Harmonic)
+        angle = sim._get_force(hoomd.md.angle.Harmonic)
         orig_bond_params = {p: dict(bond.params[p]) for p in bond.params}
         orig_angle_params = {p: dict(angle.params[p]) for p in angle.params}
 
@@ -247,7 +247,7 @@ class TestHoomdSimulation(BaseTest):
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_get_force_exists(self, sim):
         """Test retrieving existing forces."""
-        force = sim.get_force(hoomd.md.pair.LJ)
+        force = sim._get_force(hoomd.md.pair.LJ)
         assert force is not None
         assert isinstance(force, hoomd.md.pair.LJ)
 
@@ -255,17 +255,17 @@ class TestHoomdSimulation(BaseTest):
     def test_get_force_not_found(self, sim_no_ff):
         """Test that ValueError is raised for non-existent force type."""
         with pytest.raises(ValueError):
-            sim_no_ff.get_force(hoomd.md.dihedral.OPLS)
+            sim_no_ff._get_force(hoomd.md.dihedral.OPLS)
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_get_force_active_only(self, sim):
         """Test get_force with active_only flag."""
         fh = ForcesHandler(scale_lj=1, scale_bond=0, scale_angle=0)
         fh.scale_sim(sim)
-        force = sim.get_force(hoomd.md.pair.LJ, active_only=True)
+        force = sim._get_force(hoomd.md.pair.LJ, active_only=True)
         assert force is not None
         with pytest.raises(ValueError):
-            sim.get_force(hoomd.md.bond.Harmonic, active_only=True)
+            sim._get_force(hoomd.md.bond.Harmonic, active_only=True)
 
     # ── Simulation method tests ───────────────────────────────────────────
 
@@ -283,22 +283,6 @@ class TestHoomdSimulation(BaseTest):
         old_coords = sim_no_ff.compound.xyz.copy()
         sim_no_ff.nvt(forces_handler=None, n_steps=20, kT=2.0, dt=1e-4, tau=1e-2)
         assert not np.allclose(old_coords, sim_no_ff.compound.xyz, atol=1e-5)
-
-    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_npt(self, sim):
-        """Test NPT simulation method."""
-        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
-        old_coords = sim.compound.xyz.copy()
-        sim.npt(
-            forces_handler=fh,
-            n_steps=20,
-            kT=2.0,
-            dt=1e-4,
-            tau=1e-2,
-            pressure=1.0,
-            tauS=1e-1,
-        )
-        assert not np.allclose(old_coords, sim.compound.xyz, atol=1e-5)
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_fire(self, sim):
@@ -435,7 +419,7 @@ class TestHoomdSimulation(BaseTest):
     def test_integrate_group_all(self, octane, oplsaa):
         """Test that default integration group includes all particles."""
         sim = HoomdSimulation(octane, oplsaa, r_cut=0.3, run_on_gpu=False)
-        group = sim.get_integrate_group()
+        group = sim._get_integrate_group()
         assert isinstance(group, hoomd.filter.All)
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
@@ -452,7 +436,7 @@ class TestHoomdSimulation(BaseTest):
                 fixed_compounds=[children[1]],
             )
             with pytest.raises(RuntimeError):
-                sim.get_integrate_group()
+                sim._get_integrate_group()
 
 
 class TestOpenMMSimulation(BaseTest):
@@ -489,7 +473,7 @@ class TestOpenMMSimulation(BaseTest):
 
         cpd = mb.Compound()
         for i in range(3):
-            p = mb.Compound(name="Ar", pos=[i * 0.4, 0.0, 0.0], element="Ar")
+            p = mb.Compound(name="C", pos=[i * 0.4, 0.0, 0.0], element="C")
             cpd.add(p)
         return cpd
 
@@ -537,7 +521,7 @@ class TestOpenMMSimulation(BaseTest):
         """Test that default system has LJ + bond forces."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
         n_forces = sim.system.getNumForces()
-        assert n_forces >= 2  # NonbondedForce + HarmonicBondForce
+        assert n_forces >= 2  # CustomNonbondedForce + HarmonicBondForce
 
     def test_init_default_forces_no_bonds(self, compound_no_bonds):
         """Test default system with only LJ (no bonds)."""
@@ -551,9 +535,10 @@ class TestOpenMMSimulation(BaseTest):
         sim = OpenMMSimulation(compound_with_box, forcefield=None)
         for i in range(sim.system.getNumForces()):
             force = sim.system.getForce(i)
-            if isinstance(force, openmm.NonbondedForce):
+            if isinstance(force, openmm.CustomNonbondedForce):
                 assert (
-                    force.getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic
+                    force.getNonbondedMethod()
+                    == openmm.CustomNonbondedForce.CutoffPeriodic
                 )
                 break
 
@@ -565,8 +550,11 @@ class TestOpenMMSimulation(BaseTest):
         sim = OpenMMSimulation(simple_compound, forcefield=None)
         for i in range(sim.system.getNumForces()):
             force = sim.system.getForce(i)
-            if isinstance(force, openmm.NonbondedForce):
-                assert force.getNonbondedMethod() == openmm.NonbondedForce.NoCutoff
+            if isinstance(force, openmm.CustomNonbondedForce):
+                assert (
+                    force.getNonbondedMethod()
+                    == openmm.CustomNonbondedForce.NoCutoff
+                )
                 break
 
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
@@ -597,20 +585,20 @@ class TestOpenMMSimulation(BaseTest):
         """Test energy minimization on a Compound."""
         old_coords = simple_compound.xyz.copy()
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(steps=100)
+        sim.minimize(n_steps=100)
         assert not np.allclose(old_coords, simple_compound.xyz, atol=1e-6)
 
     def test_minimize_path(self, simple_path):
         """Test energy minimization on a Path."""
         old_coords = simple_path.coordinates.copy()
         sim = OpenMMSimulation(simple_path, forcefield=None)
-        sim.minimize(steps=100)
+        sim.minimize(n_steps=100)
         assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
 
     def test_minimize_records_energy(self, simple_compound):
         """Test that minimize records energy."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(steps=50)
+        sim.minimize(n_steps=50)
         energy = sim.get_energy()
         assert energy is not None
         assert "potential_energy" in energy
@@ -619,7 +607,7 @@ class TestOpenMMSimulation(BaseTest):
     def test_minimize_custom_tolerance(self, simple_compound):
         """Test minimize with custom tolerance."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(steps=100, tolerance=1.0)
+        sim.minimize(n_steps=100, tolerance=1.0)
         assert sim.get_energy() is not None
 
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
@@ -630,7 +618,7 @@ class TestOpenMMSimulation(BaseTest):
             p.pos = p.pos + np.array([0.01 * (i % 3), -0.01 * (i % 2), 0.005 * i])
         old_coords = octane.xyz.copy()
         sim = OpenMMSimulation(octane, forcefield="oplsaa")
-        sim.minimize(steps=100)
+        sim.minimize(n_steps=100)
         assert not np.allclose(old_coords, octane.xyz, atol=1e-4)
 
     # ── nvt tests ─────────────────────────────────────────────────────────
@@ -638,7 +626,7 @@ class TestOpenMMSimulation(BaseTest):
     def test_nvt_compound(self, simple_compound):
         """Test NVT simulation on a Compound."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(steps=1000)
+        sim.minimize(n_steps=1000)
         old_coords = simple_compound.xyz.copy()
         sim.nvt(n_steps=50, kT=300, dt=0.0001)
         assert not np.allclose(old_coords, simple_compound.xyz, atol=1e-6)
@@ -646,7 +634,7 @@ class TestOpenMMSimulation(BaseTest):
     def test_nvt_path(self, simple_path):
         """Test NVT simulation on a Path."""
         sim = OpenMMSimulation(simple_path, forcefield=None)
-        sim.minimize(steps=100)
+        sim.minimize(n_steps=100)
         old_coords = simple_path.coordinates.copy()
         sim.nvt(n_steps=50, kT=300, dt=0.0001)
         assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
@@ -654,7 +642,7 @@ class TestOpenMMSimulation(BaseTest):
     def test_nvt_records_energy(self, simple_compound):
         """Test that NVT records energy."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(steps=50)
+        sim.minimize(n_steps=50)
         sim.nvt(n_steps=50, kT=300, dt=0.0001)
         energy = sim.get_energy()
         assert energy is not None
@@ -672,7 +660,7 @@ class TestOpenMMSimulation(BaseTest):
     def test_nvt_custom_friction(self, simple_compound):
         """Test NVT with custom friction coefficient."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(steps=50)
+        sim.minimize(n_steps=50)
         sim.nvt(n_steps=20, kT=300, dt=0.0001, friction=5.0)
         assert sim.get_energy() is not None
 
@@ -681,34 +669,10 @@ class TestOpenMMSimulation(BaseTest):
         """Test NVT with a real forcefield."""
         octane.box = mb.Box([5, 5, 5])
         sim = OpenMMSimulation(octane, forcefield="oplsaa")
-        sim.minimize(steps=200)
+        sim.minimize(n_steps=200)
         old_coords = octane.xyz.copy()
         sim.nvt(n_steps=50, kT=300, dt=0.0001)
         assert not np.allclose(old_coords, octane.xyz, atol=1e-6)
-
-    # ── npt tests ─────────────────────────────────────────────────────────
-
-    def test_npt_compound(self, compound_with_box):
-        """Test NPT simulation on a Compound."""
-        sim = OpenMMSimulation(compound_with_box, forcefield=None)
-        sim.minimize(steps=100)
-        old_coords = compound_with_box.xyz.copy()
-        sim.npt(n_steps=50, kT=300, dt=0.0001, pressure=1.0)
-        assert not np.allclose(old_coords, compound_with_box.xyz, atol=1e-6)
-
-    def test_npt_with_report_interval(self, compound_with_box):
-        """Test NPT with periodic reporting."""
-        logger = PropertyLogger(properties=["potential_energy"])
-        sim = OpenMMSimulation(compound_with_box, forcefield=None, logger=logger)
-        sim.npt(n_steps=100, kT=300, dt=0.0001, pressure=1.0, report_interval=50)
-        assert len(logger.data["potential_energy"]) == 2
-
-    def test_npt_custom_barostat_interval(self, compound_with_box):
-        """Test NPT with custom barostat interval."""
-        sim = OpenMMSimulation(compound_with_box, forcefield=None)
-        sim.minimize(steps=100)
-        sim.npt(n_steps=50, kT=300, dt=0.0001, pressure=1.0, barostat_interval=10)
-        assert sim.get_energy() is not None
 
     # ── get_energy tests ──────────────────────────────────────────────────
 
@@ -720,7 +684,7 @@ class TestOpenMMSimulation(BaseTest):
     def test_get_energy_accumulates(self, simple_compound):
         """Test that energies accumulate across multiple calls."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(steps=50)
+        sim.minimize(n_steps=50)
         sim.nvt(n_steps=20, kT=300, dt=0.0001)
         energy = sim.get_energy()
         assert len(energy["potential_energy"]) == 2
@@ -731,7 +695,7 @@ class TestOpenMMSimulation(BaseTest):
         """Test logger records potential energy."""
         logger = PropertyLogger(properties=["potential_energy"])
         sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
-        sim.minimize(steps=50)
+        sim.minimize(n_steps=50)
         assert len(logger.data["potential_energy"]) == 1
         assert isinstance(logger.data["potential_energy"][0], float)
 
@@ -746,7 +710,7 @@ class TestOpenMMSimulation(BaseTest):
         """Test logger.as_dict() returns numpy arrays."""
         logger = PropertyLogger(properties=["potential_energy"])
         sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
-        sim.minimize(steps=50)
+        sim.minimize(n_steps=50)
         data = logger.as_dict()
         assert isinstance(data["potential_energy"], np.ndarray)
 
@@ -765,14 +729,14 @@ class TestOpenMMSimulation(BaseTest):
         """Test Path coordinates are updated after minimize."""
         old_coords = simple_path.coordinates.copy()
         sim = OpenMMSimulation(simple_path, forcefield=None)
-        sim.minimize(steps=100)
+        sim.minimize(n_steps=100)
         assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
         assert np.allclose(sim.compound.xyz, simple_path.coordinates)
 
     def test_path_syncs_back_nvt(self, simple_path):
         """Test Path coordinates are updated after NVT."""
         sim = OpenMMSimulation(simple_path, forcefield=None)
-        sim.minimize(steps=100)
+        sim.minimize(n_steps=100)
         old_coords = simple_path.coordinates.copy()
         sim.nvt(n_steps=50, kT=300, dt=0.0001)
         assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
@@ -783,7 +747,7 @@ class TestOpenMMSimulation(BaseTest):
     def test_minimize_then_nvt(self, simple_compound):
         """Test calling minimize then nvt sequentially."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
-        sim.minimize(steps=50)
+        sim.minimize(n_steps=50)
         coords_after_min = simple_compound.xyz.copy()
         sim.nvt(n_steps=50, kT=300, dt=0.0001)
         assert not np.allclose(coords_after_min, simple_compound.xyz, atol=1e-6)

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -426,6 +426,70 @@ class TestHoomdSimulation(BaseTest):
             with pytest.raises(RuntimeError):
                 sim._get_integrate_group()
 
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_integrate_compounds_only_selected_moves(self):
+        """Test that only integrate_compounds move while the rest stay fixed."""
+        methane = mb.load("C", smiles=True)
+        methane.name = "Methane"
+        ethanol = mb.load("CCO", smiles=True)
+        ethanol.name = "Ethanol"
+        box = mb.fill_box(
+            compound=[methane, ethanol], n_compounds=[10, 1], box=[3, 3, 3]
+        )
+        ethanol_compound = box.children[-1]
+        sim = HoomdSimulation(
+            system=box,
+            integrate_compounds=[ethanol_compound],
+            r_cut=1.0,
+            box_buffer=2,
+            run_on_gpu=False,
+        )
+
+        ethanol_ids = {id(p) for p in ethanol_compound.particles()}
+        methane_particles = [p for p in box.particles() if id(p) not in ethanol_ids]
+        methane_before = np.array([np.copy(p.pos) for p in methane_particles])
+        ethanol_before = np.copy(ethanol_compound.xyz)
+
+        sim.nvt(n_steps=50000, kT=2, dt=1e-4, tau=1e-2)
+
+        methane_after = np.array([p.pos for p in methane_particles])
+        ethanol_after = ethanol_compound.xyz
+
+        # HOOMD centers its box at the origin, so sync-back applies a rigid frame
+        # shift to every particle. Compare positions relative to each set's centroid
+        # so the assertions test actual motion, not the global translation.
+        methane_before -= methane_before.mean(axis=0)
+        methane_after -= methane_after.mean(axis=0)
+        ethanol_before -= ethanol_before.mean(axis=0)
+        ethanol_after -= ethanol_after.mean(axis=0)
+
+        # Non-integrated methane particles do not move relative to each other
+        assert np.allclose(methane_before, methane_after, atol=1e-2)
+        # Integrated ethanol changes its internal configuration
+        assert not np.allclose(ethanol_before, ethanol_after, atol=1e-2)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_fixed_compounds_anchor_stays_put(self):
+        """Test that a fixed_compounds particle does not move during a run."""
+        chain = mb.load("CCCCCCC", smiles=True)
+        chain.translate_to((0, 0, 0))
+        sim = HoomdSimulation(
+            system=chain, fixed_compounds=[3], r_cut=1.0, box_buffer=4, run_on_gpu=False
+        )
+
+        anchor_pos_before = np.copy(chain.xyz[3])
+        other_pos_before = np.copy(chain.xyz[0])
+
+        sim.nvt(n_steps=50000, kT=2, dt=1e-4, tau=1e-2)
+
+        anchor_pos_after = chain.xyz[3]
+        other_pos_after = chain.xyz[0]
+
+        # The fixed anchor particle stays put
+        assert np.allclose(anchor_pos_before, anchor_pos_after, atol=1e-2)
+        # A non-fixed particle moves
+        assert not np.allclose(other_pos_before, other_pos_after, atol=1e-2)
+
 
 class TestOpenMMSimulation(BaseTest):
     """Tests for the OpenMMSimulation class."""

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -552,8 +552,7 @@ class TestOpenMMSimulation(BaseTest):
             force = sim.system.getForce(i)
             if isinstance(force, openmm.CustomNonbondedForce):
                 assert (
-                    force.getNonbondedMethod()
-                    == openmm.CustomNonbondedForce.NoCutoff
+                    force.getNonbondedMethod() == openmm.CustomNonbondedForce.NoCutoff
                 )
                 break
 

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -194,8 +194,6 @@ class TestHoomdSimulation(BaseTest):
     def sim_no_ff(self, octane):
         return HoomdSimulation(octane, forcefield=None, r_cut=0.3, run_on_gpu=False)
 
-    # ── Initialization tests ──────────────────────────────────────────────
-
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_init_with_compound(self, octane, oplsaa):
         """Test initialization with an mb.Compound."""
@@ -242,8 +240,6 @@ class TestHoomdSimulation(BaseTest):
         )
         assert sim.logger is logger
 
-    # ── get_force tests ───────────────────────────────────────────────────
-
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_get_force_exists(self, sim):
         """Test retrieving existing forces."""
@@ -266,8 +262,6 @@ class TestHoomdSimulation(BaseTest):
         assert force is not None
         with pytest.raises(ValueError):
             sim._get_force(hoomd.md.bond.Harmonic, active_only=True)
-
-    # ── Simulation method tests ───────────────────────────────────────────
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_nvt(self, sim):
@@ -333,8 +327,6 @@ class TestHoomdSimulation(BaseTest):
         force_types = set(type(f) for f in sim.active_forces)
         assert force_types == {hoomd.md.pair.DPDConservative, hoomd.md.bond.Harmonic}
 
-    # ── Energy tracking tests ─────────────────────────────────────────────
-
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_get_energy_empty(self, sim):
         """Test get_energy returns None before any run."""
@@ -372,8 +364,6 @@ class TestHoomdSimulation(BaseTest):
         sim.nvt(forces_handler=fh, n_steps=20, kT=2.0, dt=1e-4, tau=1e-2)
         assert len(logger.data["potential_energy"]) > 0
 
-    # ── Path-specific tests ───────────────────────────────────────────────
-
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_path_fire(self):
         """Test FIRE minimization on a Path."""
@@ -409,11 +399,9 @@ class TestHoomdSimulation(BaseTest):
         old_coords = path.coordinates.copy()
         sim = HoomdSimulation(path, forcefield=None, r_cut=0.5, run_on_gpu=False)
         sim.cap_displacement(
-            forces_handler=None, dt=1, max_displacement=0.5, n_steps=10
+            forces_handler=None, dt=1, max_displacement=0.001, n_steps=10
         )
         assert not np.allclose(old_coords, path.coordinates, atol=1e-5)
-
-    # ── Integration group tests ───────────────────────────────────────────
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_integrate_group_all(self, octane, oplsaa):
@@ -447,10 +435,6 @@ class TestOpenMMSimulation(BaseTest):
         return _make_simple_compound(n=5, spacing=0.15)
 
     @pytest.fixture
-    def simple_path(self):
-        return _make_simple_path(n=8)
-
-    @pytest.fixture
     def compound_with_box(self):
         """Compound with box, particles centered inside."""
         cpd = mb.Compound()
@@ -477,8 +461,6 @@ class TestOpenMMSimulation(BaseTest):
             cpd.add(p)
         return cpd
 
-    # ── Initialization tests ──────────────────────────────────────────────
-
     def test_init_with_compound(self, simple_compound):
         """Test initialization with a Compound."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
@@ -486,12 +468,6 @@ class TestOpenMMSimulation(BaseTest):
         assert sim.compound is simple_compound
         assert sim.system is not None
         assert sim.topology is not None
-
-    def test_init_with_path(self, simple_path):
-        """Test initialization with a Path."""
-        sim = OpenMMSimulation(simple_path, forcefield=None)
-        assert sim._is_path is True
-        assert sim.compound.n_particles == 8
 
     def test_init_invalid_input(self):
         """Test that invalid input raises TypeError."""
@@ -578,21 +554,12 @@ class TestOpenMMSimulation(BaseTest):
         sim = OpenMMSimulation(simple_compound, forcefield=None, nthreads=2)
         assert sim._platform.getPropertyDefaultValue("Threads") == "2"
 
-    # ── minimize tests ────────────────────────────────────────────────────
-
     def test_minimize_compound(self, simple_compound):
         """Test energy minimization on a Compound."""
         old_coords = simple_compound.xyz.copy()
         sim = OpenMMSimulation(simple_compound, forcefield=None)
         sim.minimize(n_steps=100)
         assert not np.allclose(old_coords, simple_compound.xyz, atol=1e-6)
-
-    def test_minimize_path(self, simple_path):
-        """Test energy minimization on a Path."""
-        old_coords = simple_path.coordinates.copy()
-        sim = OpenMMSimulation(simple_path, forcefield=None)
-        sim.minimize(n_steps=100)
-        assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
 
     def test_minimize_records_energy(self, simple_compound):
         """Test that minimize records energy."""
@@ -620,8 +587,6 @@ class TestOpenMMSimulation(BaseTest):
         sim.minimize(n_steps=100)
         assert not np.allclose(old_coords, octane.xyz, atol=1e-4)
 
-    # ── nvt tests ─────────────────────────────────────────────────────────
-
     def test_nvt_compound(self, simple_compound):
         """Test NVT simulation on a Compound."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
@@ -629,14 +594,6 @@ class TestOpenMMSimulation(BaseTest):
         old_coords = simple_compound.xyz.copy()
         sim.nvt(n_steps=50, kT=300, dt=0.0001)
         assert not np.allclose(old_coords, simple_compound.xyz, atol=1e-6)
-
-    def test_nvt_path(self, simple_path):
-        """Test NVT simulation on a Path."""
-        sim = OpenMMSimulation(simple_path, forcefield=None)
-        sim.minimize(n_steps=100)
-        old_coords = simple_path.coordinates.copy()
-        sim.nvt(n_steps=50, kT=300, dt=0.0001)
-        assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
 
     def test_nvt_records_energy(self, simple_compound):
         """Test that NVT records energy."""
@@ -673,8 +630,6 @@ class TestOpenMMSimulation(BaseTest):
         sim.nvt(n_steps=50, kT=300, dt=0.0001)
         assert not np.allclose(old_coords, octane.xyz, atol=1e-6)
 
-    # ── get_energy tests ──────────────────────────────────────────────────
-
     def test_get_energy_empty(self, simple_compound):
         """Test get_energy returns None before any run."""
         sim = OpenMMSimulation(simple_compound, forcefield=None)
@@ -687,8 +642,6 @@ class TestOpenMMSimulation(BaseTest):
         sim.nvt(n_steps=20, kT=300, dt=0.0001)
         energy = sim.get_energy()
         assert len(energy["potential_energy"]) == 2
-
-    # ── PropertyLogger integration ────────────────────────────────────────
 
     def test_logger_records_pe(self, simple_compound):
         """Test logger records potential energy."""
@@ -721,27 +674,6 @@ class TestOpenMMSimulation(BaseTest):
         logger.reset()
         assert len(logger.data["potential_energy"]) == 0
         assert len(logger.data["kinetic_energy"]) == 0
-
-    # ── Path sync-back tests ──────────────────────────────────────────────
-
-    def test_path_syncs_back_minimize(self, simple_path):
-        """Test Path coordinates are updated after minimize."""
-        old_coords = simple_path.coordinates.copy()
-        sim = OpenMMSimulation(simple_path, forcefield=None)
-        sim.minimize(n_steps=100)
-        assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
-        assert np.allclose(sim.compound.xyz, simple_path.coordinates)
-
-    def test_path_syncs_back_nvt(self, simple_path):
-        """Test Path coordinates are updated after NVT."""
-        sim = OpenMMSimulation(simple_path, forcefield=None)
-        sim.minimize(n_steps=100)
-        old_coords = simple_path.coordinates.copy()
-        sim.nvt(n_steps=50, kT=300, dt=0.0001)
-        assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
-        assert np.allclose(sim.compound.xyz, simple_path.coordinates)
-
-    # ── Multiple calls / reuse tests ──────────────────────────────────────
 
     def test_minimize_then_nvt(self, simple_compound):
         """Test calling minimize then nvt sequentially."""

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -1,361 +1,49 @@
-import sys
-
 import hoomd
 import numpy as np
 import pytest
 from gmso import ForceField
 
 import mbuild as mb
-from mbuild.exceptions import MBuildError
 from mbuild.simulation import (
     ForcesHandler,
     HoomdSimulation,
-    energy_minimize,
-    hoomd_cap_displacement,
-    hoomd_fire,
-    hoomd_nvt,
+    OpenMMSimulation,
+    PropertyLogger,
 )
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import get_fn, has_foyer, has_hoomd, has_openbabel
+from mbuild.utils.io import get_fn, has_foyer, has_hoomd
 
 
-class TestSimulation(BaseTest):
-    def test_energy_minimize(self, octane):
-        energy_minimize(compound=octane)
+def _make_simple_compound(n=5, spacing=0.15):
+    """Create a simple linear compound with bonds and proper elements."""
 
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_shift_com(self, octane):
-        com_old = octane.pos
-        energy_minimize(compound=octane)
-        # check to see if COM of energy minimized Compound
-        # has been shifted back to the original COM
-        assert np.allclose(com_old, octane.pos)
-
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_shift_anchor(self, octane):
-        anchor_compound = octane.labels["chain"].labels["CH3[0]"]
-        pos_old = anchor_compound.pos
-        energy_minimize(compound=octane, anchor=anchor_compound)
-        # check to see if COM of the anchor Compound
-        # has been shifted back to the original COM
-        assert np.allclose(pos_old, anchor_compound.pos)
-
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_fix_compounds(self, octane):
-        methyl_end0 = octane.labels["chain"].labels["CH3[0]"]
-        methyl_end1 = octane.labels["chain"].labels["CH3[0]"]
-        carbon_end = octane.labels["chain"].labels["CH3[0]"].labels["C[0]"]
-        not_in_compound = mb.Compound(name="H")
-
-        # fix the whole molecule and make sure positions are close
-        # given stochastic nature and use of restraining springs
-        # we need to have a pretty loose tolerance for checking
-        old_com = octane.pos
-        energy_minimize(
-            compound=octane,
-            fixed_compounds=octane,
-            shift_com=False,
-            constraint_factor=1e6,
-        )
-        assert np.allclose(octane.pos, old_com, rtol=1e-2, atol=1e-2)
-
-        # primarily focus on checking inputs are parsed correctly
-        energy_minimize(compound=octane, fixed_compounds=[octane])
-        energy_minimize(compound=octane, fixed_compounds=carbon_end)
-        energy_minimize(compound=octane, fixed_compounds=methyl_end0)
-        energy_minimize(compound=octane, fixed_compounds=[methyl_end0])
-        energy_minimize(
-            compound=octane, fixed_compounds=[methyl_end0, (True, True, True)]
-        )
-
-        energy_minimize(
-            compound=octane, fixed_compounds=[methyl_end0, (True, True, False)]
-        )
-        energy_minimize(
-            compound=octane, fixed_compounds=[methyl_end0, [True, True, False]]
-        )
-        energy_minimize(
-            compound=octane, fixed_compounds=[methyl_end0, (True, False, False)]
-        )
-        energy_minimize(
-            compound=octane, fixed_compounds=[methyl_end0, (False, False, False)]
-        )
-
-        energy_minimize(compound=octane, fixed_compounds=[methyl_end0, methyl_end1])
-        energy_minimize(compound=octane, fixed_compounds=[[methyl_end0], [methyl_end1]])
-        energy_minimize(
-            compound=octane,
-            fixed_compounds=[
-                [methyl_end0, (True, True, True)],
-                [methyl_end1, (True, True, True)],
-            ],
-        )
-
-        with pytest.raises(MBuildError):
-            energy_minimize(compound=octane, fixed_compounds=not_in_compound)
-        with pytest.raises(MBuildError):
-            energy_minimize(compound=octane, fixed_compounds=[not_in_compound])
-        with pytest.raises(MBuildError):
-            energy_minimize(
-                compound=octane, fixed_compounds=[12323.3, (True, False, False)]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane,
-                fixed_compounds=[methyl_end0, (True, False, False, False)],
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, True, False, False]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(compound=octane, fixed_compounds=[methyl_end0, True])
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane,
-                fixed_compounds=[methyl_end0, [True, False, False, False]],
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, (True, False)]
-            )
-
-        with pytest.raises(Exception):
-            energy_minimize(compound=octane, fixed_compounds=[methyl_end0, (True)])
-
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, ("True", True, True)]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, (True, "True", True)]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, (True, True, "True")]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, ("True", True, "True")]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, (True, "True", "True")]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, ("True", "True", True)]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, ("True", "True", "True")]
-            )
-        with pytest.raises(Exception):
-            energy_minimize(
-                compound=octane, fixed_compounds=[methyl_end0, (123.0, 231, "True")]
-            )
-
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_ignore_compounds(self, octane):
-        methyl_end0 = octane.labels["chain"].labels["CH3[0]"]
-        methyl_end1 = octane.labels["chain"].labels["CH3[1]"]
-        carbon_end = octane.labels["chain"].labels["CH3[0]"].labels["C[0]"]
-        not_in_compound = mb.Compound(name="H")
-
-        # fix the whole molecule and make sure positions are close
-        # given stochastic nature and use of restraining springs
-        # we need to have a pretty loose tolerance for checking
-        old_com = octane.pos
-        energy_minimize(
-            compound=octane,
-            ignore_compounds=octane,
-            shift_com=False,
-            constraint_factor=1e6,
-        )
-        assert np.allclose(octane.pos, old_com, rtol=1e-2, atol=1e-2)
-
-        # primarily focus on checking inputs are parsed correctly
-        energy_minimize(compound=octane, ignore_compounds=[octane])
-        energy_minimize(compound=octane, ignore_compounds=carbon_end)
-        energy_minimize(compound=octane, ignore_compounds=methyl_end0)
-        energy_minimize(compound=octane, ignore_compounds=[methyl_end0])
-        energy_minimize(compound=octane, ignore_compounds=[methyl_end0, methyl_end1])
-        energy_minimize(
-            compound=octane, ignore_compounds=[[methyl_end0], [methyl_end1]]
-        )
-
-        with pytest.raises(MBuildError):
-            energy_minimize(compound=octane, ignore_compounds=not_in_compound)
-        with pytest.raises(MBuildError):
-            energy_minimize(compound=octane, ignore_compounds=[1231, 123124])
-
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_distance_constraints(self, octane):
-        methyl_end0 = octane.labels["chain"].labels["CH3[0]"]
-        methyl_end1 = octane.labels["chain"].labels["CH3[1]"]
-
-        carbon_end0 = octane.labels["chain"].labels["CH3[0]"].labels["C[0]"]
-        carbon_end1 = octane.labels["chain"].labels["CH3[1]"].labels["C[0]"]
-        h_end0 = octane.labels["chain"].labels["CH3[0]"].labels["H[0]"]
-
-        not_in_compound = mb.Compound(name="H")
-
-        # given stochastic nature and use of restraining springs
-        # we need to have a pretty loose tolerance for checking
-        energy_minimize(
-            compound=octane,
-            distance_constraints=[(carbon_end0, carbon_end1), 0.7],
-            constraint_factor=1e20,
-        )
-        assert np.allclose(
-            np.linalg.norm(carbon_end0.pos - carbon_end1.pos),
-            0.7,
-            rtol=1e-2,
-            atol=1e-2,
-        )
-
-        energy_minimize(
-            compound=octane, distance_constraints=[[(carbon_end0, carbon_end1), 0.7]]
-        )
-        energy_minimize(
-            compound=octane,
-            distance_constraints=[
-                [(carbon_end0, carbon_end1), 0.7],
-                [(carbon_end0, h_end0), 0.1],
-            ],
-        )
-
-        with pytest.raises(MBuildError):
-            energy_minimize(
-                compound=octane,
-                distance_constraints=[(carbon_end0, not_in_compound), 0.7],
-            )
-        with pytest.raises(MBuildError):
-            energy_minimize(
-                compound=octane, distance_constraints=[(carbon_end0, carbon_end0), 0.7]
-            )
-        with pytest.raises(MBuildError):
-            energy_minimize(
-                compound=octane, distance_constraints=[(methyl_end0, carbon_end1), 0.7]
-            )
-        with pytest.raises(MBuildError):
-            energy_minimize(
-                compound=octane, distance_constraints=[(methyl_end0, methyl_end1), 0.7]
-            )
-
-    @pytest.mark.skipif(has_openbabel, reason="Open Babel package is installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_openbabel_warn(self, octane):
-        with pytest.raises(MBuildError):
-            energy_minimize(compound=octane)
-
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_ff(self, octane):
-        for ff in ["UFF", "GAFF", "MMFF94", "MMFF94s", "Ghemical"]:
-            energy_minimize(compound=octane, forcefield=ff)
-        with pytest.raises(IOError):
-            energy_minimize(compound=octane, forcefield="fakeFF")
-
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_algorithm(self, octane):
-        for algorithm in ["cg", "steep", "md"]:
-            energy_minimize(compound=octane, algorithm=algorithm)
-        with pytest.raises(MBuildError):
-            energy_minimize(compound=octane, algorithm="fakeAlg")
-
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_non_element(self, octane):
-        for particle in octane.particles():
-            particle.element = None
-        # Pass with element inference from names
-        energy_minimize(compound=octane)
-        for particle in octane.particles():
-            particle.name = "Q"
-            particle.element = None
-
-        # Fail once names cannot be set as elements
-        with pytest.raises(MBuildError):
-            energy_minimize(compound=octane)
-
-    @pytest.mark.skipif(not has_openbabel, reason="Open Babel not installed")
-    @pytest.mark.skipif(
-        "win" in sys.platform, reason="Unknown issue with Window's Open Babel "
-    )
-    def test_energy_minimize_ports(self, octane):
-        distances = np.round(
-            [
-                octane.min_periodic_distance(port.pos, port.anchor.pos)
-                for port in octane.all_ports()
-            ],
-            5,
-        )
-        orientations = np.round(
-            [port.pos - port.anchor.pos for port in octane.all_ports()], 5
-        )
-
-        energy_minimize(compound=octane)
-
-        updated_distances = np.round(
-            [
-                octane.min_periodic_distance(port.pos, port.anchor.pos)
-                for port in octane.all_ports()
-            ],
-            5,
-        )
-        updated_orientations = np.round(
-            [port.pos - port.anchor.pos for port in octane.all_ports()], 5
-        )
-
-        assert np.array_equal(distances, updated_distances)
-        assert np.array_equal(orientations, updated_orientations)
-
-    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
-    def test_energy_minimize_openmm(self, octane):
-        energy_minimize(compound=octane, forcefield="oplsaa")
-
-    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
-    @pytest.mark.parametrize("constraints", ["AllBonds", "HBonds", "HAngles", None])
-    def test_energy_minimize_openmm_constraints(self, octane, constraints):
-        energy_minimize(compound=octane, forcefield="oplsaa", constraints=constraints)
-
-    def test_energy_minimize_openmm_invalid_constraints(self, octane):
-        with pytest.raises(ValueError):
-            energy_minimize(compound=octane, forcefield="oplsaa", constraints="boo")
-
-    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
-    def test_energy_minimize_openmm_xml(self, octane):
-        energy_minimize(compound=octane, forcefield=get_fn("small_oplsaa.xml"))
+    cpd = mb.Compound()
+    for i in range(n):
+        p = mb.Compound(name="C", pos=[i * spacing, 0.0, 0.0], element="C")
+        cpd.add(p)
+    particles = list(cpd.particles())
+    for i in range(len(particles) - 1):
+        cpd.add_bond((particles[i], particles[i + 1]))
+    return cpd
 
 
-class TestSimulationHoomd(BaseTest):
-    """Test minimization methods using hoomd-blue."""
+def _make_simple_path(n=8, spacing=0.15):
+    """Create a simple Path object with name attributes on nodes."""
+    import networkx as nx
+
+    from mbuild.path.build import Path
+
+    coords = np.array([[i * spacing, 0.0, 0.0] for i in range(n)])
+    bond_graph = nx.Graph()
+    for i in range(n):
+        bond_graph.add_node(i, name="_A")
+    for i in range(n - 1):
+        bond_graph.add_edge(i, i + 1)
+    return Path(coordinates=coords, bond_graph=bond_graph)
+
+
+class TestForcesHandler(BaseTest):
+    """Tests for the ForcesHandler class."""
 
     @pytest.fixture
     def oplsaa(self):
@@ -366,100 +54,88 @@ class TestSimulationHoomd(BaseTest):
         return HoomdSimulation(octane, oplsaa, r_cut=0.3, run_on_gpu=False)
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_forces_handler(self, sim):
-        force = sim.get_force(hoomd.md.pair.LJ)
-        assert len(force.params.keys()) == 6
-        force = sim.get_force(hoomd.md.pair.Ewald)
-        assert force
-        force = sim.get_force(hoomd.md.long_range.pppm.Coulomb)
-        assert force
-        force = sim.get_force(hoomd.md.special_pair.LJ)
-        assert len(force.params.keys()) == 5
-        force = sim.get_force(hoomd.md.special_pair.Coulomb)
-        assert force
-        force = sim.get_force(hoomd.md.bond.Harmonic)
-        assert len(force.params.keys()) == 2
-        force = sim.get_force(hoomd.md.angle.Harmonic)
-        assert len(force.params.keys()) == 3
-        force = sim.get_force(hoomd.md.dihedral.OPLS)
-        assert len(force.params.keys()) == 3
+    def test_default_init(self):
+        """Test default ForcesHandler initialization."""
+        fh = ForcesHandler()
+        assert fh.dpd == 0.0
+        assert fh.scale_forces["bond"] == 1
+        assert fh.scale_forces["angle"] == 1
+        assert fh.scale_forces["lj"] == 1
+        assert fh.scale_forces["charge"] == 0
+        assert fh.scale_forces["opls"] == 0
+        assert fh.scale_forces["periodic"] == 0
+        assert fh.scale_forces["improper"] == 0
 
-    def test_scale_forces(self, sim):
-        A = 1
-        ffhandler = ForcesHandler(dpd=A, scale_bond=0, scale_angle=0)
-        ffhandler.scale_sim(sim)
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_custom_init(self):
+        """Test ForcesHandler with custom scaling."""
+        fh = ForcesHandler(dpd=5.0, scale_bond=0.5, scale_angle=0.2, scale_lj=0.8)
+        assert fh.dpd == 5.0
+        assert fh.scale_forces["bond"] == 0.5
+        assert fh.scale_forces["angle"] == 0.2
+        assert fh.scale_forces["lj"] == 0.8
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_scale_sim_dpd(self, sim):
+        """Test that DPD replaces LJ when dpd > 0."""
+        fh = ForcesHandler(dpd=1.0, scale_bond=0, scale_angle=0)
+        fh.scale_sim(sim)
         lj_force = sim.get_force(hoomd.md.pair.LJ)
-        force = sim.get_force(hoomd.md.pair.DPDConservative, active_only=True)
-        for param in force.params:
-            assert force.params[param]["A"] == A
-            assert force.r_cut[param] == lj_force.params[param]["sigma"]
-        forceTypes = [type(force) for force in sim.active_forces]
-        allforceTypes = [type(force) for force in sim.forces]
-        assert hoomd.md.bond.Harmonic not in forceTypes
-        assert hoomd.md.bond.Harmonic in allforceTypes
-        assert hoomd.md.angle.Harmonic not in forceTypes
-        assert hoomd.md.angle.Harmonic in allforceTypes
-        assert hoomd.md.dihedral.OPLS not in forceTypes
-        assert hoomd.md.dihedral.OPLS in allforceTypes
-
-    def test_scale_opls(self, sim):
-        ffhandler = ForcesHandler(scale_opls=0.5)
-        ffhandler.scale_sim(sim)
-        forceTypes = [type(force) for force in sim.active_forces]
-        assert hoomd.md.dihedral.OPLS in forceTypes
+        dpd_force = sim.get_force(hoomd.md.pair.DPDConservative, active_only=True)
+        for param in dpd_force.params:
+            assert dpd_force.params[param]["A"] == 1.0
+            assert dpd_force.r_cut[param] == lj_force.params[param]["sigma"]
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_nvt(self, sim):
-        ffhandler = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
-        cpd = sim.compound
-        old_coords = cpd.xyz.copy()
-        hoomd_nvt(
-            compound=cpd,
-            sim=sim,
-            forces_handler=ffhandler,
-            n_steps=20,
-            kT=2.0,
-            dt=1e-4,
-            tau=1e-2,
-        )
-        new_coords = cpd.xyz
-        assert not np.allclose(old_coords, new_coords, atol=1e-5)
+    def test_scale_sim_excludes_zero_forces(self, sim):
+        """Test that forces with scale=0 are excluded from active_forces."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=0, scale_angle=0)
+        fh.scale_sim(sim)
+        force_types = [type(f) for f in sim.active_forces]
+        assert hoomd.md.bond.Harmonic not in force_types
+        assert hoomd.md.angle.Harmonic not in force_types
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_fire(self, sim):
-        ffhandler = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
-        cpd = sim.compound
-        old_coords = cpd.xyz.copy()
-        hoomd_fire(cpd, sim, ffhandler, n_steps=20)
-        new_coords = cpd.xyz
-        assert not np.allclose(old_coords, new_coords, atol=1e-5)
-        # TODO: Get and validate energies here
+    def test_scale_sim_includes_nonzero_forces(self, sim):
+        """Test that forces with scale>0 are included in active_forces."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        fh.scale_sim(sim)
+        force_types = [type(f) for f in sim.active_forces]
+        assert hoomd.md.pair.LJ in force_types
+        assert hoomd.md.bond.Harmonic in force_types
+        assert hoomd.md.angle.Harmonic in force_types
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_capped_displacement(self, sim):
+    def test_scale_bond_values(self, sim):
+        """Test that bond k values are properly scaled."""
         bond = sim.get_force(hoomd.md.bond.Harmonic)
-        orig_bond_params = {p: dict(bond.params[p]) for p in bond.params}
+        orig_params = {p: dict(bond.params[p]) for p in bond.params}
 
-        ffhandler = ForcesHandler(dpd=1, scale_bond=0.1, scale_angle=0)
-        cpd = sim.compound
-        old_coords = cpd.xyz.copy()
-        hoomd_cap_displacement(
-            cpd, sim, ffhandler, dt=1, max_displacement=1, n_steps=10
-        )
-        new_coords = cpd.xyz
-        assert not np.allclose(old_coords, new_coords, atol=1e-5)
-        forcesTypesSet = set([type(force) for force in sim.active_forces])
-        assert forcesTypesSet == set(
-            (
-                hoomd.md.pair.DPDConservative,
-                hoomd.md.bond.Harmonic,
-            )
-        )
+        ForcesHandler(scale_bond=0.5, scale_angle=0).scale_sim(sim)
         for p in bond.params:
-            assert np.isclose(bond.params[p]["k"], orig_bond_params[p]["k"] * 0.1)
+            assert np.isclose(bond.params[p]["k"], orig_params[p]["k"] * 0.5)
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_scale_forces_restores_on_second_call(self, sim):
+    def test_scale_angle_values(self, sim):
+        """Test that angle k values are properly scaled."""
+        angle = sim.get_force(hoomd.md.angle.Harmonic)
+        orig_params = {p: dict(angle.params[p]) for p in angle.params}
+
+        ForcesHandler(scale_bond=0, scale_angle=0.3).scale_sim(sim)
+        for p in angle.params:
+            assert np.isclose(angle.params[p]["k"], orig_params[p]["k"] * 0.3)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_scale_opls(self, sim):
+        """Test that OPLS dihedral forces can be activated."""
+        fh = ForcesHandler(scale_opls=0.5)
+        fh.scale_sim(sim)
+        force_types = [type(f) for f in sim.active_forces]
+        assert hoomd.md.dihedral.OPLS in force_types
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_scale_restores_on_second_call(self, sim):
+        """Test that calling scale_sim again restores original params before scaling."""
         bond = sim.get_force(hoomd.md.bond.Harmonic)
         angle = sim.get_force(hoomd.md.angle.Harmonic)
         orig_bond_params = {p: dict(bond.params[p]) for p in bond.params}
@@ -478,24 +154,638 @@ class TestSimulationHoomd(BaseTest):
             assert np.isclose(angle.params[p]["k"], orig_angle_params[p]["k"])
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
-    def test_get_energy(self, sim):
-        cpd = sim.compound
-        ffhandler = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+    def test_forces_dict_populated(self, sim):
+        """Test that forcesDict is populated after scale_sim."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        fh.scale_sim(sim)
+        assert "lj" in fh.forcesDict
+        assert "bond" in fh.forcesDict
+        assert "angle" in fh.forcesDict
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_missing_force_skipped(self):
+        """Test that missing forces (e.g., no dihedrals) are skipped gracefully."""
+        cpd = mb.Compound()
+        for i in range(3):
+            p = mb.Compound(name="C", pos=[i * 0.15, 0.0, 0.0], element="C")
+            cpd.add(p)
+        particles = list(cpd.particles())
+        for i in range(len(particles) - 1):
+            cpd.add_bond((particles[i], particles[i + 1]))
+
+        sim = HoomdSimulation(cpd, forcefield=None, r_cut=0.5, run_on_gpu=False)
+        # No OPLS dihedrals exist in the default system
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1, scale_opls=1)
+        fh.scale_sim(sim)  # Should not raise
+
+
+class TestHoomdSimulation(BaseTest):
+    """Tests for the HoomdSimulation class."""
+
+    @pytest.fixture
+    def oplsaa(self):
+        return ForceField("oplsaa")
+
+    @pytest.fixture
+    def sim(self, octane, oplsaa):
+        return HoomdSimulation(octane, oplsaa, r_cut=0.3, run_on_gpu=False)
+
+    @pytest.fixture
+    def sim_no_ff(self, octane):
+        return HoomdSimulation(octane, forcefield=None, r_cut=0.3, run_on_gpu=False)
+
+    # ── Initialization tests ──────────────────────────────────────────────
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_init_with_compound(self, octane, oplsaa):
+        """Test initialization with an mb.Compound."""
+        sim = HoomdSimulation(octane, oplsaa, r_cut=0.3, run_on_gpu=False)
+        assert sim._is_path is False
+        assert sim.compound is octane
+        assert len(sim.forces) > 0
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_init_with_path(self):
+        """Test initialization with a Path object."""
+        path = _make_simple_path(n=6)
+        sim = HoomdSimulation(path, forcefield=None, r_cut=0.5, run_on_gpu=False)
+        assert sim._is_path is True
+        assert sim.compound.n_particles == 6
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_init_invalid_input(self):
+        """Test that invalid input raises TypeError."""
+        with pytest.raises(TypeError):
+            HoomdSimulation("invalid", forcefield=None, r_cut=0.3)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_init_no_forcefield_creates_defaults(self, sim_no_ff):
+        """Test that default forces are created when no FF is given."""
+        force_types = [type(f) for f in sim_no_ff.forces]
+        assert hoomd.md.pair.LJ in force_types
+        assert hoomd.md.bond.Harmonic in force_types
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_init_with_forcefield(self, sim):
+        """Test that forces are created from the provided forcefield."""
+        force_types = [type(f) for f in sim.forces]
+        assert hoomd.md.pair.LJ in force_types
+        assert hoomd.md.bond.Harmonic in force_types
+        assert hoomd.md.angle.Harmonic in force_types
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_init_with_logger(self, octane, oplsaa):
+        """Test initialization with a PropertyLogger."""
+        logger = PropertyLogger(properties=["potential_energy"])
+        sim = HoomdSimulation(
+            octane, oplsaa, r_cut=0.3, run_on_gpu=False, logger=logger
+        )
+        assert sim.logger is logger
+
+    # ── get_force tests ───────────────────────────────────────────────────
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_get_force_exists(self, sim):
+        """Test retrieving existing forces."""
+        force = sim.get_force(hoomd.md.pair.LJ)
+        assert force is not None
+        assert isinstance(force, hoomd.md.pair.LJ)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_get_force_not_found(self, sim_no_ff):
+        """Test that ValueError is raised for non-existent force type."""
+        with pytest.raises(ValueError):
+            sim_no_ff.get_force(hoomd.md.dihedral.OPLS)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_get_force_active_only(self, sim):
+        """Test get_force with active_only flag."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=0, scale_angle=0)
+        fh.scale_sim(sim)
+        force = sim.get_force(hoomd.md.pair.LJ, active_only=True)
+        assert force is not None
+        with pytest.raises(ValueError):
+            sim.get_force(hoomd.md.bond.Harmonic, active_only=True)
+
+    # ── Simulation method tests ───────────────────────────────────────────
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_nvt(self, sim):
+        """Test NVT simulation method."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        old_coords = sim.compound.xyz.copy()
+        sim.nvt(forces_handler=fh, n_steps=20, kT=2.0, dt=1e-4, tau=1e-2)
+        assert not np.allclose(old_coords, sim.compound.xyz, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_nvt_no_forces_handler(self, sim_no_ff):
+        """Test NVT with forces_handler=None uses all forces."""
+        old_coords = sim_no_ff.compound.xyz.copy()
+        sim_no_ff.nvt(forces_handler=None, n_steps=20, kT=2.0, dt=1e-4, tau=1e-2)
+        assert not np.allclose(old_coords, sim_no_ff.compound.xyz, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_npt(self, sim):
+        """Test NPT simulation method."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        old_coords = sim.compound.xyz.copy()
+        sim.npt(
+            forces_handler=fh,
+            n_steps=20,
+            kT=2.0,
+            dt=1e-4,
+            tau=1e-2,
+            pressure=1.0,
+            tauS=1e-1,
+        )
+        assert not np.allclose(old_coords, sim.compound.xyz, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_fire(self, sim):
+        """Test FIRE minimization method."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        old_coords = sim.compound.xyz.copy()
+        sim.fire(forces_handler=fh, n_steps=20)
+        assert not np.allclose(old_coords, sim.compound.xyz, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_fire_no_forces_handler(self, sim_no_ff):
+        """Test FIRE with no forces handler."""
+        old_coords = sim_no_ff.compound.xyz.copy()
+        sim_no_ff.fire(forces_handler=None, n_steps=20)
+        assert not np.allclose(old_coords, sim_no_ff.compound.xyz, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_fire_multiple_iterations(self, sim):
+        """Test FIRE with multiple iterations."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        old_coords = sim.compound.xyz.copy()
+        sim.fire(forces_handler=fh, n_steps=200, n_iterations=3)
+        new_coords = sim.compound.xyz
+        assert not np.allclose(old_coords, new_coords, atol=1e-4)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_cap_displacement(self, sim):
+        """Test capped displacement method."""
+        fh = ForcesHandler(dpd=1, scale_bond=0.1, scale_angle=0)
+        old_coords = sim.compound.xyz.copy()
+        sim.cap_displacement(forces_handler=fh, dt=1, max_displacement=1, n_steps=10)
+        assert not np.allclose(old_coords, sim.compound.xyz, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_cap_displacement_no_forces_handler(self, sim_no_ff):
+        """Test capped displacement with forces_handler=None."""
+        old_coords = sim_no_ff.compound.xyz.copy()
+        sim_no_ff.cap_displacement(
+            forces_handler=None, dt=1, max_displacement=1, n_steps=10
+        )
+        assert not np.allclose(old_coords, sim_no_ff.compound.xyz, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_cap_displacement_force_types(self, sim):
+        """Test that only expected forces are active after cap_displacement."""
+        fh = ForcesHandler(dpd=1, scale_bond=0.1, scale_angle=0)
+        sim.cap_displacement(forces_handler=fh, dt=1, max_displacement=1, n_steps=10)
+        force_types = set(type(f) for f in sim.active_forces)
+        assert force_types == {hoomd.md.pair.DPDConservative, hoomd.md.bond.Harmonic}
+
+    # ── Energy tracking tests ─────────────────────────────────────────────
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_get_energy_empty(self, sim):
+        """Test get_energy returns None before any run."""
         assert sim.get_energy() is None
-        hoomd_cap_displacement(
-            cpd, sim, ffhandler, dt=1, max_displacement=1, n_steps=10
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_get_energy_after_run(self, sim):
+        """Test get_energy returns data after running."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        sim.cap_displacement(forces_handler=fh, dt=1, max_displacement=1, n_steps=10)
+        energy = sim.get_energy()
+        assert energy is not None
+        assert len(energy) > 0
+        for key in energy:
+            assert len(energy[key]) == 2
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_energies_accumulate(self, sim):
+        """Test that energies accumulate over multiple calls."""
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        sim.cap_displacement(forces_handler=fh, dt=1, max_displacement=1, n_steps=5)
+        sim.cap_displacement(forces_handler=fh, dt=1, max_displacement=1, n_steps=5)
+        energy = sim.get_energy()
+        for key in energy:
+            assert len(energy[key]) == 3
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_property_logger(self, octane, oplsaa):
+        """Test that PropertyLogger records data during runs."""
+        logger = PropertyLogger(properties=["potential_energy"])
+        sim = HoomdSimulation(
+            octane, oplsaa, r_cut=0.3, run_on_gpu=False, logger=logger
         )
-        energyDict = sim.get_energy()
-        assert np.allclose(
-            energyDict["hoomd.md.pair.pair.LJ"], np.array(([-1.25498152, 0.0]))
+        fh = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        sim.nvt(forces_handler=fh, n_steps=20, kT=2.0, dt=1e-4, tau=1e-2)
+        assert len(logger.data["potential_energy"]) > 0
+
+    # ── Path-specific tests ───────────────────────────────────────────────
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_fire(self):
+        """Test FIRE minimization on a Path."""
+        path = _make_simple_path(n=10)
+        old_coords = path.coordinates.copy()
+        sim = HoomdSimulation(path, forcefield=None, r_cut=0.5, run_on_gpu=False)
+        sim.fire(forces_handler=None, n_steps=50)
+        assert not np.allclose(old_coords, path.coordinates, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_nvt(self):
+        """Test NVT simulation on a Path."""
+        path = _make_simple_path(n=10)
+        old_coords = path.coordinates.copy()
+        sim = HoomdSimulation(path, forcefield=None, r_cut=0.5, run_on_gpu=False)
+        sim.nvt(forces_handler=None, n_steps=20, kT=1.0, dt=1e-4, tau=1e-2)
+        assert not np.allclose(old_coords, path.coordinates, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_syncs_back(self):
+        """Test that Path coordinates are synced back after simulation."""
+        path = _make_simple_path(n=5)
+        old_coords = path.coordinates.copy()
+        sim = HoomdSimulation(path, forcefield=None, r_cut=0.5, run_on_gpu=False)
+        sim.fire(forces_handler=None, n_steps=50)
+        assert not np.allclose(old_coords, path.coordinates, atol=1e-5)
+        assert np.allclose(sim.compound.xyz, path.coordinates)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_cap_displacement(self):
+        """Test capped displacement on a Path."""
+        path = _make_simple_path(n=8)
+        old_coords = path.coordinates.copy()
+        sim = HoomdSimulation(path, forcefield=None, r_cut=0.5, run_on_gpu=False)
+        sim.cap_displacement(
+            forces_handler=None, dt=1, max_displacement=0.5, n_steps=10
         )
-        assert np.allclose(
-            energyDict["hoomd.md.bond.Harmonic"],
-            np.array(([1.35651551e02, 3.05080224e06])),
-            rtol=1e-2,
+        assert not np.allclose(old_coords, path.coordinates, atol=1e-5)
+
+    # ── Integration group tests ───────────────────────────────────────────
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_integrate_group_all(self, octane, oplsaa):
+        """Test that default integration group includes all particles."""
+        sim = HoomdSimulation(octane, oplsaa, r_cut=0.3, run_on_gpu=False)
+        group = sim.get_integrate_group()
+        assert isinstance(group, hoomd.filter.All)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_integrate_group_both_raises(self, octane, oplsaa):
+        """Test that passing both integrate and fixed compounds raises."""
+        children = list(octane.children)
+        if len(children) >= 2:
+            sim = HoomdSimulation(
+                octane,
+                oplsaa,
+                r_cut=0.3,
+                run_on_gpu=False,
+                integrate_compounds=[children[0]],
+                fixed_compounds=[children[1]],
+            )
+            with pytest.raises(RuntimeError):
+                sim.get_integrate_group()
+
+
+class TestOpenMMSimulation(BaseTest):
+    """Tests for the OpenMMSimulation class."""
+
+    @pytest.fixture
+    def simple_compound(self):
+        return _make_simple_compound(n=5, spacing=0.15)
+
+    @pytest.fixture
+    def simple_path(self):
+        return _make_simple_path(n=8)
+
+    @pytest.fixture
+    def compound_with_box(self):
+        """Compound with box, particles centered inside."""
+        cpd = mb.Compound()
+        for i in range(5):
+            p = mb.Compound(
+                name="C",
+                pos=[4.0 + i * 0.5, 5.0, 5.0],  # centered in box
+                element="C",
+            )
+            cpd.add(p)
+        particles = list(cpd.particles())
+        for i in range(len(particles) - 1):
+            cpd.add_bond((particles[i], particles[i + 1]))
+        cpd.box = mb.Box([10, 10, 10])
+        return cpd
+
+    @pytest.fixture
+    def compound_no_bonds(self):
+        """Compound with no bonds (isolated particles)."""
+
+        cpd = mb.Compound()
+        for i in range(3):
+            p = mb.Compound(name="Ar", pos=[i * 0.4, 0.0, 0.0], element="Ar")
+            cpd.add(p)
+        return cpd
+
+    # ── Initialization tests ──────────────────────────────────────────────
+
+    def test_init_with_compound(self, simple_compound):
+        """Test initialization with a Compound."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        assert sim._is_path is False
+        assert sim.compound is simple_compound
+        assert sim.system is not None
+        assert sim.topology is not None
+
+    def test_init_with_path(self, simple_path):
+        """Test initialization with a Path."""
+        sim = OpenMMSimulation(simple_path, forcefield=None)
+        assert sim._is_path is True
+        assert sim.compound.n_particles == 8
+
+    def test_init_invalid_input(self):
+        """Test that invalid input raises TypeError."""
+        with pytest.raises(TypeError):
+            OpenMMSimulation("not_valid", forcefield=None)
+
+    def test_init_invalid_constraints(self, simple_compound):
+        """Test that invalid constraints raise ValueError."""
+        with pytest.raises(ValueError):
+            OpenMMSimulation(simple_compound, forcefield=None, constraints="BadValue")
+
+    @pytest.mark.parametrize("constraints", [None, "AllBonds", "HBonds", "HAngles"])
+    def test_init_valid_constraints(self, simple_compound, constraints):
+        """Test that all valid constraint options are accepted."""
+        sim = OpenMMSimulation(
+            simple_compound, forcefield=None, constraints=constraints
         )
-        assert np.allclose(
-            energyDict["hoomd.md.angle.Harmonic"],
-            np.array(([3942.05658645, 19129.72619001])),
-            rtol=1e-2,
-        )
+        assert sim is not None
+
+    def test_init_with_logger(self, simple_compound):
+        """Test initialization with a PropertyLogger."""
+        logger = PropertyLogger(properties=["potential_energy"])
+        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
+        assert sim.logger is logger
+
+    def test_init_default_forces_with_bonds(self, simple_compound):
+        """Test that default system has LJ + bond forces."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        n_forces = sim.system.getNumForces()
+        assert n_forces >= 2  # NonbondedForce + HarmonicBondForce
+
+    def test_init_default_forces_no_bonds(self, compound_no_bonds):
+        """Test default system with only LJ (no bonds)."""
+        sim = OpenMMSimulation(compound_no_bonds, forcefield=None)
+        assert sim.system.getNumForces() >= 1
+
+    def test_init_with_box_uses_periodic(self, compound_with_box):
+        """Test that a compound with a box uses periodic boundary conditions."""
+        import openmm
+
+        sim = OpenMMSimulation(compound_with_box, forcefield=None)
+        for i in range(sim.system.getNumForces()):
+            force = sim.system.getForce(i)
+            if isinstance(force, openmm.NonbondedForce):
+                assert (
+                    force.getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic
+                )
+                break
+
+    def test_init_without_box_uses_nocutoff(self, simple_compound):
+        """Test that a compound without a box uses NoCutoff."""
+        import openmm
+
+        simple_compound.box = None
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        for i in range(sim.system.getNumForces()):
+            force = sim.system.getForce(i)
+            if isinstance(force, openmm.NonbondedForce):
+                assert force.getNonbondedMethod() == openmm.NonbondedForce.NoCutoff
+                break
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    def test_init_with_forcefield(self, octane):
+        """Test initialization with a foyer forcefield."""
+        sim = OpenMMSimulation(octane, forcefield="oplsaa")
+        assert sim.system is not None
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    def test_init_with_xml_forcefield(self, octane):
+        """Test initialization with an XML forcefield file."""
+        sim = OpenMMSimulation(octane, forcefield=get_fn("small_oplsaa.xml"))
+        assert sim.system is not None
+
+    def test_init_platform_cpu(self, simple_compound):
+        """Test that CPU platform is set correctly."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None, platform="CPU")
+        assert sim._platform.getName() == "CPU"
+
+    def test_init_nthreads(self, simple_compound):
+        """Test that nthreads is set."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None, nthreads=2)
+        assert sim._platform.getPropertyDefaultValue("Threads") == "2"
+
+    # ── minimize tests ────────────────────────────────────────────────────
+
+    def test_minimize_compound(self, simple_compound):
+        """Test energy minimization on a Compound."""
+        old_coords = simple_compound.xyz.copy()
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        sim.minimize(steps=100)
+        assert not np.allclose(old_coords, simple_compound.xyz, atol=1e-6)
+
+    def test_minimize_path(self, simple_path):
+        """Test energy minimization on a Path."""
+        old_coords = simple_path.coordinates.copy()
+        sim = OpenMMSimulation(simple_path, forcefield=None)
+        sim.minimize(steps=100)
+        assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
+
+    def test_minimize_records_energy(self, simple_compound):
+        """Test that minimize records energy."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        sim.minimize(steps=50)
+        energy = sim.get_energy()
+        assert energy is not None
+        assert "potential_energy" in energy
+        assert len(energy["potential_energy"]) == 1
+
+    def test_minimize_custom_tolerance(self, simple_compound):
+        """Test minimize with custom tolerance."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        sim.minimize(steps=100, tolerance=1.0)
+        assert sim.get_energy() is not None
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    def test_minimize_with_forcefield(self, octane):
+        """Test minimize with a real forcefield."""
+        # Distort the molecule away from its minimum
+        for i, p in enumerate(octane.particles()):
+            p.pos = p.pos + np.array([0.01 * (i % 3), -0.01 * (i % 2), 0.005 * i])
+        old_coords = octane.xyz.copy()
+        sim = OpenMMSimulation(octane, forcefield="oplsaa")
+        sim.minimize(steps=100)
+        assert not np.allclose(old_coords, octane.xyz, atol=1e-4)
+
+    # ── nvt tests ─────────────────────────────────────────────────────────
+
+    def test_nvt_compound(self, simple_compound):
+        """Test NVT simulation on a Compound."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        sim.minimize(steps=1000)
+        old_coords = simple_compound.xyz.copy()
+        sim.nvt(n_steps=50, kT=300, dt=0.0001)
+        assert not np.allclose(old_coords, simple_compound.xyz, atol=1e-6)
+
+    def test_nvt_path(self, simple_path):
+        """Test NVT simulation on a Path."""
+        sim = OpenMMSimulation(simple_path, forcefield=None)
+        sim.minimize(steps=100)
+        old_coords = simple_path.coordinates.copy()
+        sim.nvt(n_steps=50, kT=300, dt=0.0001)
+        assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
+
+    def test_nvt_records_energy(self, simple_compound):
+        """Test that NVT records energy."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        sim.minimize(steps=50)
+        sim.nvt(n_steps=50, kT=300, dt=0.0001)
+        energy = sim.get_energy()
+        assert energy is not None
+        # minimize + nvt = 2 entries
+        assert len(energy["potential_energy"]) == 2
+
+    def test_nvt_with_report_interval(self, simple_compound):
+        """Test NVT with periodic reporting."""
+        logger = PropertyLogger(properties=["potential_energy", "kinetic_energy"])
+        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
+        sim.nvt(n_steps=100, kT=300, dt=0.0001, report_interval=25)
+        assert len(logger.data["potential_energy"]) == 4
+        assert len(logger.data["kinetic_energy"]) == 4
+
+    def test_nvt_custom_friction(self, simple_compound):
+        """Test NVT with custom friction coefficient."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        sim.minimize(steps=50)
+        sim.nvt(n_steps=20, kT=300, dt=0.0001, friction=5.0)
+        assert sim.get_energy() is not None
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    def test_nvt_with_forcefield(self, octane):
+        """Test NVT with a real forcefield."""
+        octane.box = mb.Box([5, 5, 5])
+        sim = OpenMMSimulation(octane, forcefield="oplsaa")
+        sim.minimize(steps=200)
+        old_coords = octane.xyz.copy()
+        sim.nvt(n_steps=50, kT=300, dt=0.0001)
+        assert not np.allclose(old_coords, octane.xyz, atol=1e-6)
+
+    # ── npt tests ─────────────────────────────────────────────────────────
+
+    def test_npt_compound(self, compound_with_box):
+        """Test NPT simulation on a Compound."""
+        sim = OpenMMSimulation(compound_with_box, forcefield=None)
+        sim.minimize(steps=100)
+        old_coords = compound_with_box.xyz.copy()
+        sim.npt(n_steps=50, kT=300, dt=0.0001, pressure=1.0)
+        assert not np.allclose(old_coords, compound_with_box.xyz, atol=1e-6)
+
+    def test_npt_with_report_interval(self, compound_with_box):
+        """Test NPT with periodic reporting."""
+        logger = PropertyLogger(properties=["potential_energy"])
+        sim = OpenMMSimulation(compound_with_box, forcefield=None, logger=logger)
+        sim.npt(n_steps=100, kT=300, dt=0.0001, pressure=1.0, report_interval=50)
+        assert len(logger.data["potential_energy"]) == 2
+
+    def test_npt_custom_barostat_interval(self, compound_with_box):
+        """Test NPT with custom barostat interval."""
+        sim = OpenMMSimulation(compound_with_box, forcefield=None)
+        sim.minimize(steps=100)
+        sim.npt(n_steps=50, kT=300, dt=0.0001, pressure=1.0, barostat_interval=10)
+        assert sim.get_energy() is not None
+
+    # ── get_energy tests ──────────────────────────────────────────────────
+
+    def test_get_energy_empty(self, simple_compound):
+        """Test get_energy returns None before any run."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        assert sim.get_energy() is None
+
+    def test_get_energy_accumulates(self, simple_compound):
+        """Test that energies accumulate across multiple calls."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        sim.minimize(steps=50)
+        sim.nvt(n_steps=20, kT=300, dt=0.0001)
+        energy = sim.get_energy()
+        assert len(energy["potential_energy"]) == 2
+
+    # ── PropertyLogger integration ────────────────────────────────────────
+
+    def test_logger_records_pe(self, simple_compound):
+        """Test logger records potential energy."""
+        logger = PropertyLogger(properties=["potential_energy"])
+        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
+        sim.minimize(steps=50)
+        assert len(logger.data["potential_energy"]) == 1
+        assert isinstance(logger.data["potential_energy"][0], float)
+
+    def test_logger_records_ke(self, simple_compound):
+        """Test logger records kinetic energy during dynamics."""
+        logger = PropertyLogger(properties=["kinetic_energy"])
+        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
+        sim.nvt(n_steps=50, kT=300, dt=0.0001, report_interval=25)
+        assert len(logger.data["kinetic_energy"]) == 2
+
+    def test_logger_as_dict(self, simple_compound):
+        """Test logger.as_dict() returns numpy arrays."""
+        logger = PropertyLogger(properties=["potential_energy"])
+        sim = OpenMMSimulation(simple_compound, forcefield=None, logger=logger)
+        sim.minimize(steps=50)
+        data = logger.as_dict()
+        assert isinstance(data["potential_energy"], np.ndarray)
+
+    def test_logger_reset(self):
+        """Test logger reset clears all data."""
+        logger = PropertyLogger(properties=["potential_energy", "kinetic_energy"])
+        logger.data["potential_energy"].append(1.0)
+        logger.data["kinetic_energy"].append(2.0)
+        logger.reset()
+        assert len(logger.data["potential_energy"]) == 0
+        assert len(logger.data["kinetic_energy"]) == 0
+
+    # ── Path sync-back tests ──────────────────────────────────────────────
+
+    def test_path_syncs_back_minimize(self, simple_path):
+        """Test Path coordinates are updated after minimize."""
+        old_coords = simple_path.coordinates.copy()
+        sim = OpenMMSimulation(simple_path, forcefield=None)
+        sim.minimize(steps=100)
+        assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
+        assert np.allclose(sim.compound.xyz, simple_path.coordinates)
+
+    def test_path_syncs_back_nvt(self, simple_path):
+        """Test Path coordinates are updated after NVT."""
+        sim = OpenMMSimulation(simple_path, forcefield=None)
+        sim.minimize(steps=100)
+        old_coords = simple_path.coordinates.copy()
+        sim.nvt(n_steps=50, kT=300, dt=0.0001)
+        assert not np.allclose(old_coords, simple_path.coordinates, atol=1e-6)
+        assert np.allclose(sim.compound.xyz, simple_path.coordinates)
+
+    # ── Multiple calls / reuse tests ──────────────────────────────────────
+
+    def test_minimize_then_nvt(self, simple_compound):
+        """Test calling minimize then nvt sequentially."""
+        sim = OpenMMSimulation(simple_compound, forcefield=None)
+        sim.minimize(steps=50)
+        coords_after_min = simple_compound.xyz.copy()
+        sim.nvt(n_steps=50, kT=300, dt=0.0001)
+        assert not np.allclose(coords_after_min, simple_compound.xyz, atol=1e-6)
+        energy = sim.get_energy()
+        assert len(energy["potential_energy"]) == 2

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -404,6 +404,21 @@ class TestHoomdSimulation(BaseTest):
         assert not np.allclose(old_coords, path.coordinates, atol=1e-5)
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_stress_uff(self):
+        """UFF on a 60-atom molecule spanning all 10 elements and every hybridization."""
+        smiles = "N#CC(=O)OC(O)C(Br)(Cl)c1ccc(o1)C=Nc1ncc(F)cc1C#CCSCP(C)CCN(C)CI"
+        comp = mb.load(smiles, smiles=True)
+        old_coords = comp.xyz.copy()
+        sim = HoomdSimulation(
+            comp, forcefield=None, r_cut=0.5, box_buffer=6, run_on_gpu=False
+        )
+        # LJ + harmonic bonds + harmonic angles + periodic dihedrals.
+        assert len(sim.forces) == 4
+        sim.fire(forces_handler=None, n_steps=100)
+        assert np.isfinite(comp.xyz).all()
+        assert not np.allclose(old_coords, comp.xyz, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_integrate_group_all(self, octane, oplsaa):
         """Test that default integration group includes all particles."""
         sim = HoomdSimulation(octane, oplsaa, r_cut=0.3, run_on_gpu=False)

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -1,17 +1,21 @@
 import sys
 
+import hoomd
 import numpy as np
 import pytest
+from gmso import ForceField
 
 import mbuild as mb
 from mbuild.exceptions import MBuildError
-from mbuild.simulation import energy_minimize
-from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import (
-    get_fn,
-    has_foyer,
-    has_openbabel,
+from mbuild.simulation import (
+    ForcesHandler,
+    HoomdSimulation,
+    energy_minimize,
+    hoomd_cap_displacement,
+    hoomd_fire,
 )
+from mbuild.tests.base_test import BaseTest
+from mbuild.utils.io import get_fn, has_foyer, has_hoomd, has_openbabel
 
 
 class TestSimulation(BaseTest):
@@ -347,3 +351,89 @@ class TestSimulation(BaseTest):
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_energy_minimize_openmm_xml(self, octane):
         energy_minimize(compound=octane, forcefield=get_fn("small_oplsaa.xml"))
+
+
+class TestSimulationHoomd(BaseTest):
+    """Test minimization methods using hoomd-blue."""
+
+    @pytest.fixture
+    def oplsaa(self):
+        return ForceField("oplsaa")
+
+    @pytest.fixture
+    def sim(self, octane, oplsaa):
+        return HoomdSimulation(octane, oplsaa, r_cut=0.3, run_on_gpu=False)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_forces_handler(self, sim):
+        force = sim.get_force(hoomd.md.pair.LJ)
+        assert len(force.params.keys()) == 6
+        force = sim.get_force(hoomd.md.pair.Ewald)
+        assert force
+        force = sim.get_force(hoomd.md.long_range.pppm.Coulomb)
+        assert force
+        force = sim.get_force(hoomd.md.special_pair.LJ)
+        assert len(force.params.keys()) == 5
+        force = sim.get_force(hoomd.md.special_pair.Coulomb)
+        assert force
+        force = sim.get_force(hoomd.md.bond.Harmonic)
+        assert len(force.params.keys()) == 2
+        force = sim.get_force(hoomd.md.angle.Harmonic)
+        assert len(force.params.keys()) == 3
+        force = sim.get_force(hoomd.md.dihedral.OPLS)
+        assert len(force.params.keys()) == 3
+
+    def test_scale_forces(self, sim):
+        A = 1
+        ffhandler = ForcesHandler(dpd=A, scale_bond=0, scale_angle=0)
+        ffhandler.scale_sim(sim)
+        lj_force = sim.get_force(hoomd.md.pair.LJ)
+        force = sim.get_force(hoomd.md.pair.DPDConservative, active_only=True)
+        for param in force.params:
+            assert force.params[param]["A"] == A
+            assert force.r_cut[param] == lj_force.params[param]["sigma"]
+        forceTypes = [type(force) for force in sim.active_forces]
+        allforceTypes = [type(force) for force in sim.forces]
+        assert hoomd.md.bond.Harmonic not in forceTypes
+        assert hoomd.md.bond.Harmonic in allforceTypes
+        assert hoomd.md.angle.Harmonic not in forceTypes
+        assert hoomd.md.angle.Harmonic in allforceTypes
+        assert hoomd.md.dihedral.OPLS not in forceTypes
+        assert hoomd.md.dihedral.OPLS in allforceTypes
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_fire(self, sim):
+        ffhandler = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        cpd = sim.compound
+        old_coords = cpd.xyz.copy()
+        hoomd_fire(cpd, sim, ffhandler, n_steps=20)
+        new_coords = cpd.xyz
+        assert not np.allclose(old_coords, new_coords, atol=1e-5)
+        # TODO: Get and validate energies here
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_capped_displacement(self, sim):
+        ffhandler = ForcesHandler(scale_lj=1, scale_bond=1, scale_angle=1)
+        ffhandler = ForcesHandler(dpd=1, scale_bond=0.1, scale_angle=0)
+        cpd = sim.compound
+        old_coords = cpd.xyz.copy()
+        hoomd_cap_displacement(
+            cpd, sim, ffhandler, dt=1, max_displacement=1, n_steps=10
+        )
+        new_coords = cpd.xyz
+        assert not np.allclose(old_coords, new_coords, atol=1e-5)
+        forcesTypesSet = set([type(force) for force in sim.active_forces])
+        assert forcesTypesSet == set(
+            (
+                hoomd.md.pair.DPDConservative,
+                hoomd.md.bond.Harmonic,
+            )
+        )
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_reports_energy(self, octane):
+        pass
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_plots_energy(self, octane):
+        pass

--- a/mbuild/tests/test_simulation.py
+++ b/mbuild/tests/test_simulation.py
@@ -42,6 +42,14 @@ def _make_simple_path(n=8, spacing=0.15):
     return Path(coordinates=coords, bond_graph=bond_graph)
 
 
+def _make_two_type_path(n=6, spacing=0.15):
+    """Create a straight-line Path with alternating A/B bead types."""
+    from mbuild.path.build import straight_line
+    from mbuild.path.namers import CyclicNamer
+
+    return straight_line(spacing=spacing, N=n, bead_name=CyclicNamer(["A", "B"]))
+
+
 class TestForcesHandler(BaseTest):
     """Tests for the ForcesHandler class."""
 
@@ -402,6 +410,110 @@ class TestHoomdSimulation(BaseTest):
             forces_handler=None, dt=1, max_displacement=0.001, n_steps=10
         )
         assert not np.allclose(old_coords, path.coordinates, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_explicit_box(self):
+        """An explicit box=[Lx, Ly, Lz] is used verbatim and stays fixed."""
+        path = _make_simple_path(n=6)
+        box = [5.0, 6.0, 7.0]
+        for _ in range(2):
+            sim = HoomdSimulation(path, forcefield=None, box=box, run_on_gpu=False)
+            assert np.allclose(sim.state.box.L, box)
+            sim.fire(forces_handler=None, n_steps=10)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_per_type_radius(self):
+        """Per-bead-type radii set unlike-pair WCA sigma to the arithmetic mean."""
+        from mbuild.utils.simulation.path_forces import PathForcefield
+
+        path = _make_two_type_path(n=6)
+        pff = PathForcefield(radius={"A": 0.4, "B": 0.8})
+        sim = HoomdSimulation(path, forcefield=pff, r_cut=0.5, run_on_gpu=False)
+        wca = sim.forces[0]
+        assert wca.params[("A", "A")]["sigma"] == pytest.approx(0.4)
+        assert wca.params[("B", "B")]["sigma"] == pytest.approx(0.8)
+        assert wca.params[("A", "B")]["sigma"] == pytest.approx(0.6)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_per_type_bond_length(self):
+        """Bond length keyed by bond-type name sizes the FENE bond."""
+        from mbuild.utils.simulation.path_forces import PathForcefield
+
+        path = _make_two_type_path(n=6)
+        pff = PathForcefield(radius=0.4, bond_length={"A-B": 0.25})
+        sim = HoomdSimulation(path, forcefield=pff, r_cut=0.5, run_on_gpu=False)
+        fene = sim.forces[1]
+        assert fene.params["A-B"]["sigma"] == pytest.approx(0.25)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_auto_per_type(self):
+        """forcefield=None derives per-type radii/lengths and relaxes a 2-type path."""
+        path = _make_two_type_path(n=8)
+        old_coords = path.coordinates.copy()
+        sim = HoomdSimulation(path, forcefield=None, r_cut=0.5, run_on_gpu=False)
+        wca_pairs = set(sim.forces[0].params.keys())
+        assert {("A", "A"), ("A", "B"), ("B", "B")} <= wca_pairs
+        sim.fire(forces_handler=None, n_steps=50)
+        assert not np.allclose(old_coords, path.coordinates, atol=1e-5)
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_missing_type_raises(self):
+        """A per-type radius dict missing a bead type raises a clear error."""
+        from mbuild.utils.simulation.path_forces import PathForcefield
+
+        path = _make_two_type_path(n=6)
+        with pytest.raises(KeyError, match="type"):
+            HoomdSimulation(
+                path, forcefield=PathForcefield(radius={"A": 0.4}), run_on_gpu=False
+            )
+
+    @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
+    def test_path_per_type_angle_partial(self):
+        """A per-type angle dict covers only its types and still runs."""
+        from mbuild.path.points import AnglesSampler
+        from mbuild.utils.simulation.path_forces import PathForcefield
+
+        path = _make_two_type_path(n=6)
+        sampler = AnglesSampler("normal", {"loc": 2.5, "scale": 0.2})
+        pff = PathForcefield(radius=0.15, angles={"A-B-A": sampler})
+        sim = HoomdSimulation(path, forcefield=pff, r_cut=0.5, run_on_gpu=False)
+        angle = sim.forces[-1]
+        assert isinstance(angle, hoomd.md.angle.Table)
+        # Covered type carries a nonzero potential; uncovered type is flat.
+        assert np.any(np.asarray(angle.params["A-B-A"]["U"]) != 0)
+        assert np.all(np.asarray(angle.params["B-A-B"]["U"]) == 0)
+        sim.cap_displacement(dt=1, max_displacement=0.003, n_steps=50)
+        sim.fire(forces_handler=None, n_steps=50)
+
+    def test_auto_bond_length_median_ignores_wrapping(self):
+        """Median sampling ignores periodic-wrap bonds seen as long outliers."""
+        import gsd.hoomd
+
+        from mbuild.utils.simulation.path_forces import (
+            _auto_bond_lengths,
+            _auto_radii,
+        )
+
+        frame = gsd.hoomd.Frame()
+        frame.particles.N = 5
+        # Four in a row 0.25 apart, plus one placed far away.
+        frame.particles.position = [
+            [0, 0, 0],
+            [0.25, 0, 0],
+            [0.5, 0, 0],
+            [0.75, 0, 0],
+            [4.5, 0, 0],
+        ]
+        frame.particles.types = ["A"]
+        frame.particles.typeid = [0] * 5
+        frame.configuration.box = [10, 10, 10, 0, 0, 0]
+        # Three real 0.25 bonds and one long outlier (0,4), like a wrap artifact.
+        frame.bonds.N = 4
+        frame.bonds.types = ["A-A"]
+        frame.bonds.typeid = [0, 0, 0, 0]
+        frame.bonds.group = [[0, 1], [1, 2], [2, 3], [0, 4]]
+        assert _auto_bond_lengths(frame)["A-A"] == pytest.approx(0.25)
+        assert _auto_radii(frame)["A"] == pytest.approx(0.25 / 0.97)
 
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     def test_stress_uff(self):

--- a/mbuild/utils/simulation/__init__.py
+++ b/mbuild/utils/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""mBuild simulation utilities."""

--- a/mbuild/utils/simulation/path_forces.py
+++ b/mbuild/utils/simulation/path_forces.py
@@ -1,0 +1,330 @@
+"""Utility to build forces for relaxing coarse bead paths without a chemical forcefield.
+
+Paths are relaxed with a coarse Kremer-Grest model built from the geometry
+the path was generated with: a WCA pair potential for excluded volume, a
+FENE+WCA bond, and, only when the caller supplies a sampler, a tabulated angle
+and/or dihedral potential.
+"""
+
+import logging
+import math
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+TWO_POW_1_6 = 2.0 ** (1.0 / 6.0)
+
+# Kremer-Grest equilibrium bond length as a fraction of the WCA sigma.
+KG_BOND_SIGMA_RATIO = 0.97
+
+
+class PathForcefield:
+    """Coarse Kremer-Grest forcefield parameters for a bead Path.
+
+    Passed to a simulation in place of a chemical forcefield to override the
+    geometry-derived defaults. Any value left None falls back to its geometric
+    default: the mean bond length, radius = bond_length / 0.97, and no angle or
+    dihedral term.
+
+    Parameters
+    ----------
+    radius : float or None, default None
+        WCA sigma (bead exclusion diameter, center-to-center).
+    bond_length : float or None, default None
+        Target bond length for the FENE+WCA bond.
+    angles : mbuild.path.points.AnglesSampler or None, default None
+        Optional bond-angle distribution for a tabulated angle potential.
+    dihedrals : object or None, default None
+        Optional dihedral distribution for a tabulated dihedral potential.
+    epsilon : float, default 1.0
+        Energy scale for the WCA and FENE potentials.
+    per_type : dict or None, default None
+        Reserved for future per-bead-type parameters, e.g.
+        {bead_type: {"radius": ..., "bond_length": ...}}. Not yet used.
+    """
+
+    def __init__(
+        self,
+        radius=None,
+        bond_length=None,
+        angles=None,
+        dihedrals=None,
+        epsilon=1.0,
+        per_type=None,
+    ):
+        self.radius = radius
+        self.bond_length = bond_length
+        self.angles = angles
+        self.dihedrals = dihedrals
+        self.epsilon = epsilon
+        self.per_type = per_type
+
+
+def generate_ff_from_path(
+    path,
+    snap,
+    radius=None,
+    bond_length=None,
+    angles_sampler=None,
+    dihedrals_sampler=None,
+    epsilon=1.0,
+):
+    """Build a coarse forcefield for a path from its geometry.
+
+    When not given explicitly, the bond length is the mean over the path's
+    bonds and the bead radius follows the Kremer-Grest relation l0 = sigma * 0.97
+    Angle and dihedral terms are added only when a sampler is supplied.
+
+    Parameters
+    ----------
+    path : mbuild.path.build.Path
+        Path providing the geometry the bond length is derived from.
+    snap : gsd.hoomd.Frame
+        Snapshot providing particle, bond, angle, and dihedral type names.
+    radius : float or None, default None
+        WCA sigma. If None, derived from bond_length via the Kremer-Grest
+        relation.
+    bond_length : float or None, default None
+        Target bond length. If None, the mean over the path's bonds is used.
+    angles_sampler : mbuild.path.points.AnglesSampler or None, default None
+        Optional bond-angle distribution for a tabulated angle potential.
+    dihedrals_sampler : object or None, default None
+        Optional dihedral distribution for a tabulated dihedral potential.
+    epsilon : float, default 1.0
+        Energy scale for the WCA and FENE potentials.
+
+    Returns
+    -------
+    list
+        HOOMD force objects, as returned by build_path_ff.
+    """
+    if bond_length is None:
+        bond_length = _mean_bond_length(path)
+    if radius is None:
+        radius = bond_length / KG_BOND_SIGMA_RATIO
+    return build_path_ff(
+        snap,
+        radius=radius,
+        bond_length=bond_length,
+        angle_sampler=angles_sampler,
+        dihedral_sampler=dihedrals_sampler,
+        epsilon=epsilon,
+    )
+
+
+def build_path_ff(
+    snap,
+    radius,
+    bond_length,
+    angle_sampler=None,
+    dihedral_sampler=None,
+    epsilon=1.0,
+    table_width=100,
+):
+    """Build coarse Kremer-Grest HOOMD forces for a bead path.
+
+    Every bead, bond, angle and dihedral type in the
+    snapshot receives the same corresponding parameters.
+
+    Parameters
+    ----------
+    snap : gsd.hoomd.Frame
+        Snapshot providing particle, bond, angle, and dihedral type names.
+    radius : float
+        WCA sigma (bead exclusion diameter, center-to-center).
+    bond_length : float
+        Target bond length, used to size the FENE+WCA bond.
+    angle_sampler : mbuild.path.points.AnglesSampler or None, default None
+        If given, a tabulated angle potential is Boltzmann-inverted from it.
+    dihedral_sampler : object or None, default None
+        If given, a tabulated dihedral potential is Boltzmann-inverted from it.
+    epsilon : float, default 1.0
+        Energy scale for the WCA and FENE potentials.
+    table_width : int, default 100
+        Resolution of the tabulated angle and dihedral potentials.
+
+    Returns
+    -------
+    list
+        HOOMD force objects: [WCA pairs, FENE+WCA bonds, (angle), (dihedral)].
+    """
+    # TODO: Add a backend arg ("hoomd"/"openmm") like uff_forces so
+    # OpenMMSimulation can consume the same PathForcefield: WCA via
+    # CustomNonbondedForce, FENE via CustomBondForce, tables via Discrete/
+    # tabulated potentials.
+    import hoomd
+
+    forces = []
+
+    # WCA excluded volume between non-bonded beads. 1-2 pairs are excluded and
+    # handled by the bond's own WCA term.
+    r_cut = TWO_POW_1_6 * radius
+    nlist = hoomd.md.nlist.Cell(buffer=0.2, exclusions=("bond",))
+    wca = hoomd.md.pair.LJ(nlist=nlist, default_r_cut=r_cut, mode="shift")
+    ptypes = list(set(snap.particles.types))
+    for i, t1 in enumerate(ptypes):
+        for t2 in ptypes[i:]:
+            wca.params[(t1, t2)] = dict(sigma=radius, epsilon=epsilon)
+    forces.append(wca)
+
+    if snap.bonds.N > 0:
+        sigma_bond = bond_length
+        if bond_length > 1.33 * radius:
+            logger.warning(
+                "build_path_ff: bond_length (%.3g) exceeds ~1.33*radius (%.3g); "
+                "FENE+WCA no longer guarantees non-crossing bonds.",
+                bond_length,
+                radius,
+            )
+        fene = hoomd.md.bond.FENEWCA()
+        for bt in set(snap.bonds.types):
+            fene.params[bt] = dict(
+                k=30.0 * epsilon / sigma_bond**2,
+                r0=1.5 * sigma_bond,
+                epsilon=epsilon,
+                sigma=sigma_bond,
+                delta=0.0,
+            )
+        forces.append(fene)
+
+    # Tabulated angle from a sampled bond-angle distribution.
+    if angle_sampler is not None and snap.angles.N > 0:
+        _, U, tau = angle_table_from_sampler(angle_sampler, table_width)
+        angle = hoomd.md.angle.Table(width=len(U))
+        for angle_type in set(snap.angles.types):
+            angle.params[angle_type] = dict(U=U, tau=tau)
+        forces.append(angle)
+
+    # Tabulated dihedral from a sampled dihedral distribution.
+    if dihedral_sampler is not None and snap.dihedrals.N > 0:
+        _, U, tau = dihedral_table_from_sampler(dihedral_sampler, table_width)
+        dihedral = hoomd.md.dihedral.Table(width=len(U))
+        for dih_type in set(snap.dihedrals.types):
+            dihedral.params[dih_type] = dict(U=U, tau=tau)
+        forces.append(dihedral)
+
+    return forces
+
+
+def angle_table_from_sampler(sampler, n_bins=100, jacobian=True, n_samples=500_000):
+    """Boltzmann-invert an AnglesSampler into a tabulated angle potential.
+    The Boltzmann-inversion assumes kT = 1.0
+
+    Parameters
+    ----------
+    sampler : mbuild.path.points.AnglesSampler
+        Provides sampled bond angles (radians) via sampler.sample(size).
+    n_bins : int, default 100
+        Number of evenly spaced theta points from 0 to pi.
+    jacobian : bool, default True
+        Divide the sampled density by sin(theta) before inverting, so that an
+        MD angle distribution reproduces the sampled one.
+    n_samples : int, default 500000
+        Number of angles drawn to estimate the distribution.
+
+    Returns
+    -------
+    theta, U, tau : numpy.ndarray
+        Grid (radians), potential energy, and torque (-dU/dtheta), each of
+        length n_bins, ready for hoomd.md.angle.Table.
+    """
+    theta = np.linspace(0.0, math.pi, n_bins)
+    samples = np.clip(
+        np.asarray(sampler.sample(size=n_samples), dtype=float), 0.0, math.pi
+    )
+    density, edges = np.histogram(
+        samples, bins=n_bins, range=(0.0, math.pi), density=True
+    )
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    prob = np.interp(theta, centers, density)
+
+    prob = np.maximum(prob, prob.max() * 1e-8)
+    if jacobian:
+        prob = prob / np.clip(np.sin(theta), 1e-6, None)
+
+    # Assuming kT=1.
+    # TODO: Possibly add kT parameter for paramaterized Boltzmann sampling.
+    U = -1 * np.log(prob)
+
+    # Beyond the sampled range the density is noise, and dividing it by a small
+    # sin(theta) can produce wells at theta = 0 or pi. Force U to rise
+    # monotonically toward each pole outside the sample quantiles.
+    q_lo, q_hi = np.quantile(samples, [0.005, 0.995])
+    lo = int(np.searchsorted(theta, q_lo))
+    hi = int(np.searchsorted(theta, q_hi))
+    for i in range(lo - 1, -1, -1):
+        U[i] = max(U[i], U[i + 1])
+    for i in range(hi, n_bins):
+        U[i] = max(U[i], U[i - 1])
+
+    U -= U.min()
+    tau = -np.gradient(U, theta)
+    return theta, U, tau
+
+
+def dihedral_table_from_sampler(sampler, n_bins=100, n_samples=500_000):
+    """Boltzmann-invert a dihedral-angle sampler into a tabulated potential.
+    The Boltzmann-inversion assumes kT = 1.0
+
+    Parameters
+    ----------
+    sampler : object with a sample(size) method
+        Provides sampled dihedral angles (radians) in [-pi, pi].
+    n_bins : int, default 100
+        Number of evenly spaced phi points from -pi to pi.
+    n_samples : int, default 500000
+        Number of angles drawn to estimate the distribution.
+
+    Returns
+    -------
+    phi, U, tau : numpy.ndarray
+        Grid (radians), potential energy, and torque (-dU/dphi), each of
+        length n_bins, ready for hoomd.md.dihedral.Table.
+    """
+    phi = np.linspace(-math.pi, math.pi, n_bins)
+    samples = np.clip(
+        np.asarray(sampler.sample(size=n_samples), dtype=float), -math.pi, math.pi
+    )
+    density, edges = np.histogram(
+        samples, bins=n_bins, range=(-math.pi, math.pi), density=True
+    )
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    prob = np.interp(phi, centers, density)
+
+    prob = np.maximum(prob, prob.max() * 1e-8)
+    # Assuming kT=1. TODO: Possibly add kT parameter for Boltzmann sampling.
+    U = -1 * np.log(prob)
+    U -= U.min()
+    tau = -np.gradient(U, phi)
+    return phi, U, tau
+
+
+def _mean_bond_length(path):
+    """Return the mean center-to-center distance over the path's bonds.
+
+    Parameters
+    ----------
+    path : mbuild.path.build.Path
+        Path whose coordinates and bond_graph define the bonds.
+
+    Returns
+    -------
+    float
+        Mean bond length over every edge in the bond graph.
+
+    Raises
+    ------
+    ValueError
+        If the path has no bonds, so no length can be derived. Pass radius
+        and bond_length explicitly through build_path_ff instead.
+    """
+    coords = np.asarray(path.coordinates)
+    edges = list(path.bond_graph.edges())
+    if not edges:
+        raise ValueError(
+            "Cannot derive a bond length from a path with no bonds. "
+            "Use build_path_ff with explicit radius and bond_length."
+        )
+    lengths = [float(np.linalg.norm(coords[u] - coords[v])) for u, v in edges]
+    return float(np.mean(lengths))

--- a/mbuild/utils/simulation/path_forces.py
+++ b/mbuild/utils/simulation/path_forces.py
@@ -13,10 +13,11 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-TWO_POW_1_6 = 2.0 ** (1.0 / 6.0)
-
 # Kremer-Grest equilibrium bond length as a fraction of the WCA sigma.
 KG_BOND_SIGMA_RATIO = 0.97
+
+# Used as default r_cut to give purely repulsive (WCA)
+TWO_POW_1_6 = 2.0 ** (1.0 / 6.0)
 
 
 class PathForcefield:
@@ -24,24 +25,37 @@ class PathForcefield:
 
     Passed to a simulation in place of a chemical forcefield to override the
     geometry-derived defaults. Any value left None falls back to its geometric
-    default: the mean bond length, radius = bond_length / 0.97, and no angle or
-    dihedral term.
+    default: per-type bond lengths sampled from the system, per-bead-type radii
+    from those lengths, and no angle or dihedral term.
+
+    Each parameter may be a single value applied to every type, or a dict for
+    per-type parameterization keyed by the type names of the built system (its
+    gmso/HOOMD snapshot types), for example radius={"A": 0.5, "B": 0.8} and
+    bond_length={"A-B": 0.3}. radius keys are bead-type names; bond_length,
+    angles and dihedrals keys are the bond/angle/dihedral-type names gmso
+    assigns (sorted bead names joined by "-", e.g. "A-B", "A-B-A"). radius and
+    bond_length dicts must cover every type; an angles/dihedrals dict need only
+    cover the types it should act on.
 
     Parameters
     ----------
-    radius : float or None, default None
-        WCA sigma (bead exclusion diameter, center-to-center).
-    bond_length : float or None, default None
-        Target bond length for the FENE+WCA bond.
-    angles : mbuild.path.points.AnglesSampler or None, default None
-        Optional bond-angle distribution for a tabulated angle potential.
-    dihedrals : object or None, default None
-        Optional dihedral distribution for a tabulated dihedral potential.
+    radius : float or dict or None, default None
+        WCA sigma (bead exclusion diameter, center-to-center), keyed by bead
+        type. Unlike-pair sigma is the arithmetic mean of the two bead radii.
+    bond_length : float or dict or None, default None
+        Target bond length for the FENE+WCA bond, keyed by bond-type name.
+    angles : mbuild.path.points.AnglesSampler or dict or None, default None
+        Optional bond-angle distribution(s) for a tabulated angle potential,
+        keyed by angle-type name.
+    dihedrals : object or dict or None, default None
+        Optional dihedral distribution(s) for a tabulated dihedral potential,
+        keyed by dihedral-type name.
     epsilon : float, default 1.0
         Energy scale for the WCA and FENE potentials.
-    per_type : dict or None, default None
-        Reserved for future per-bead-type parameters, e.g.
-        {bead_type: {"radius": ..., "bond_length": ...}}. Not yet used.
+    r_cut : float, default 2**(1/6)
+        Pair cutoff in units of sigma. The default gives purely repulsive
+        WCA/KG pairs; larger values include the attractive portion of the LJ
+        well, which helps close excluded-volume voids during relaxation.
     """
 
     def __init__(
@@ -51,65 +65,86 @@ class PathForcefield:
         angles=None,
         dihedrals=None,
         epsilon=1.0,
-        per_type=None,
+        r_cut=TWO_POW_1_6,
     ):
         self.radius = radius
         self.bond_length = bond_length
         self.angles = angles
         self.dihedrals = dihedrals
         self.epsilon = epsilon
-        self.per_type = per_type
+        self.r_cut = r_cut
 
 
 def generate_ff_from_path(
-    path,
     snap,
     radius=None,
     bond_length=None,
     angles_sampler=None,
     dihedrals_sampler=None,
     epsilon=1.0,
+    r_cut=TWO_POW_1_6,
 ):
-    """Build a coarse forcefield for a path from its geometry.
+    """Build a coarse Kremer-Grest forcefield from a system snapshot.
 
-    When not given explicitly, the bond length is the mean over the path's
-    bonds and the bead radius follows the Kremer-Grest relation l0 = sigma * 0.97
-    Angle and dihedral terms are added only when a sampler is supplied.
+    Resolves each parameter against the snapshot's type names and passes fully
+    keyed dicts to build_path_ff. A scalar is broadcast to every type; None is
+    auto-derived from the snapshot geometry (per-bond-type median lengths, and
+    per-bead-type radii from the incident bond lengths via bond_l = sigma * 0.97);
+    a dict is used as given, keyed by type name. Angle and dihedral terms are
+    added only when a sampler is supplied.
 
     Parameters
     ----------
-    path : mbuild.path.build.Path
-        Path providing the geometry the bond length is derived from.
     snap : gsd.hoomd.Frame
-        Snapshot providing particle, bond, angle, and dihedral type names.
-    radius : float or None, default None
-        WCA sigma. If None, derived from bond_length via the Kremer-Grest
-        relation.
-    bond_length : float or None, default None
-        Target bond length. If None, the mean over the path's bonds is used.
-    angles_sampler : mbuild.path.points.AnglesSampler or None, default None
-        Optional bond-angle distribution for a tabulated angle potential.
-    dihedrals_sampler : object or None, default None
-        Optional dihedral distribution for a tabulated dihedral potential.
+        Snapshot providing the particle, bond, angle, and dihedral types and
+        the geometry the defaults are derived from.
+    radius : float or dict or None, default None
+        WCA sigma, keyed by bead type. If None, derived from incident bonds.
+    bond_length : float or dict or None, default None
+        Target bond length, keyed by bond-type name. If None, per-bond-type
+        medians over the snapshot's bonds are used.
+    angles_sampler : mbuild.path.points.AnglesSampler or dict or None, default None
+        Optional bond-angle distribution(s), keyed by angle-type name.
+    dihedrals_sampler : object or dict or None, default None
+        Optional dihedral distribution(s), keyed by dihedral-type name.
     epsilon : float, default 1.0
         Energy scale for the WCA and FENE potentials.
+    r_cut : float, default 2**(1/6)
+        Pair cutoff in units of sigma. The default gives purely repulsive
+        WCA/KG pairs; larger values include the attractive portion of the well.
+
+    Notes
+    -----
+    Using the default values gives a Kremer-Grest bead-spring model with a purely
+    repulsive and shifted pair force (WCA), FENE bonds, and no angle or dihedral forces.
+    To include attractive portions of the LJ force, use larger values of r_cut.
 
     Returns
     -------
     list
         HOOMD force objects, as returned by build_path_ff.
     """
-    if bond_length is None:
-        bond_length = _mean_bond_length(path)
-    if radius is None:
-        radius = bond_length / KG_BOND_SIGMA_RATIO
+    radius = _resolve_param(
+        radius, list(snap.particles.types or []), "radius", lambda: _auto_radii(snap)
+    )
+    bond_length = _resolve_param(
+        bond_length,
+        list(snap.bonds.types or []),
+        "bond_length",
+        lambda: _auto_bond_lengths(snap),
+    )
+    angle_sampler = _resolve_sampler(angles_sampler, list(snap.angles.types or []))
+    dihedral_sampler = _resolve_sampler(
+        dihedrals_sampler, list(snap.dihedrals.types or [])
+    )
     return build_path_ff(
         snap,
         radius=radius,
         bond_length=bond_length,
-        angle_sampler=angles_sampler,
-        dihedral_sampler=dihedrals_sampler,
+        angle_sampler=angle_sampler,
+        dihedral_sampler=dihedral_sampler,
         epsilon=epsilon,
+        r_cut=r_cut,
     )
 
 
@@ -121,60 +156,77 @@ def build_path_ff(
     dihedral_sampler=None,
     epsilon=1.0,
     table_width=100,
+    r_cut=TWO_POW_1_6,
 ):
     """Build coarse Kremer-Grest HOOMD forces for a bead path.
 
-    Every bead, bond, angle and dihedral type in the
-    snapshot receives the same corresponding parameters.
+    All parameters are dicts keyed by the snapshot's own type names. radius is
+    keyed by bead (particle) type and bond_length by bond-type name, and both
+    must cover every type present. angle_sampler/dihedral_sampler are None or
+    dicts keyed by angle/dihedral-type name and may cover a subset (uncovered
+    types get a flat, zero table). LJ cross-pairs sigma is the arithmetic
+    mean of the two bead radii.
 
     Parameters
     ----------
     snap : gsd.hoomd.Frame
         Snapshot providing particle, bond, angle, and dihedral type names.
-    radius : float
-        WCA sigma (bead exclusion diameter, center-to-center).
-    bond_length : float
-        Target bond length, used to size the FENE+WCA bond.
-    angle_sampler : mbuild.path.points.AnglesSampler or None, default None
-        If given, a tabulated angle potential is Boltzmann-inverted from it.
-    dihedral_sampler : object or None, default None
-        If given, a tabulated dihedral potential is Boltzmann-inverted from it.
+    radius : dict
+        {bead_type: WCA sigma}, the center-to-center bead exclusion diameter.
+    bond_length : dict
+        {bond_type: target bond length}, used to size the FENE+WCA bond.
+    angle_sampler : dict or None, default None
+        {angle_type: sampler}; each is Boltzmann-inverted into a tabulated term.
+    dihedral_sampler : dict or None, default None
+        {dihedral_type: sampler}, Boltzmann-inverted into a tabulated term.
     epsilon : float, default 1.0
         Energy scale for the WCA and FENE potentials.
     table_width : int, default 100
         Resolution of the tabulated angle and dihedral potentials.
+    r_cut : float, default 2**(1/6)
+        Pair cutoff in units of sigma (per-pair cutoff is r_cut * sigma_ij).
+        The default truncates at the LJ minimum for purely repulsive pairs
+        (WCA/KG); larger values include the attractive portion of the LJ well.
 
     Returns
     -------
     list
-        HOOMD force objects: [WCA pairs, FENE+WCA bonds, (angle), (dihedral)].
+        HOOMD force objects: [LJ pairs, FENE+WCA bonds, (angle), (dihedral)].
     """
     import hoomd
 
     forces = []
+    ptypes = list(snap.particles.types)
 
-    # WCA excluded volume between non-bonded beads. 1-2 pairs are excluded and
-    # handled by the bond's own WCA term.
-    r_cut = TWO_POW_1_6 * radius
     nlist = hoomd.md.nlist.Cell(buffer=0.2, exclusions=("bond",))
-    wca = hoomd.md.pair.LJ(nlist=nlist, default_r_cut=r_cut, mode="shift")
-    ptypes = list(set(snap.particles.types))
+    lj = hoomd.md.pair.LJ(
+        nlist=nlist, default_r_cut=r_cut * max(radius.values()), mode="shift"
+    )
     for i, t1 in enumerate(ptypes):
         for t2 in ptypes[i:]:
-            wca.params[(t1, t2)] = dict(sigma=radius, epsilon=epsilon)
-    forces.append(wca)
+            sigma_ij = 0.5 * (radius[t1] + radius[t2])
+            lj.params[(t1, t2)] = dict(sigma=sigma_ij, epsilon=epsilon)
+            lj.r_cut[(t1, t2)] = r_cut * sigma_ij
+    forces.append(lj)
 
     if snap.bonds.N > 0:
-        sigma_bond = bond_length
-        if bond_length > 1.33 * radius:
-            logger.warning(
-                "build_path_ff: bond_length (%.3g) exceeds ~1.33*radius (%.3g); "
-                "FENE+WCA no longer guarantees non-crossing bonds.",
-                bond_length,
-                radius,
-            )
+        ptypeid = np.asarray(snap.particles.typeid)
+        group = np.asarray(snap.bonds.group)
+        btypeid = np.asarray(snap.bonds.typeid)
         fene = hoomd.md.bond.FENEWCA()
-        for bt in set(snap.bonds.types):
+        for i, bt in enumerate(snap.bonds.types):
+            sigma_bond = bond_length[bt]
+            a, b = group[np.argmax(btypeid == i)]
+            sigma_pair = 0.5 * (radius[ptypes[ptypeid[a]]] + radius[ptypes[ptypeid[b]]])
+            if sigma_bond > 1.33 * sigma_pair:
+                logger.warning(
+                    "build_path_ff: bond_length (%.3g) for %s exceeds "
+                    "~1.33*radius (%.3g); FENE+WCA no longer guarantees "
+                    "non-crossing bonds.",
+                    sigma_bond,
+                    bt,
+                    sigma_pair,
+                )
             fene.params[bt] = dict(
                 k=30.0 * epsilon / sigma_bond**2,
                 r0=1.5 * sigma_bond,
@@ -184,23 +236,120 @@ def build_path_ff(
             )
         forces.append(fene)
 
-    # Tabulated angle from a sampled bond-angle distribution.
-    if angle_sampler is not None and snap.angles.N > 0:
-        _, U, tau = angle_table_from_sampler(angle_sampler, table_width)
-        angle = hoomd.md.angle.Table(width=len(U))
-        for angle_type in set(snap.angles.types):
-            angle.params[angle_type] = dict(U=U, tau=tau)
+    # Tabulated angle(s). Types the sampler dict does not cover get a flat
+    # (zero) table so HOOMD sees every angle type specified.
+    if angle_sampler and snap.angles.N > 0:
+        angle = hoomd.md.angle.Table(width=table_width)
+        for at in snap.angles.types:
+            if at in angle_sampler:
+                _, U, tau = angle_table_from_sampler(angle_sampler[at], table_width)
+            else:
+                U = tau = np.zeros(table_width)
+            angle.params[at] = dict(U=U, tau=tau)
         forces.append(angle)
 
-    # Tabulated dihedral from a sampled dihedral distribution.
-    if dihedral_sampler is not None and snap.dihedrals.N > 0:
-        _, U, tau = dihedral_table_from_sampler(dihedral_sampler, table_width)
-        dihedral = hoomd.md.dihedral.Table(width=len(U))
-        for dih_type in set(snap.dihedrals.types):
-            dihedral.params[dih_type] = dict(U=U, tau=tau)
+    if dihedral_sampler and snap.dihedrals.N > 0:
+        dihedral = hoomd.md.dihedral.Table(width=table_width)
+        for dt in snap.dihedrals.types:
+            if dt in dihedral_sampler:
+                _, U, tau = dihedral_table_from_sampler(
+                    dihedral_sampler[dt], table_width
+                )
+            else:
+                U = tau = np.zeros(table_width)
+            dihedral.params[dt] = dict(U=U, tau=tau)
         forces.append(dihedral)
 
     return forces
+
+
+def _resolve_param(value, type_names, label, auto_fn):
+    """Resolve radius/bond_length to a {type_name: float} dict over every type.
+
+    None auto-derives from the snapshot; a scalar broadcasts to all types; a
+    dict is used as given and must cover every type name.
+    """
+    if value is None:
+        return auto_fn()
+    if isinstance(value, dict):
+        missing = [t for t in type_names if t not in value]
+        if missing:
+            raise KeyError(f"{label} has no entry for type(s) {missing}.")
+        return {t: float(value[t]) for t in type_names}
+    return {t: float(value) for t in type_names}
+
+
+def _resolve_sampler(sampler, type_names):
+    """Resolve a sampler (or dict of them) to a {type_name: sampler} dict, or None.
+
+    A single sampler broadcasts to every type; a dict is used as given (keyed
+    by type name) and may cover only the types it should act on.
+    """
+    if sampler is None:
+        return None
+    if isinstance(sampler, dict):
+        return {t: sampler[t] for t in type_names if t in sampler} or None
+    return {t: sampler for t in type_names}
+
+
+def _bond_lengths(snap):
+    """Per-bond center-to-center lengths from the snapshot, minimum-imaged.
+
+    Assumes an orthorhombic box: only the Lx/Ly/Lz box lengths are used and any
+    triclinic tilt factors are ignored (paths produce orthorhombic boxes). The
+    minimum image also assumes bonds shorter than half the box.
+    """
+    pos = np.asarray(snap.particles.position)
+    group = np.asarray(snap.bonds.group)
+    d = pos[group[:, 0]] - pos[group[:, 1]]
+    box = np.asarray(snap.configuration.box[:3], dtype=float)
+    periodic = box > 0
+    d[:, periodic] -= box[periodic] * np.round(d[:, periodic] / box[periodic])
+    return np.linalg.norm(d, axis=1)
+
+
+def _auto_bond_lengths(snap):
+    """{bond_type: median length} from the snapshot geometry.
+
+    The median (not the mean) is robust to bonds that wrap across a periodic
+    boundary whose true period is not the snapshot box, which appear as a few
+    large outliers and would otherwise inflate the sampled length.
+    """
+    if snap.bonds.N == 0:
+        return {}
+    lengths = _bond_lengths(snap)
+    btypeid = np.asarray(snap.bonds.typeid)
+    return {
+        bt: float(np.median(lengths[btypeid == i]))
+        for i, bt in enumerate(snap.bonds.types)
+    }
+
+
+def _auto_radii(snap):
+    """{bead_type: radius} from median incident bond length via l0 = sigma * 0.97.
+
+    Uses the median for robustness to periodic-wrap bonds (see
+    _auto_bond_lengths). Bead types with no incident bond fall back to the
+    overall median length.
+    """
+    if snap.bonds.N == 0:
+        raise ValueError(
+            "Cannot derive radii from a system with no bonds. "
+            "Pass radius (and bond_length) explicitly."
+        )
+    lengths = _bond_lengths(snap)
+    group = np.asarray(snap.bonds.group)
+    ptypeid = np.asarray(snap.particles.typeid)
+    ptypes = list(snap.particles.types)
+    incident = {t: [] for t in ptypes}
+    for (a, b), length in zip(group, lengths):
+        incident[ptypes[ptypeid[a]]].append(length)
+        incident[ptypes[ptypeid[b]]].append(length)
+    fallback = float(np.median(lengths))
+    return {
+        t: (float(np.median(v)) if v else fallback) / KG_BOND_SIGMA_RATIO
+        for t, v in incident.items()
+    }
 
 
 def angle_table_from_sampler(sampler, n_bins=100, jacobian=True, n_samples=500_000):
@@ -239,7 +388,7 @@ def angle_table_from_sampler(sampler, n_bins=100, jacobian=True, n_samples=500_0
     if jacobian:
         prob = prob / np.clip(np.sin(theta), 1e-6, None)
 
-    # Assuming kT=1.
+    # U(theta) = -kTlog(P(theta)) --> Assume kT = 1
     # TODO: Possibly add kT parameter for paramaterized Boltzmann sampling.
     U = -1 * np.log(prob)
 

--- a/mbuild/utils/simulation/path_forces.py
+++ b/mbuild/utils/simulation/path_forces.py
@@ -149,10 +149,6 @@ def build_path_ff(
     list
         HOOMD force objects: [WCA pairs, FENE+WCA bonds, (angle), (dihedral)].
     """
-    # TODO: Add a backend arg ("hoomd"/"openmm") like uff_forces so
-    # OpenMMSimulation can consume the same PathForcefield: WCA via
-    # CustomNonbondedForce, FENE via CustomBondForce, tables via Discrete/
-    # tabulated potentials.
     import hoomd
 
     forces = []

--- a/mbuild/utils/simulation/uff.py
+++ b/mbuild/utils/simulation/uff.py
@@ -34,25 +34,25 @@ G_ANGLE = 664.12  # angle force-constant prefactor, kcal/mol
 _COLS = ("r1", "theta0", "x1", "D1", "Zstar", "Vi", "Uj", "chi")
 _TABLE = {
     #  label      r1     theta0   x1      D1     Zstar   Vi     Uj    chi
-    "H_":     (0.354, 180.00, 2.886, 0.044, 0.712, 0.000, 0.0, 4.528),
-    "C_3":    (0.757, 109.47, 3.851, 0.105, 1.912, 2.119, 2.0, 5.343),
-    "C_R":    (0.729, 120.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
-    "C_2":    (0.732, 120.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
-    "C_1":    (0.706, 180.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
-    "N_3":    (0.700, 106.70, 3.660, 0.069, 2.544, 0.450, 2.0, 6.899),
-    "N_R":    (0.699, 120.00, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
-    "N_2":    (0.685, 111.20, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
-    "N_1":    (0.656, 180.00, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
-    "O_3":    (0.658, 104.51, 3.500, 0.060, 2.300, 0.018, 2.0, 8.741),
-    "O_R":    (0.680, 110.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
-    "O_2":    (0.634, 120.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
-    "O_1":    (0.639, 180.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
-    "F_":     (0.668, 180.00, 3.364, 0.050, 1.735, 0.000, 2.0, 10.874),
-    "Cl":     (1.044, 180.00, 3.947, 0.227, 2.348, 0.000, 2.0, 8.564),
-    "Br":     (1.192, 180.00, 4.189, 0.251, 2.519, 0.000, 2.0, 7.790),
-    "I_":     (1.382, 180.00, 4.500, 0.339, 2.650, 0.000, 2.0, 6.822),
-    "S_3+2":  (1.064, 92.10, 4.035, 0.274, 2.703, 0.484, 2.0, 6.928),
-    "P_3+3":  (1.101, 93.80, 4.147, 0.305, 2.863, 2.400, 2.0, 5.463),
+    "H_": (0.354, 180.00, 2.886, 0.044, 0.712, 0.000, 0.0, 4.528),
+    "C_3": (0.757, 109.47, 3.851, 0.105, 1.912, 2.119, 2.0, 5.343),
+    "C_R": (0.729, 120.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
+    "C_2": (0.732, 120.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
+    "C_1": (0.706, 180.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
+    "N_3": (0.700, 106.70, 3.660, 0.069, 2.544, 0.450, 2.0, 6.899),
+    "N_R": (0.699, 120.00, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
+    "N_2": (0.685, 111.20, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
+    "N_1": (0.656, 180.00, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
+    "O_3": (0.658, 104.51, 3.500, 0.060, 2.300, 0.018, 2.0, 8.741),
+    "O_R": (0.680, 110.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
+    "O_2": (0.634, 120.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
+    "O_1": (0.639, 180.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
+    "F_": (0.668, 180.00, 3.364, 0.050, 1.735, 0.000, 2.0, 10.874),
+    "Cl": (1.044, 180.00, 3.947, 0.227, 2.348, 0.000, 2.0, 8.564),
+    "Br": (1.192, 180.00, 4.189, 0.251, 2.519, 0.000, 2.0, 7.790),
+    "I_": (1.382, 180.00, 4.500, 0.339, 2.650, 0.000, 2.0, 6.822),
+    "S_3+2": (1.064, 92.10, 4.035, 0.274, 2.703, 0.484, 2.0, 6.928),
+    "P_3+3": (1.101, 93.80, 4.147, 0.305, 2.863, 2.400, 2.0, 5.463),
 }
 UFF_PARAMS = {label: dict(zip(_COLS, vals)) for label, vals in _TABLE.items()}
 
@@ -219,8 +219,8 @@ def _bond_rest_length(ti, tj, order):
     r_bo = -LAMBDA * (ri + rj) * math.log(order)
     # Electronegativity correction (Rappe eq. 4).
     chi_i, chi_j = pi["chi"], pj["chi"]
-    r_en = ri * rj * (math.sqrt(chi_i) - math.sqrt(chi_j)) ** 2 / (
-        chi_i * ri + chi_j * rj
+    r_en = (
+        ri * rj * (math.sqrt(chi_i) - math.sqrt(chi_j)) ** 2 / (chi_i * ri + chi_j * rj)
     )
     return ri + rj + r_bo - r_en
 
@@ -358,7 +358,9 @@ def _hoomd_forces(top, snap, order_map, r_cut):
                 logger.warning(
                     "UFF: skipping linear angle type %s-%s-%s (theta0=180); the "
                     "lean harmonic approximation cannot represent it.",
-                    ti, tj, tk,
+                    ti,
+                    tj,
+                    tk,
                 )
                 seen.update({(ti, tj, tk), (tk, tj, ti)})
                 continue
@@ -381,11 +383,12 @@ def _hoomd_forces(top, snap, order_map, r_cut):
         seen = set()
         for dih in top.dihedrals:
             m0, m1, m2, m3 = dih.connection_members
-            i, j, k_idx, ll = (
-                site_idx[m0], site_idx[m1], site_idx[m2], site_idx[m3]
-            )
+            i, j, k_idx, ll = (site_idx[m0], site_idx[m1], site_idx[m2], site_idx[m3])
             ti, tj, tk, tl = (
-                sites[i].name, sites[j].name, sites[k_idx].name, sites[ll].name
+                sites[i].name,
+                sites[j].name,
+                sites[k_idx].name,
+                sites[ll].name,
             )
             if (ti, tj, tk, tl) in seen:
                 continue
@@ -461,9 +464,7 @@ def _openmm_forces(top, order_map, r_cut):
     vdw.addPerParticleParameter("epsilon")
     for s in sites:
         p = UFF_PARAMS[s.name]
-        vdw.addParticle(
-            [p["x1"] / two_pow * ANG_TO_NM, p["D1"] * KCAL_TO_KJ]
-        )
+        vdw.addParticle([p["x1"] / two_pow * ANG_TO_NM, p["D1"] * KCAL_TO_KJ])
     # UFF computes vdW for atoms >= 3 bonds apart: exclude 1-2 and 1-3.
     vdw.createExclusionsFromBonds([(i, j) for (i, j) in order_map], 2)
     if top.box is not None:
@@ -482,16 +483,12 @@ def _openmm_forces(top, order_map, r_cut):
             ti, tj = sites[i].name, sites[j].name
             r_ij = _bond_rest_length(ti, tj, order_between(i, j))
             k = _bond_force_constant(ti, tj, r_ij)
-            bond_force.addBond(
-                i, j, r_ij * ANG_TO_NM, k * BOND_K_TO_KJ_NM2
-            )
+            bond_force.addBond(i, j, r_ij * ANG_TO_NM, k * BOND_K_TO_KJ_NM2)
         forces.append(bond_force)
 
     # --- Angles (exact UFF cosine-Fourier, + linear form) ---------------------
     if top.n_angles > 0:
-        general = openmm.CustomAngleForce(
-            "K*(C0 + C1*cos(theta) + C2*cos(2*theta))"
-        )
+        general = openmm.CustomAngleForce("K*(C0 + C1*cos(theta) + C2*cos(2*theta))")
         for name in ("K", "C0", "C1", "C2"):
             general.addPerAngleParameter(name)
         linear = openmm.CustomAngleForce("K*(1 + cos(theta))")
@@ -529,9 +526,7 @@ def _openmm_forces(top, order_map, r_cut):
         torsion = openmm.PeriodicTorsionForce()
         for dih in top.dihedrals:
             m0, m1, m2, m3 = dih.connection_members
-            i, j, k_idx, ll = (
-                site_idx[m0], site_idx[m1], site_idx[m2], site_idx[m3]
-            )
+            i, j, k_idx, ll = (site_idx[m0], site_idx[m1], site_idx[m2], site_idx[m3])
             tj, tk = sites[j].name, sites[k_idx].name
             params = _torsion_params(tj, tk, order_between(j, k_idx))
             if params is None:
@@ -544,12 +539,8 @@ def _openmm_forces(top, order_map, r_cut):
             # OpenMM: k (1 + cos(n phi - phase)); k = 0.5 V,
             # phase = 0 when cos(n phi0) = -1 else pi.
             phase = 0.0 if cos_n_phi0 < 0 else math.pi
-            torsion.addTorsion(
-                i, j, k_idx, ll, n, phase, 0.5 * v * KCAL_TO_KJ
-            )
+            torsion.addTorsion(i, j, k_idx, ll, n, phase, 0.5 * v * KCAL_TO_KJ)
         if torsion.getNumTorsions() > 0:
             forces.append(torsion)
 
     return forces
-
-

--- a/mbuild/utils/simulation/uff.py
+++ b/mbuild/utils/simulation/uff.py
@@ -1,0 +1,555 @@
+"""Rule-based Universal Force Field (UFF) parameter generation for mBuild.
+
+Implements UFF (Rappe et al., *J. Am. Chem. Soc.* 1992, 114, 10024) as an
+on-the-fly generator: bonded and nonbonded parameters are computed directly
+from element + bond order. Hybridization and aromaticity are read from the
+bond-graph bond orders, not perceived from geometry or ring topology.
+
+References
+----------
+Rappe, Casewit, Colwell, Goddard, Skiff. *J. Am. Chem. Soc.* 1992, 114, 10024.
+Parameter values follow the canonical UFF table as distributed with Open Babel.
+"""
+
+import logging
+import math
+
+logger = logging.getLogger(__name__)
+
+KCAL_TO_KJ = 4.184
+ANG_TO_NM = 0.1
+# kcal/mol/Ang^2 -> kJ/mol/nm^2  == 4.184 / 0.01
+BOND_K_TO_KJ_NM2 = KCAL_TO_KJ / (ANG_TO_NM**2)
+
+# UFF universal constants
+LAMBDA = 0.1332  # bond-order correction coefficient (Rappe eq. 3)
+G_BOND = 664.12  # bond force-constant prefactor, kcal/mol (== 2 * 332.06)
+G_ANGLE = 664.12  # angle force-constant prefactor, kcal/mol
+
+# UFF atom-type parameters (organic / main-group subset)
+# Columns: r1 (valence bond radius, Ang), theta0 (equilibrium angle, deg),
+#          x1 (vdW minimum distance r_min, Ang), D1 (vdW well depth, kcal/mol),
+#          Zstar (effective charge), Vi (sp3 torsional barrier, kcal/mol),
+#          Uj (sp2 torsional constant), chi (GMP electronegativity).
+_COLS = ("r1", "theta0", "x1", "D1", "Zstar", "Vi", "Uj", "chi")
+_TABLE = {
+    #  label      r1     theta0   x1      D1     Zstar   Vi     Uj    chi
+    "H_":     (0.354, 180.00, 2.886, 0.044, 0.712, 0.000, 0.0, 4.528),
+    "C_3":    (0.757, 109.47, 3.851, 0.105, 1.912, 2.119, 2.0, 5.343),
+    "C_R":    (0.729, 120.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
+    "C_2":    (0.732, 120.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
+    "C_1":    (0.706, 180.00, 3.851, 0.105, 1.912, 0.000, 2.0, 5.343),
+    "N_3":    (0.700, 106.70, 3.660, 0.069, 2.544, 0.450, 2.0, 6.899),
+    "N_R":    (0.699, 120.00, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
+    "N_2":    (0.685, 111.20, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
+    "N_1":    (0.656, 180.00, 3.660, 0.069, 2.544, 0.000, 2.0, 6.899),
+    "O_3":    (0.658, 104.51, 3.500, 0.060, 2.300, 0.018, 2.0, 8.741),
+    "O_R":    (0.680, 110.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
+    "O_2":    (0.634, 120.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
+    "O_1":    (0.639, 180.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
+    "F_":     (0.668, 180.00, 3.364, 0.050, 1.735, 0.000, 2.0, 10.874),
+    "Cl":     (1.044, 180.00, 3.947, 0.227, 2.348, 0.000, 2.0, 8.564),
+    "Br":     (1.192, 180.00, 4.189, 0.251, 2.519, 0.000, 2.0, 7.790),
+    "I_":     (1.382, 180.00, 4.500, 0.339, 2.650, 0.000, 2.0, 6.822),
+    "S_3+2":  (1.064, 92.10, 4.035, 0.274, 2.703, 0.484, 2.0, 6.928),
+    "P_3+3":  (1.101, 93.80, 4.147, 0.305, 2.863, 2.400, 2.0, 5.463),
+}
+UFF_PARAMS = {label: dict(zip(_COLS, vals)) for label, vals in _TABLE.items()}
+
+# Which UFF label to use per element, keyed by hybridization category derived
+# from bond order.  Elements with a single supported type ignore the category.
+_HYB_TYPES = {
+    "H": {"*": "H_"},
+    "C": {"sp3": "C_3", "sp2": "C_2", "ar": "C_R", "sp": "C_1"},
+    "N": {"sp3": "N_3", "sp2": "N_2", "ar": "N_R", "sp": "N_1"},
+    "O": {"sp3": "O_3", "sp2": "O_2", "ar": "O_R", "sp": "O_1"},
+    "F": {"*": "F_"},
+    "Cl": {"*": "Cl"},
+    "Br": {"*": "Br"},
+    "I": {"*": "I_"},
+    "S": {"*": "S_3+2"},
+    "P": {"*": "P_3+3"},
+}
+
+
+def uff_forces(top, snap, order_map, r_cut=1.0, backend="hoomd"):
+    """Generate UFF forces as backend-native force objects.
+
+    Requires the topology to already be UFF-typed and the snapshot built from
+    that typed topology, so their type strings stay consistent with the forces.
+
+    Parameters
+    ----------
+    top : gmso.Topology
+        UFF-typed topology with connections identified.
+    snap : gsd.hoomd.Frame
+        Snapshot built from the UFF-typed topology (types are UFF labels).
+    order_map : dict
+        ``(i, j) -> bond order`` map, as returned by :func:`assign_uff_types`.
+    r_cut : float, default 1.0
+        Nonbonded cutoff (nm).
+    backend : {"hoomd", "openmm"}, default "hoomd"
+        Force representation to emit.
+
+    Returns
+    -------
+    list
+        Backend-native force objects.
+    """
+    if backend == "hoomd":
+        return _hoomd_forces(top, snap, order_map, r_cut)
+
+    if backend == "openmm":
+        # snap is HOOMD-specific and unused here; OpenMM forces reference atom
+        # indices (site order), which the caller's System particles must match.
+        return _openmm_forces(top, order_map, r_cut)
+
+    raise ValueError(f"Unknown backend '{backend}'. Options: 'hoomd', 'openmm'.")
+
+
+class UFFTypingError(Exception):
+    """Raised when a compound cannot be typed with the lean UFF subset."""
+
+
+def assign_uff_types(top, compound):
+    """Type every site in a GMSO topology with a UFF atom-type label.
+
+    Sets ``site.name`` to the UFF label (e.g. ``"C_3"``) so that a GSD snapshot
+    built afterward carries UFF-consistent particle / bond / angle type strings.
+    Returns the per-index label list and an ``(i, j) -> order`` bond-order map.
+
+    Hybridization and aromaticity come from the bond-graph bond orders, so
+    aromatic bonds must be marked as such in the input to be typed as resonant.
+
+    Parameters
+    ----------
+    top : gmso.Topology
+        Topology whose sites are relabeled in place. Site order must match the
+        order of ``compound.particles()``.
+    compound : mb.Compound
+        Source of elements and bond orders (via ``compound.bond_graph``).
+    """
+    particles = list(compound.particles())
+    index_of = {p: i for i, p in enumerate(particles)}
+    n = len(particles)
+
+    # Numeric bond orders keyed by sorted index pair, plus per-atom order lists.
+    order_map = {}
+    atom_orders = {i: [] for i in range(n)}
+    assumed_single = False
+    for u, v, order in compound.bond_graph.edges.data("bond_order"):
+        num, assumed = _num_order(order)
+        assumed_single = assumed_single or assumed
+        i, j = index_of[u], index_of[v]
+        order_map[(min(i, j), max(i, j))] = num
+        atom_orders[i].append(num)
+        atom_orders[j].append(num)
+
+    if assumed_single:
+        logger.warning(
+            "UFF: one or more bonds had missing or unrecognized bond order; "
+            "assumed single bonds. Set bond_order for correct sp/sp2/sp3 and "
+            "resonance typing."
+        )
+
+    labels = []
+    for i, p in enumerate(particles):
+        element = getattr(p, "element", None)
+        if element is None or getattr(element, "symbol", None) is None:
+            raise UFFTypingError(
+                f"Particle {i} ('{p.name}') has no element set; UFF requires "
+                "elements. Build the compound with element information."
+            )
+        labels.append(_label_for(element.symbol, atom_orders[i]))
+
+    for site, label in zip(top.sites, labels):
+        site.name = label
+
+    return labels, order_map
+
+
+_ORDER_STRINGS = {"single": 1.0, "double": 2.0, "triple": 3.0, "aromatic": 1.5}
+
+
+def _num_order(order):
+    """Map an mBuild bond-order value to a numeric UFF bond order.
+
+    Returns (order, assumed), where assumed is True when the value was missing
+    or unrecognized and a single bond was substituted.
+    """
+    if order in (None, "unspecified", "default", 0.0):
+        return 1.0, True
+    if isinstance(order, str):
+        if order in _ORDER_STRINGS:
+            return _ORDER_STRINGS[order], False
+        return 1.0, True
+    return float(order), False
+
+
+def _hyb_category(orders):
+    """Classify hybridization from the set of bond orders on an atom."""
+    if any(abs(o - 1.5) < 1e-6 for o in orders):
+        return "ar"
+    max_order = max(orders) if orders else 1.0
+    if max_order >= 2.5:
+        return "sp"
+    if max_order >= 1.5:
+        return "sp2"
+    return "sp3"
+
+
+def _label_for(element_symbol, orders):
+    """Return the UFF atom-type label for an element + its bond orders."""
+    types = _HYB_TYPES.get(element_symbol)
+    if types is None:
+        raise UFFTypingError(
+            f"Element '{element_symbol}' is not in the lean UFF subset. "
+            f"Supported: {sorted(_HYB_TYPES)}."
+        )
+    if "*" in types:
+        return types["*"]
+    return types[_hyb_category(orders)]
+
+
+def _bond_rest_length(ti, tj, order):
+    """UFF natural bond length r_ij (Angstrom) for types ti, tj at bond order."""
+    pi, pj = UFF_PARAMS[ti], UFF_PARAMS[tj]
+    ri, rj = pi["r1"], pj["r1"]
+    # Bond-order correction (Rappe eq. 3).
+    r_bo = -LAMBDA * (ri + rj) * math.log(order)
+    # Electronegativity correction (Rappe eq. 4).
+    chi_i, chi_j = pi["chi"], pj["chi"]
+    r_en = ri * rj * (math.sqrt(chi_i) - math.sqrt(chi_j)) ** 2 / (
+        chi_i * ri + chi_j * rj
+    )
+    return ri + rj + r_bo - r_en
+
+
+def _bond_force_constant(ti, tj, r_ij):
+    """UFF bond force constant (kcal/mol/Ang^2) for E = 0.5 k (r - r_ij)^2."""
+    return G_BOND * UFF_PARAMS[ti]["Zstar"] * UFF_PARAMS[tj]["Zstar"] / r_ij**3
+
+
+def _angle_force_constant(ti, tj, tk, r_ij, r_jk, theta0):
+    """UFF angle force constant (kcal/mol/rad^2), == curvature at theta0.
+
+    ``theta0`` is in radians. Equal to the second derivative of the UFF
+    cosine-Fourier angle term at equilibrium, i.e. the harmonic stiffness.
+    """
+    c = math.cos(theta0)
+    r_ik2 = r_ij**2 + r_jk**2 - 2.0 * r_ij * r_jk * c  # law of cosines
+    zi, zk = UFF_PARAMS[ti]["Zstar"], UFF_PARAMS[tk]["Zstar"]
+    return (
+        G_ANGLE
+        * (zi * zk / r_ik2**2.5)
+        * r_ij
+        * r_jk
+        * (3.0 * r_ij * r_jk * (1.0 - c * c) - r_ik2 * c)
+    )
+
+
+def _hyb_of(label):
+    """Return 'sp3' | 'sp2' | 'sp' | None from a UFF label suffix."""
+    if label.endswith("_3") or label.endswith("+2") or label.endswith("+3"):
+        return "sp3"
+    if label.endswith("_2") or label.endswith("_R"):
+        return "sp2"
+    if label.endswith("_1"):
+        return "sp"
+    return None
+
+
+def _torsion_params(tj, tk, order_jk):
+    """UFF torsion parameters for the central bond j-k.
+
+    Returns ``(V, n, cos_n_phi0)`` in kcal/mol, or ``None`` if the case is
+    outside the lean subset. ``V`` is the *total* barrier before dividing by
+    the number of torsions about the bond.
+    """
+    hj, hk = _hyb_of(tj), _hyb_of(tk)
+    vj, vk = UFF_PARAMS[tj], UFF_PARAMS[tk]
+
+    if hj == "sp3" and hk == "sp3":
+        # n = 3, phi0 = 180 deg -> cos(n phi0) = -1.
+        return math.sqrt(vj["Vi"] * vk["Vi"]), 3, -1.0
+    if {hj, hk} == {"sp2", "sp3"}:
+        # Single bond, one sp2 one sp3: n = 6, phi0 = 0 -> cos = +1, V = 1.0.
+        return 1.0, 6, 1.0
+    if hj == "sp2" and hk == "sp2":
+        # Conjugated / double bond: n = 2, phi0 = 180 -> cos = +1.
+        v = 5.0 * math.sqrt(vj["Uj"] * vk["Uj"]) * (1.0 + 4.18 * math.log(order_jk))
+        return v, 2, 1.0
+    return None  # sp centers, group-16 specials, etc.not currently handled.
+
+
+def _set_both(force, type_tuple, params, seen):
+    """Register ``params`` on a HOOMD force under a type string and its reverse.
+
+    The GSD snapshot's connection type-string ordering is not guaranteed to
+    match ours; UFF bonded terms are symmetric under member reversal, so setting
+    both orientations guarantees a match without changing any parameter value.
+    """
+    forward = "-".join(type_tuple)
+    reverse = "-".join(type_tuple[::-1])
+    force.params[forward] = params
+    if reverse != forward:
+        force.params[reverse] = params
+    seen.update({type_tuple, type_tuple[::-1]})
+
+
+def _hoomd_forces(top, snap, order_map, r_cut):
+    """Build UFF HOOMD forces from a UFF-typed topology + snapshot."""
+    import hoomd
+
+    sites = list(top.sites)
+    site_idx = {s: i for i, s in enumerate(sites)}
+
+    def order_between(i, j):
+        return order_map.get((min(i, j), max(i, j)), 1.0)
+
+    particle_types = list(set(snap.particles.types))
+    # UFF computes vdW for atoms >= 3 bonds apart: exclude 1-2 (bond) and 1-3
+    # neighbors; 1-4 and beyond are included at full strength (UFF does not
+    # scale 1-4, unlike OPLS). HOOMD's default nlist excludes only 'bond'.
+    nlist = hoomd.md.nlist.Cell(buffer=0.4, exclusions=("bond", "1-3"))
+    lj = hoomd.md.pair.LJ(nlist=nlist, default_r_cut=r_cut)
+    two_pow = 2.0 ** (1.0 / 6.0)
+    for a, t1 in enumerate(particle_types):
+        for t2 in particle_types[a:]:
+            x1, x2 = UFF_PARAMS[t1]["x1"], UFF_PARAMS[t2]["x1"]
+            d1, d2 = UFF_PARAMS[t1]["D1"], UFF_PARAMS[t2]["D1"]
+            # Geometric combining (UFF): r_min = sqrt(x_i x_j), D = sqrt(D_i D_j).
+            sigma = math.sqrt(x1 * x2) / two_pow * ANG_TO_NM
+            epsilon = math.sqrt(d1 * d2) * KCAL_TO_KJ
+            lj.params[(t1, t2)] = dict(sigma=sigma, epsilon=epsilon)
+    forces = [lj]
+
+    if top.n_bonds > 0:
+        bond_force = hoomd.md.bond.Harmonic()
+        seen = set()
+        for bond in top.bonds:
+            m0, m1 = bond.connection_members
+            i, j = site_idx[m0], site_idx[m1]
+            ti, tj = sites[i].name, sites[j].name
+            if (ti, tj) in seen:
+                continue
+            key = tuple(sorted((ti, tj)))
+            order = order_between(i, j)
+            r_ij = _bond_rest_length(key[0], key[1], order)
+            k = _bond_force_constant(key[0], key[1], r_ij)
+            params = dict(k=k * BOND_K_TO_KJ_NM2, r0=r_ij * ANG_TO_NM)
+            # Register both orderings: the GSD snapshot's type-string ordering is
+            # not guaranteed to match ours, and the potential is symmetric.
+            _set_both(bond_force, (ti, tj), params, seen)
+        forces.append(bond_force)
+
+    if top.n_angles > 0:
+        angle_force = hoomd.md.angle.Harmonic()
+        seen = set()
+        for angle in top.angles:
+            m0, m1, m2 = angle.connection_members
+            i, j, k_idx = site_idx[m0], site_idx[m1], site_idx[m2]
+            ti, tj, tk = sites[i].name, sites[j].name, sites[k_idx].name
+            if (ti, tj, tk) in seen:
+                continue
+            theta0 = math.radians(UFF_PARAMS[tj]["theta0"])
+            # Harmonic approximation is invalid at linear centers (sin -> 0).
+            if abs(math.sin(theta0)) < 1e-3:
+                logger.warning(
+                    "UFF: skipping linear angle type %s-%s-%s (theta0=180); the "
+                    "lean harmonic approximation cannot represent it.",
+                    ti, tj, tk,
+                )
+                seen.update({(ti, tj, tk), (tk, tj, ti)})
+                continue
+            r_ij = _bond_rest_length(ti, tj, order_between(i, j))
+            r_jk = _bond_rest_length(tj, tk, order_between(j, k_idx))
+            k_theta = _angle_force_constant(ti, tj, tk, r_ij, r_jk, theta0)
+            params = dict(k=k_theta * KCAL_TO_KJ, t0=theta0)
+            _set_both(angle_force, (ti, tj, tk), params, seen)
+        forces.append(angle_force)
+
+    if top.n_dihedrals > 0:
+        # Count torsions about each central bond for the multiplicity divisor.
+        mult = {}
+        for dih in top.dihedrals:
+            _, mj, mk, _ = dih.connection_members
+            bond_key = tuple(sorted((site_idx[mj], site_idx[mk])))
+            mult[bond_key] = mult.get(bond_key, 0) + 1
+
+        dihedral_force = hoomd.md.dihedral.Periodic()
+        seen = set()
+        for dih in top.dihedrals:
+            m0, m1, m2, m3 = dih.connection_members
+            i, j, k_idx, ll = (
+                site_idx[m0], site_idx[m1], site_idx[m2], site_idx[m3]
+            )
+            ti, tj, tk, tl = (
+                sites[i].name, sites[j].name, sites[k_idx].name, sites[ll].name
+            )
+            if (ti, tj, tk, tl) in seen:
+                continue
+            params = _torsion_params(tj, tk, order_between(j, k_idx))
+            if params is None:
+                seen.update({(ti, tj, tk, tl), (tl, tk, tj, ti)})
+                continue
+            v_total, n, cos_n_phi0 = params
+            bond_key = tuple(sorted((j, k_idx)))
+            v = v_total / mult[bond_key]
+            if abs(v) < 1e-9:
+                seen.update({(ti, tj, tk, tl), (tl, tk, tj, ti)})
+                continue
+            # UFF: E = 0.5 V (1 - cos(n phi0) cos(n phi)).
+            # HOOMD Periodic: E = k (1 + d cos(n phi - phi0)); phi0 = 0,
+            # k = 0.5 V, d = -cos(n phi0) (which is +/-1).
+            params = dict(
+                k=0.5 * v * KCAL_TO_KJ,
+                d=int(round(-cos_n_phi0)),
+                n=n,
+                phi0=0.0,
+            )
+            _set_both(dihedral_force, (ti, tj, tk, tl), params, seen)
+        forces.append(dihedral_force)
+
+    return forces
+
+
+def _openmm_forces(top, order_map, r_cut):
+    """Build UFF forces as a list of openmm.Force objects.
+
+    The forces are added to an openmm.System by the caller. Each force
+    references atom indices in site order, so the System's particles must be
+    added in that same order.
+
+    Force types:
+      bonds use HarmonicBondForce.
+      angles use CustomAngleForce with the UFF cosine-Fourier energy, plus a
+        1 + cos(theta) form for linear centers.
+      torsions use PeriodicTorsionForce.
+      vdW uses CustomNonbondedForce with geometric combining of sigma and
+        epsilon. Pairs 1-2 and 1-3 are excluded; 1-4 and beyond are included at
+        full strength.
+
+    Inversion (improper) terms are not generated.
+
+    Parameters
+    ----------
+    top : gmso.Topology
+        UFF-typed topology with connections identified.
+    order_map : dict
+        (i, j) -> bond order map, as returned by assign_uff_types.
+    r_cut : float
+        Nonbonded cutoff (nm), used only when top.box is set.
+    """
+    import openmm
+
+    sites = list(top.sites)
+    site_idx = {s: i for i, s in enumerate(sites)}
+
+    def order_between(i, j):
+        return order_map.get((min(i, j), max(i, j)), 1.0)
+
+    forces = []
+    two_pow = 2.0 ** (1.0 / 6.0)
+
+    # --- vdW (LJ 12-6) with UFF geometric combining ---------------------------
+    vdw = openmm.CustomNonbondedForce(
+        "4*epsilon*((sigma/r)^12 - (sigma/r)^6);"
+        " sigma=sqrt(sigma1*sigma2); epsilon=sqrt(epsilon1*epsilon2)"
+    )
+    vdw.addPerParticleParameter("sigma")
+    vdw.addPerParticleParameter("epsilon")
+    for s in sites:
+        p = UFF_PARAMS[s.name]
+        vdw.addParticle(
+            [p["x1"] / two_pow * ANG_TO_NM, p["D1"] * KCAL_TO_KJ]
+        )
+    # UFF computes vdW for atoms >= 3 bonds apart: exclude 1-2 and 1-3.
+    vdw.createExclusionsFromBonds([(i, j) for (i, j) in order_map], 2)
+    if top.box is not None:
+        vdw.setNonbondedMethod(openmm.CustomNonbondedForce.CutoffPeriodic)
+        vdw.setCutoffDistance(r_cut)
+    else:
+        vdw.setNonbondedMethod(openmm.CustomNonbondedForce.NoCutoff)
+    forces.append(vdw)
+
+    # --- Bonds (harmonic) -----------------------------------------------------
+    if top.n_bonds > 0:
+        bond_force = openmm.HarmonicBondForce()
+        for bond in top.bonds:
+            m0, m1 = bond.connection_members
+            i, j = site_idx[m0], site_idx[m1]
+            ti, tj = sites[i].name, sites[j].name
+            r_ij = _bond_rest_length(ti, tj, order_between(i, j))
+            k = _bond_force_constant(ti, tj, r_ij)
+            bond_force.addBond(
+                i, j, r_ij * ANG_TO_NM, k * BOND_K_TO_KJ_NM2
+            )
+        forces.append(bond_force)
+
+    # --- Angles (exact UFF cosine-Fourier, + linear form) ---------------------
+    if top.n_angles > 0:
+        general = openmm.CustomAngleForce(
+            "K*(C0 + C1*cos(theta) + C2*cos(2*theta))"
+        )
+        for name in ("K", "C0", "C1", "C2"):
+            general.addPerAngleParameter(name)
+        linear = openmm.CustomAngleForce("K*(1 + cos(theta))")
+        linear.addPerAngleParameter("K")
+        for angle in top.angles:
+            m0, m1, m2 = angle.connection_members
+            i, j, k_idx = site_idx[m0], site_idx[m1], site_idx[m2]
+            ti, tj, tk = sites[i].name, sites[j].name, sites[k_idx].name
+            theta0 = math.radians(UFF_PARAMS[tj]["theta0"])
+            r_ij = _bond_rest_length(ti, tj, order_between(i, j))
+            r_jk = _bond_rest_length(tj, tk, order_between(j, k_idx))
+            k_ang = _angle_force_constant(ti, tj, tk, r_ij, r_jk, theta0)
+            k_ang *= KCAL_TO_KJ
+            if abs(math.sin(theta0)) < 1e-3:  # linear center
+                linear.addAngle(i, j, k_idx, [k_ang])
+            else:
+                c = math.cos(theta0)
+                c2 = 1.0 / (4.0 * math.sin(theta0) ** 2)
+                c1 = -4.0 * c2 * c
+                c0 = c2 * (2.0 * c * c + 1.0)
+                general.addAngle(i, j, k_idx, [k_ang, c0, c1, c2])
+        if general.getNumAngles() > 0:
+            forces.append(general)
+        if linear.getNumAngles() > 0:
+            forces.append(linear)
+
+    # --- Torsions (principal cases) -------------------------------------------
+    if top.n_dihedrals > 0:
+        mult = {}
+        for dih in top.dihedrals:
+            _, mj, mk, _ = dih.connection_members
+            key = tuple(sorted((site_idx[mj], site_idx[mk])))
+            mult[key] = mult.get(key, 0) + 1
+
+        torsion = openmm.PeriodicTorsionForce()
+        for dih in top.dihedrals:
+            m0, m1, m2, m3 = dih.connection_members
+            i, j, k_idx, ll = (
+                site_idx[m0], site_idx[m1], site_idx[m2], site_idx[m3]
+            )
+            tj, tk = sites[j].name, sites[k_idx].name
+            params = _torsion_params(tj, tk, order_between(j, k_idx))
+            if params is None:
+                continue
+            v_total, n, cos_n_phi0 = params
+            v = v_total / mult[tuple(sorted((j, k_idx)))]
+            if abs(v) < 1e-9:
+                continue
+            # UFF: E = 0.5 V (1 - cos(n phi0) cos(n phi)).
+            # OpenMM: k (1 + cos(n phi - phase)); k = 0.5 V,
+            # phase = 0 when cos(n phi0) = -1 else pi.
+            phase = 0.0 if cos_n_phi0 < 0 else math.pi
+            torsion.addTorsion(
+                i, j, k_idx, ll, n, phase, 0.5 * v * KCAL_TO_KJ
+            )
+        if torsion.getNumTorsions() > 0:
+            forces.append(torsion)
+
+    return forces
+
+

--- a/mbuild/utils/simulation/uff.py
+++ b/mbuild/utils/simulation/uff.py
@@ -30,7 +30,9 @@ G_ANGLE = 664.12  # angle force-constant prefactor, kcal/mol
 # Columns: r1 (valence bond radius, Ang), theta0 (equilibrium angle, deg),
 #          x1 (vdW minimum distance r_min, Ang), D1 (vdW well depth, kcal/mol),
 #          Zstar (effective charge), Vi (sp3 torsional barrier, kcal/mol),
-#          Uj (sp2 torsional constant), chi (GMP electronegativity).
+#          Uj (sp2 torsional constant; UFF assigns it by periodic-table row:
+#          period 1 = 0.0, 2 = 2.0, 3 = 1.25, 4 = 0.7, 5 = 0.2, 6 = 0.1),
+#          chi (GMP electronegativity).
 _COLS = ("r1", "theta0", "x1", "D1", "Zstar", "Vi", "Uj", "chi")
 _TABLE = {
     #  label      r1     theta0   x1      D1     Zstar   Vi     Uj    chi
@@ -48,11 +50,11 @@ _TABLE = {
     "O_2": (0.634, 120.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
     "O_1": (0.639, 180.00, 3.500, 0.060, 2.300, 0.000, 2.0, 8.741),
     "F_": (0.668, 180.00, 3.364, 0.050, 1.735, 0.000, 2.0, 10.874),
-    "Cl": (1.044, 180.00, 3.947, 0.227, 2.348, 0.000, 2.0, 8.564),
-    "Br": (1.192, 180.00, 4.189, 0.251, 2.519, 0.000, 2.0, 7.790),
-    "I_": (1.382, 180.00, 4.500, 0.339, 2.650, 0.000, 2.0, 6.822),
-    "S_3+2": (1.064, 92.10, 4.035, 0.274, 2.703, 0.484, 2.0, 6.928),
-    "P_3+3": (1.101, 93.80, 4.147, 0.305, 2.863, 2.400, 2.0, 5.463),
+    "Cl": (1.044, 180.00, 3.947, 0.227, 2.348, 0.000, 1.25, 8.564),
+    "Br": (1.192, 180.00, 4.189, 0.251, 2.519, 0.000, 0.7, 7.790),
+    "I_": (1.382, 180.00, 4.500, 0.339, 2.650, 0.000, 0.2, 6.822),
+    "S_3+2": (1.064, 92.10, 4.035, 0.274, 2.703, 0.484, 1.25, 6.928),
+    "P_3+3": (1.101, 93.80, 4.147, 0.305, 2.863, 2.400, 1.25, 5.463),
 }
 UFF_PARAMS = {label: dict(zip(_COLS, vals)) for label, vals in _TABLE.items()}
 
@@ -353,20 +355,11 @@ def _hoomd_forces(top, snap, order_map, r_cut):
             if (ti, tj, tk) in seen:
                 continue
             theta0 = math.radians(UFF_PARAMS[tj]["theta0"])
-            # Harmonic approximation is invalid at linear centers (sin -> 0).
-            if abs(math.sin(theta0)) < 1e-3:
-                logger.warning(
-                    "UFF: skipping linear angle type %s-%s-%s (theta0=180); the "
-                    "lean harmonic approximation cannot represent it.",
-                    ti,
-                    tj,
-                    tk,
-                )
-                seen.update({(ti, tj, tk), (tk, tj, ti)})
-                continue
             r_ij = _bond_rest_length(ti, tj, order_between(i, j))
             r_jk = _bond_rest_length(tj, tk, order_between(j, k_idx))
             k_theta = _angle_force_constant(ti, tj, tk, r_ij, r_jk, theta0)
+            # Linear centers (theta0=180) get a harmonic too: k_theta is finite
+            # there, and HOOMD requires every angle type to be parameterized.
             params = dict(k=k_theta * KCAL_TO_KJ, t0=theta0)
             _set_both(angle_force, (ti, tj, tk), params, seen)
         forces.append(angle_force)
@@ -392,15 +385,17 @@ def _hoomd_forces(top, snap, order_map, r_cut):
             )
             if (ti, tj, tk, tl) in seen:
                 continue
-            params = _torsion_params(tj, tk, order_between(j, k_idx))
-            if params is None:
-                seen.update({(ti, tj, tk, tl), (tl, tk, tj, ti)})
+            # No-op fallback: unhandled (sp centers etc.) or zero-barrier cases
+            # still need a param entry or HOOMD raises on the missing type.
+            zero = dict(k=0.0, d=1, n=1, phi0=0.0)
+            tp = _torsion_params(tj, tk, order_between(j, k_idx))
+            if tp is None:
+                _set_both(dihedral_force, (ti, tj, tk, tl), zero, seen)
                 continue
-            v_total, n, cos_n_phi0 = params
-            bond_key = tuple(sorted((j, k_idx)))
-            v = v_total / mult[bond_key]
+            v_total, n, cos_n_phi0 = tp
+            v = v_total / mult[tuple(sorted((j, k_idx)))]
             if abs(v) < 1e-9:
-                seen.update({(ti, tj, tk, tl), (tl, tk, tj, ti)})
+                _set_both(dihedral_force, (ti, tj, tk, tl), zero, seen)
                 continue
             # UFF: E = 0.5 V (1 - cos(n phi0) cos(n phi)).
             # HOOMD Periodic: E = k (1 + d cos(n phi - phi0)); phi0 = 0,


### PR DESCRIPTION
### PR Summary: 
Refactor the simulation classes into objects that can be used to modify/update compound positions for initialization. Allows either to just use default values without a forcefield, or use GMSO/foyer forcefields, paired with forces_handler objects for easily rescaling/using dpd minimization forces. Finally, energy logging is possible, which helps users debug system configuration as they initialize.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
 - [ ] Logger for energy and other simulation outputs
 - [ ] Integration with various forces_handlers
 - [ ] tests on hard to minimize structures
