### PR TITLE
Make initial point an option for all closed-form Path builders

### DIFF
--- a/mbuild/path/build.py
+++ b/mbuild/path/build.py
@@ -792,7 +792,14 @@ def lamellar(
     return path
 
 
-def straight_line(spacing, N, path=None, direction=(1, 0, 0), bead_name="_A"):
+def straight_line(
+    spacing,
+    N,
+    path=None,
+    direction=(1, 0, 0),
+    bead_name="_A",
+    initial_point=None,
+):
     """Generates a set of coordinates in a straight line along a given axis.
 
     Parameters
@@ -810,11 +817,18 @@ def straight_line(spacing, N, path=None, direction=(1, 0, 0), bead_name="_A"):
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
+    initial_point : array-like (1,3), optional, default None
+        If given, translates the path so that its first site sits at this
+        coordinate.
     """
     if path is None:
         path = Path()
     direction = np.asarray(direction)
     coordinates = np.array([np.zeros(3) + i * spacing * direction for i in range(N)])
+    if initial_point is not None:
+        coordinates = coordinates + (
+            np.asarray(initial_point, dtype=float) - coordinates[0]
+        )
     start_index = len(path.coordinates)
     stop_index = start_index + N
     namer = BeadNamer.coerce(bead_name)
@@ -828,7 +842,15 @@ def straight_line(spacing, N, path=None, direction=(1, 0, 0), bead_name="_A"):
     return path
 
 
-def cyclic(spacing=None, N=None, path=None, radius=None, closed=True, bead_name="_A"):
+def cyclic(
+    spacing=None,
+    N=None,
+    path=None,
+    radius=None,
+    closed=True,
+    bead_name="_A",
+    initial_point=None,
+):
     """Generates a set of coordinates evenly spaced along a circle.
 
     Parameters
@@ -848,6 +870,9 @@ def cyclic(spacing=None, N=None, path=None, radius=None, closed=True, bead_name=
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
+    initial_point : array-like (1,3), optional, default None
+        If given, translates the path so that its first site sits at this
+        coordinate.
 
     Notes
     -----
@@ -871,6 +896,10 @@ def cyclic(spacing=None, N=None, path=None, radius=None, closed=True, bead_name=
     coordinates = np.array(
         [(np.cos(a) * radius, np.sin(a) * radius, 0) for a in angles]
     )
+    if initial_point is not None:
+        coordinates = coordinates + (
+            np.asarray(initial_point, dtype=float) - coordinates[0]
+        )
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
     namer = BeadNamer.coerce(bead_name)
@@ -889,7 +918,15 @@ def cyclic(spacing=None, N=None, path=None, radius=None, closed=True, bead_name=
     return path
 
 
-def knot(spacing, N, m, path=None, closed=True, bead_name="_A"):
+def knot(
+    spacing,
+    N,
+    m,
+    path=None,
+    closed=True,
+    bead_name="_A",
+    initial_point=None,
+):
     """Generate a knot path.
 
     Parameters
@@ -910,6 +947,9 @@ def knot(spacing, N, m, path=None, closed=True, bead_name="_A"):
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
+    initial_point : array-like (1,3), optional, default None
+        If given, translates the path so that its first site sits at this
+        coordinate.
     """
     if path is None:
         path = Path()
@@ -956,6 +996,10 @@ def knot(spacing, N, m, path=None, closed=True, bead_name="_A"):
     z_interp = interp1d(arc_lengths, coords_dense[:, 2])(desired_arcs)
     coordinates = np.stack((x_interp, y_interp, z_interp), axis=1)
 
+    if initial_point is not None:
+        coordinates = coordinates + (
+            np.asarray(initial_point, dtype=float) - coordinates[0]
+        )
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
     namer = BeadNamer.coerce(bead_name)
@@ -969,13 +1013,21 @@ def knot(spacing, N, m, path=None, closed=True, bead_name="_A"):
         )
     else:
         path._connect_edges(
-            connectivit="linear", indices=np.arange(start_index, stop_index)
+            connectivity="linear", indices=np.arange(start_index, stop_index)
         )
     return path
 
 
 def helix(
-    N, radius, rise, twist, path=None, right_handed=True, bottom_up=True, bead_name="_A"
+    N,
+    radius,
+    rise,
+    twist,
+    path=None,
+    right_handed=True,
+    bottom_up=True,
+    bead_name="_A",
+    initial_point=None,
 ):
     """Generate helical path.
 
@@ -1000,6 +1052,9 @@ def helix(
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
+    initial_point : array-like (1,3), optional, default None
+        If given, translates the path so that its first site sits at this
+        coordinate.
     """
     if path is None:
         path = Path()
@@ -1015,6 +1070,10 @@ def helix(
         z = i * rise if bottom_up else -i * rise
         coordinates[i] = (x, y, z)
 
+    if initial_point is not None:
+        coordinates = coordinates + (
+            np.asarray(initial_point, dtype=float) - coordinates[0]
+        )
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
     namer = BeadNamer.coerce(bead_name)
@@ -1028,7 +1087,7 @@ def helix(
     return path
 
 
-def spiral_2D(N, a, b, spacing, path=None, bead_name="_A"):
+def spiral_2D(N, a, b, spacing, path=None, bead_name="_A", initial_point=None):
     """Generate a 2D spiral path in the XY plane.
 
     Parameters
@@ -1048,6 +1107,9 @@ def spiral_2D(N, a, b, spacing, path=None, bead_name="_A"):
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
+    initial_point : array-like (1,3), optional, default None
+        If given, translates the path so that its first site sits at this
+        coordinate.
     """
     if path is None:
         path = Path()
@@ -1065,6 +1127,10 @@ def spiral_2D(N, a, b, spacing, path=None, bead_name="_A"):
         dtheta = spacing / ds_dtheta
         theta += dtheta
 
+    if initial_point is not None:
+        coordinates = coordinates + (
+            np.asarray(initial_point, dtype=float) - coordinates[0]
+        )
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
     namer = BeadNamer.coerce(bead_name)
@@ -1086,6 +1152,7 @@ def zigzag(
     sites_per_segment=4,
     plane="xy",
     bead_name="_A",
+    initial_point=None,
 ):
     """Generates a path following a zig-zag pattern in a given plane.
 
@@ -1108,6 +1175,9 @@ def zigzag(
         Name(s) to assign to beads. A plain string assigns the same name to
         every bead. Pass a ``BeadNamer`` instance for heterogeneous sequences.
         See mbuild.path.namers.py
+    initial_point : array-like (1,3), optional, default None
+        If given, translates the path so that its first site sits at this
+        coordinate.
     """
     if N % sites_per_segment != 0:
         raise ValueError("N must be evenly divisible by sites_per_segment")
@@ -1154,6 +1224,10 @@ def zigzag(
         elif plane == "yz":
             coordinates[i] = (0, x2d, y2d)
 
+    if initial_point is not None:
+        coordinates = coordinates + (
+            np.asarray(initial_point, dtype=float) - coordinates[0]
+        )
     start_index = len(path.coordinates)
     stop_index = start_index + len(coordinates)
     namer = BeadNamer.coerce(bead_name)

--- a/mbuild/tests/test_path.py
+++ b/mbuild/tests/test_path.py
@@ -76,6 +76,39 @@ class TestPaths(BaseTest):
         for edge in path.bond_graph.edges(data=True):
             assert np.allclose(edge[2]["direction"], np.array([1, 0, 0]))
 
+    def test_initial_point(self):
+        """Every builder places its first site at initial_point."""
+        initial_point = (1.5, -2.0, 3.0)
+        builders = [
+            (straight_line, dict(spacing=0.25, N=10)),
+            (cyclic, dict(spacing=0.25, N=20)),
+            (knot, dict(spacing=0.25, N=40, m=3)),
+            (spiral_2D, dict(N=30, a=0.5, b=0.1, spacing=0.25)),
+            (zigzag, dict(N=20, spacing=0.25)),
+            (helix, dict(N=30, radius=0.5, rise=0.1, twist=30)),
+        ]
+        for builder, kwargs in builders:
+            at_origin = builder(**kwargs).coordinates
+            shifted = builder(initial_point=initial_point, **kwargs).coordinates
+            assert np.allclose(shifted[0], initial_point)
+            # Only translated; the shape of the path is unchanged
+            assert np.allclose(shifted - shifted[0], at_origin - at_origin[0])
+
+    def test_initial_point_appends_to_path(self):
+        """Builders place their segment at initial_point within an existing path."""
+        path = straight_line(spacing=0.25, N=5)
+        straight_line(path=path, spacing=0.25, N=5, initial_point=(4.0, 0.0, 0.0))
+        assert len(path.coordinates) == 10
+        assert np.allclose(path.coordinates[0], (0, 0, 0))
+        assert np.allclose(path.coordinates[5], (4.0, 0.0, 0.0))
+        # The two segments are bonded separately, not to each other
+        assert path.bond_graph.number_of_edges() == 8
+
+    def test_knot_not_closed(self):
+        path = knot(spacing=0.25, N=50, m=3, closed=False)
+        assert len(path.coordinates) == 50
+        assert path.bond_graph.number_of_edges() == 49
+
     def test_cyclic_parameters(self):
         path = Path()
         cyclic(path=path, spacing=1, N=20)


### PR DESCRIPTION
### PR Summary:
Being able to specify the coordinate of the first bead for all closed-form paths (straight line, lamellar, zigzag, cyclic, helix, etc..) would be very useful for building up systems that contain multiple paths as it makes it easier to avoid overlaps. This will also make it easier to utilize the add method for paths `pathC = pathA + pathB`. This was already part of `lamellar` and it is straight forward to add this for the others.  It defaults to None to keep the original behavior (straight line starts at 0,0,0, but cyclic starts at -r, 0, 0). 

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
