### PR TITLE
Account for PBCs in TargetCorodinate bias and WithinCoordinate terminator.

### DIFF
--- a/mbuild/path/bias.py
+++ b/mbuild/path/bias.py
@@ -87,7 +87,12 @@ class TargetCoordinate(Bias):
         candidates : np.ndarray (N,3)
             Returns the original candidate array, sorted according to the bias.
         """
-        sq_distances = self._target_sq_distances(self.target_coordinate, candidates)
+        sq_distances = self._target_sq_distances(
+            self.target_coordinate,
+            candidates,
+            self.state.pbc,
+            self.state.box_lengths,
+        )
         scores = self._score(sq_distances)
         # Target coordinate should favor short distances, sort in ascending order (np default)
         sort_idx = np.argsort(scores)
@@ -118,7 +123,12 @@ class AvoidCoordinate(Bias):
         candidates : np.ndarray (N,3)
             Returns the original candidate array, sorted according to the bias.
         """
-        sq_distances = self._target_sq_distances(self.avoid_coordinate, candidates)
+        sq_distances = self._target_sq_distances(
+            self.avoid_coordinate,
+            candidates,
+            self.state.pbc,
+            self.state.box_lengths,
+        )
         scores = self._score(sq_distances)
         # Avoid cooardinate should favor larger distances, sort in descending order
         sort_idx = np.argsort(scores)[::-1]

--- a/mbuild/path/termination.py
+++ b/mbuild/path/termination.py
@@ -4,6 +4,8 @@ import time
 
 import numpy as np
 
+from mbuild.path.path_utils import target_sq_distances
+
 
 class Termination:
     """A modular and composable container for individual Terminator instances.
@@ -231,7 +233,16 @@ class WithinCoordinate(Terminator):
 
     def is_met(self, coordinates, names):
         last_site = coordinates[-1]
-        current_distance = np.linalg.norm(self.target_coordinate - last_site)
+        if self.state is None:
+            current_distance = np.linalg.norm(self.target_coordinate - last_site)
+        else:
+            sq_distance = target_sq_distances(
+                self.target_coordinate,
+                last_site.reshape(1, 3),
+                self.state.pbc,
+                self.state.box_lengths,
+            )
+            current_distance = np.sqrt(sq_distance[0])
         if current_distance <= self.distance + self.tolerance:
             self._is_met = True
             return True

--- a/mbuild/tests/test_bias.py
+++ b/mbuild/tests/test_bias.py
@@ -10,7 +10,13 @@ from mbuild.path.bias import (
     TargetType,
 )
 from mbuild.path.build import hard_sphere_random_walk
-from mbuild.path.termination import NumAttempts, NumSites, Termination
+from mbuild.path.constraints import CuboidConstraint
+from mbuild.path.termination import (
+    NumAttempts,
+    NumSites,
+    Termination,
+    WithinCoordinate,
+)
 from mbuild.tests.base_test import BaseTest, radius_of_gyration
 
 
@@ -180,3 +186,44 @@ class TestBias(BaseTest):
             # A given weight behaves the same at every signal scale
             assert picked[0.9] > 0.85
             assert 0.1 < picked[0.2] < 0.6
+
+    def test_target_coordinate_pbc(self):
+        """Under PBC the bias steers across the nearest boundary, not through the box."""
+        L = 10.0
+        box = CuboidConstraint(
+            Lx=L, Ly=L, Lz=L, center=(0, 0, 0), pbc=(True, True, True)
+        )
+        start = np.array([4.0, 0.0, 0.0])
+        target = np.array([-4.0, 0.0, 0.0])
+        # target is 8 nm away directly, but only 2 nm across the +x boundary
+        path = hard_sphere_random_walk(
+            termination=Termination([NumSites(6), NumAttempts(1e4)]),
+            bond_length=0.25,
+            radius=0.2,
+            bias=TargetCoordinate(target_coordinate=target, weight=0.95),
+            initial_point=start,
+            volume_constraint=box,
+            seed=3,
+        )
+        # Steps head toward the near boundary (+x), away from the raw target
+        first_steps = path.coordinates[1:5, 0] - path.coordinates[0:4, 0]
+        assert np.all(first_steps > 0)
+
+    def test_within_coordinate_pbc(self):
+        """WithinCoordinate measures distance to the target in minimum image."""
+        L = 10.0
+        target = np.array([-4.9, 0.0, 0.0])
+        # 0.2 nm from the target across the +x boundary, 9.8 nm from it directly
+        coordinates = np.array([[4.9, 0.0, 0.0]])
+        names = np.array(["_A"])
+
+        class _State:
+            pbc = np.array([True, True, True])
+            box_lengths = np.array([L, L, L], dtype=np.float32)
+
+        unattached = WithinCoordinate(target_coordinate=target, distance=0.3)
+        assert not unattached.is_met(coordinates, names)
+
+        periodic = WithinCoordinate(target_coordinate=target, distance=0.3)
+        periodic.state = _State()
+        assert periodic.is_met(coordinates, names)


### PR DESCRIPTION
### PR Summary:

Neither the `TargetCoordinate` bias or the `WithinCoordinate` terminator correctly accounted for periodic boundary conditions, even though the method they both use (`target_sq_distances`) accepts both PBC bools and box lengths. So, this only requires grabbing this info from `.state` and passing them in to `target_sq_distances`.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
