### PR TITLE
Fix bug in bias weight random noise.

### DIFF
--- a/mbuild/path/bias.py
+++ b/mbuild/path/bias.py
@@ -9,6 +9,17 @@ from mbuild.path.path_utils import (
 
 
 class Bias:
+    """Base class for biases applied to candidate sites in a random walk.
+
+    Sub classes measure a signal over candidate sites and rank them with `_score`.
+
+    Parameters
+    ----------
+    weight : float, required
+        Bias weight in (0, 1]. 1 ranks candidates by the signal alone; values
+        approaching 0 rank them close to randomly.
+    """
+
     def __init__(self, weight):
         if weight <= 0 or weight > 1:
             raise ValueError(
@@ -18,6 +29,17 @@ class Bias:
         # Large beta diminishes the effect of noise
         self.beta = self.weight / max(1e-6, (1.0 - self.weight))
         self.noise_scale = 1 - self.weight
+
+    def _score(self, signal):
+        """Score candidates by their signal plus noise scaled to the signal's spread.
+
+        A flat signal is ordered by noise alone.
+        """
+        spread = np.std(signal)
+        if spread == 0:
+            spread = 1.0
+        noise = self.rng.normal(0.0, self.noise_scale * spread, size=signal.shape)
+        return self.beta * signal + noise
 
     def _attach_path(self, path, state):
         """Create access Path and RandomWalkState used by hard_sphere_random_walk."""
@@ -66,8 +88,7 @@ class TargetCoordinate(Bias):
             Returns the original candidate array, sorted according to the bias.
         """
         sq_distances = self._target_sq_distances(self.target_coordinate, candidates)
-        noise = self.rng.normal(0, self.noise_scale, size=sq_distances.shape)
-        scores = self.beta * sq_distances + noise
+        scores = self._score(sq_distances)
         # Target coordinate should favor short distances, sort in ascending order (np default)
         sort_idx = np.argsort(scores)
         return candidates[sort_idx]
@@ -98,8 +119,7 @@ class AvoidCoordinate(Bias):
             Returns the original candidate array, sorted according to the bias.
         """
         sq_distances = self._target_sq_distances(self.avoid_coordinate, candidates)
-        noise = self.rng.normal(0, self.noise_scale, size=sq_distances.shape)
-        scores = self.beta * sq_distances + noise
+        scores = self._score(sq_distances)
         # Avoid cooardinate should favor larger distances, sort in descending order
         sort_idx = np.argsort(scores)[::-1]
         return candidates[sort_idx]
@@ -135,8 +155,7 @@ class TargetType(Bias):
         densities = self._target_density(
             candidates=candidates, target_coords=target_coords, r_cut=self.r_cut
         )
-        noise = self.rng.normal(0, self.noise_scale, size=densities.shape)
-        scores = self.beta * densities + noise
+        scores = self._score(densities)
         # Target type should favor larger densities, sort in descending order
         sort_idx = np.argsort(scores)[::-1]
         return candidates[sort_idx]
@@ -171,8 +190,7 @@ class AvoidType(Bias):
         densities = self._target_density(
             candidates=candidates, target_coords=target_coords, r_cut=self.r_cut
         )
-        noise = self.rng.normal(0, self.noise_scale, size=densities.shape)
-        scores = self.beta * densities + noise
+        scores = self._score(densities)
         # Avoid type should favor smaller densities, sort in ascending order (np default)
         sort_idx = np.argsort(scores)
         return candidates[sort_idx]
@@ -214,8 +232,7 @@ class TargetDirection(Bias):
         next_step_unit_vectors = next_step_vectors / norms
         # Alignment score: dot product with target direction
         alignment = np.dot(next_step_unit_vectors, self.direction)
-        noise = self.rng.normal(0.0, self.noise_scale, size=alignment.shape)
-        scores = self.beta * alignment + noise
+        scores = self._score(alignment)
         # Larger dot product = better alignment with target, sort descending
         sort_idx = np.argsort(scores)[::-1]
         return candidates[sort_idx]
@@ -253,8 +270,7 @@ class AvoidDirection(Bias):
         next_step_unit_vectors = next_step_vectors / norms
         # Alignment score: dot product with target direction
         alignment = np.dot(next_step_unit_vectors, self.direction)
-        noise = self.rng.normal(0.0, self.noise_scale, size=alignment.shape)
-        scores = self.beta * alignment + noise
+        scores = self._score(alignment)
         # Larger dot product = better alignment with target, sort ascending (np default)
         sort_idx = np.argsort(scores)
         return candidates[sort_idx]

--- a/mbuild/tests/test_bias.py
+++ b/mbuild/tests/test_bias.py
@@ -142,3 +142,41 @@ class TestBias(BaseTest):
         assert np.dot(head_tail_vec_avoid, np.array([1, 0, 0])) < np.dot(
             head_tail_vec_target, np.array([1, 0, 0])
         )
+
+    def test_score_affine_invariance(self):
+        """Scores rank candidates identically under any positive affine rescale."""
+        bias = TargetCoordinate(target_coordinate=(3, 3, 3), weight=0.6)
+        signal = np.array([0.1, 4.2, 1.7, 3.3, 0.9, 2.5])
+        for scale, offset in [(1.0, 0.0), (1e3, 0.0), (1e-3, 0.0), (7.0, 250.0)]:
+            bias.rng = np.random.default_rng(5)
+            baseline = np.argsort(bias._score(signal))
+            bias.rng = np.random.default_rng(5)
+            rescaled = np.argsort(bias._score(signal * scale + offset))
+            assert np.array_equal(baseline, rescaled)
+
+    def test_score_flat_signal_is_random(self):
+        """A signal carrying no information leaves ordering to noise."""
+        bias = TargetCoordinate(target_coordinate=(3, 3, 3), weight=0.6)
+        bias.rng = np.random.default_rng(5)
+        orders = {tuple(np.argsort(bias._score(np.full(6, 2.0)))) for _ in range(50)}
+        assert len(orders) > 1
+
+    def test_score_weight_controls_signal_to_noise(self):
+        """Higher weight follows the signal more closely, at any signal scale."""
+        signal = np.arange(20, dtype=float)
+        best = np.argmin(signal)
+        for scale in (1e-3, 1.0, 1e3):
+            picked = {}
+            for weight in (0.2, 0.9):
+                bias = TargetCoordinate(target_coordinate=(0, 0, 0), weight=weight)
+                bias.rng = np.random.default_rng(5)
+                picked[weight] = np.mean(
+                    [
+                        np.argsort(bias._score(signal * scale))[0] == best
+                        for _ in range(400)
+                    ]
+                )
+            assert picked[0.9] > picked[0.2]
+            # A given weight behaves the same at every signal scale
+            assert picked[0.9] > 0.85
+            assert 0.1 < picked[0.2] < 0.6


### PR DESCRIPTION
The random noise in any biases weight used a spread of `1-weight`. When the deterministic (measured) part of the bias scoring has very small values (TargetCoordinate approaching the target), this noise spread was dominating the deterministic part of the score, even at relatively high weights (0.5-0.8ish). This is a quick fix that scales the spread used in the noise part of the score by the actual spread present in the measured values (distances, density, etc..) so that it remains consistent regardless of units/magnitude.

### PR Summary:

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
